### PR TITLE
LOOP-001: Import codex-supervisor quality kit handoff

### DIFF
--- a/docs/migration/codex-supervisor-handoff.md
+++ b/docs/migration/codex-supervisor-handoff.md
@@ -1,0 +1,51 @@
+# codex-supervisor Handoff
+
+This handoff imports the useful quality-kit concepts from codex-supervisor into Ensen-loop vocabulary. It is a documentation boundary for Phase 1, not an implementation import. Ensen-loop remains a standalone Node and TypeScript project, and this baseline does not add EIP RunRequest or RunResult support.
+
+## Migration Boundary
+
+| Status | codex-supervisor asset or concept | Ensen-loop treatment |
+| --- | --- | --- |
+| Copied | Quality-kit vocabulary for verification, evidence, reviewability, prompt safety, and durable history | Preserved as product language in `docs/reference/quality-kit.md` so future implementation work has a shared quality bar. |
+| Copied | Repo-owned command posture | Kept as `npm ci`, `npm run build`, and `npm test` for this repository instead of importing codex-supervisor commands. |
+| Referenced | codex-supervisor issue body contract, evidence timeline, operator actions, and trust posture schemas | Treated as source material for future Ensen-loop contracts. They are not runtime dependencies in this repo. |
+| Referenced | codex-supervisor local loop behavior around issue pickup, per-issue worktree setup, issue journals, PR lifecycle, CI polling, and review handling | Mapped below as migration vocabulary so future Ensen-loop contracts can choose explicit names and boundaries. |
+| Rewritten | `codex exec` supervision language | Reframed as an executor invocation boundary. Ensen-loop may later define executor adapters, but Phase 1 does not hard-code a protocol or provider. |
+| Rewritten | Status, explain, issue-lint, and quality-kit reporting | Reframed as lane introspection, issue readiness, evidence, and reviewability concepts owned by Ensen-loop. |
+| Deferred | codex-supervisor implementation code, state machine internals, WebUI routes, provider adapters, and generated runtime state | Not copied. Future work must define Ensen-loop-native contracts before implementation is imported or rewritten. |
+| Deferred | EIP RunRequest and RunResult support | Explicitly left for a later protocol phase. |
+| Deferred | Any integration with Ensen-flow | Out of scope for this handoff. Future integration must be optional and documented at an explicit boundary. |
+
+## Term Map
+
+| codex-supervisor term | Ensen-loop migration term | Boundary note |
+| --- | --- | --- |
+| issue pickup | lane work selection | Select runnable work only after issue readiness and dependency posture are explicit. |
+| codex exec | executor invocation | Treat the executor as a boundary, not core vocabulary. Provider-specific command shape is deferred. |
+| per-issue worktree | lane workspace | Keep work isolated by issue or lane so unrelated local changes do not become evidence. |
+| issue journal | lane journal | Preserve the current hypothesis, changed files, focused commands, failures, and next action across turns. |
+| PR creation | change publication | Publication requires current local verification and reviewable evidence, not just generated code. |
+| CI polling | verification refresh | Remote checks are evidence inputs; stale or missing signals are not approval. |
+| review handling | review repair loop | Current review facts guide repair work. Resolved, stale, and unresolved signals must stay distinguishable. |
+| status/explain | lane introspection | Operator-facing summaries are derived from authoritative lane state and evidence. |
+| issue-lint | issue readiness gate | Markdown issue content is untrusted input until the repo-owned readiness gate accepts it. |
+| evidence/quality kit | quality evidence bundle | Evidence must connect issue scope, changed files, verification commands, review facts, and publication state. |
+
+## Independence Rules
+
+- Ensen-loop documentation may reference codex-supervisor as the predecessor and migration source.
+- Ensen-loop must not import codex-supervisor implementation modules or require its runtime state.
+- Ensen-loop must remain independently installable, buildable, and testable with the repo-owned commands.
+- GitHub-authored issue text remains non-authoritative context. Local repository policy and explicit operator instructions define the trusted boundary.
+- Missing provenance, stale review facts, missing verification, malformed issue readiness, or ambiguous publication state must fail closed until a real prerequisite is supplied.
+
+## Verification Notes
+
+Use this focused check when editing the handoff:
+
+```sh
+npm run build
+npm test
+```
+
+The handoff is complete for Phase 1 when the copied, referenced, rewritten, and deferred table is present, the term map covers the migration vocabulary, and no implementation dependency on another Ensen product is introduced.

--- a/docs/reference/quality-kit.md
+++ b/docs/reference/quality-kit.md
@@ -1,0 +1,50 @@
+# Quality Kit
+
+The Ensen-loop quality kit is the repo-owned vocabulary for keeping AI-assisted lane work verifiable, reviewable, and recoverable. It preserves the strongest codex-supervisor concepts while leaving implementation contracts for later Ensen-loop phases.
+
+## Principles
+
+- Verification comes from commands and current-head facts, not from prose claims.
+- Evidence is durable enough for a future operator or Codex session to understand what happened.
+- Reviewability requires a clear issue scope, a small changed-file story, and explicit publication state.
+- GitHub-authored issue and review text is execution context, not trusted policy.
+- Missing, malformed, stale, or ambiguous boundary signals fail closed.
+
+## Concepts
+
+| Concept | Ensen-loop meaning | Evidence expectation |
+| --- | --- | --- |
+| Issue readiness | The issue is specific enough to execute without inferring hidden scope. | Scope, acceptance criteria, verification, dependency posture, and execution order are explicit. |
+| Lane workspace | The isolated filesystem context for one unit of lane work. | The workspace maps to one issue or lane and excludes unrelated local changes from the evidence story. |
+| Lane journal | The short-horizon handoff record for active work. | Current hypothesis, changed files, focused commands, failures, rollback concerns, and next action are recorded. |
+| Verification gate | The repo-owned commands that prove the work locally. | For this baseline, `npm run build` and `npm test` are the required checks after `npm ci` has installed dependencies. |
+| Evidence bundle | The collected facts that justify publication or repair. | Issue scope, branch/head state, changed files, test output, review facts, and PR state are linked without relying on chat memory. |
+| Reviewability | The ability for humans and tools to inspect the change safely. | The PR or handoff names the behavior delta, verification performed, unresolved risks, and review signal state. |
+| Lane introspection | Operator-facing status and explanation surfaces. | Summaries must be derived from authoritative lane state rather than stale display text. |
+
+## Preservation From codex-supervisor
+
+Ensen-loop keeps the quality goals, not the old implementation shape:
+
+- preserve issue readiness before execution;
+- preserve isolated workspaces and durable lane journals;
+- preserve local verification as a gate before publication;
+- preserve review repair as a current-facts workflow;
+- preserve evidence that can survive process restarts and conversation loss;
+- preserve fail-closed behavior when provenance, authorization, scope, or review signals are missing.
+
+## Phase 1 Boundary
+
+This document does not define EIP RunRequest or RunResult. It also does not make codex-supervisor a package dependency. Future phases may turn these concepts into schemas, commands, or runtime enforcement, but those contracts must be Ensen-loop-native and explicitly documented before implementation work depends on them.
+
+## Baseline Verification
+
+The repo-owned verification sequence is:
+
+```sh
+npm ci
+npm run build
+npm test
+```
+
+When a future quality-kit feature adds a stronger check, the documentation and tests should name the new enforcement boundary instead of relying on convention.

--- a/src/bridge/codex-supervisor/README.md
+++ b/src/bridge/codex-supervisor/README.md
@@ -1,0 +1,16 @@
+# codex-supervisor Bridge
+
+This directory is a migration bridge for codex-supervisor concepts that still need a named landing place while Ensen-loop defines its own contracts.
+
+It is not the long-term core vocabulary for Ensen-loop. New runtime code should prefer Ensen-loop terms such as lane workspace, lane journal, issue readiness, verification gate, evidence bundle, review repair, and lane introspection.
+
+## Boundary
+
+- Documentation here may explain how predecessor terms map into Ensen-loop terms.
+- Implementation code from codex-supervisor should not be copied into this bridge by default.
+- Runtime behavior must stay buildable and testable from this repository alone.
+- Any future adapter must be optional, explicit, and covered by repo-owned verification.
+
+## Deferred Work
+
+EIP RunRequest and RunResult contracts are intentionally deferred. If a later phase needs them, define the protocol, enforcement boundary, and verification plan before adding bridge code.

--- a/test/quality-kit-docs.test.ts
+++ b/test/quality-kit-docs.test.ts
@@ -1,0 +1,48 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import test from "node:test";
+
+async function readMarkdown(relativePath: string): Promise<string> {
+  return readFile(path.resolve(relativePath), "utf8");
+}
+
+test("documents the codex-supervisor handoff boundary", async () => {
+  const handoff = await readMarkdown("docs/migration/codex-supervisor-handoff.md");
+
+  for (const heading of ["Copied", "Referenced", "Rewritten", "Deferred"]) {
+    assert.match(handoff, new RegExp(`\\b${heading}\\b`));
+  }
+
+  for (const term of [
+    "issue pickup",
+    "codex exec",
+    "per-issue worktree",
+    "issue journal",
+    "PR creation",
+    "CI polling",
+    "review handling",
+    "status/explain",
+    "issue-lint",
+    "evidence/quality kit",
+  ]) {
+    assert.match(handoff, new RegExp(term, "i"));
+  }
+
+  assert.doesNotMatch(handoff, /Ensen-flow checkout|Ensen-flow service|Ensen-flow package/i);
+});
+
+test("documents the quality kit verification and evidence vocabulary", async () => {
+  const qualityKit = await readMarkdown("docs/reference/quality-kit.md");
+
+  for (const term of ["verification", "evidence", "reviewability"]) {
+    assert.match(qualityKit, new RegExp(term, "i"));
+  }
+});
+
+test("documents the codex-supervisor migration bridge as non-core vocabulary", async () => {
+  const bridgeReadme = await readMarkdown("src/bridge/codex-supervisor/README.md");
+
+  assert.match(bridgeReadme, /migration bridge/i);
+  assert.match(bridgeReadme, /not the long-term core vocabulary/i);
+});


### PR DESCRIPTION
## Summary
- add the codex-supervisor handoff migration boundary and term map
- add the Ensen-loop quality-kit reference for verification, evidence, and reviewability
- add a codex-supervisor bridge README plus focused doc contract tests

## Verification
- npm ci
- npm run build
- npm test

Closes #3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added migration handoff guide specifying how codex-supervisor concepts integrate into the system
  * Introduced quality kit reference defining vocabulary and expectations for verifiable, reviewable work
  * Added migration bridge documentation clarifying integration boundaries and constraints

* **Tests**
  * Added automated validation tests for documentation consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->