### PR TITLE
LOOP-002: Define core model boundaries

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,8 @@ Do not import implementation code from Ensen-flow or require an Ensen-flow check
 
 This baseline intentionally does not implement EIP RunRequest or RunResult support. Leave that work for the later phase that defines the protocol contracts and enforcement boundary.
 
+The Phase 1 module boundaries and core vocabulary are documented in `docs/architecture/core-model.md`.
+
 ## Local Verification
 
 Use the repo-owned commands:

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Ensen-loop is an independent development lane engine and successor product to co
 
 This repository starts as a minimal TypeScript/Node project with a build, smoke test, CI workflow, and repository hygiene rules. The baseline is intentionally small so future work can add the lane engine contracts and runtime behavior behind a stable quality gate.
 
+The Phase 1 module boundaries and vocabulary are defined in [docs/architecture/core-model.md](docs/architecture/core-model.md).
+
 ## Commands
 
 ```sh

--- a/docs/architecture/core-model.md
+++ b/docs/architecture/core-model.md
@@ -1,0 +1,49 @@
+# Ensen-loop Core Model
+
+This document defines the Phase 1 module boundaries and core vocabulary for Ensen-loop. The model is intentionally small: it names the stable concepts future lane behavior can build on without requiring Ensen-flow, GitHub, Codex, or a predecessor runtime.
+
+## Module Boundaries
+
+| Module | Responsibility |
+| --- | --- |
+| `src/core/` | Shared model terms and simple TypeScript contracts that other Phase 1 modules can reference. |
+| `src/lane/` | Lane run lifecycle, lane journal ownership, and durable lane state surfaces. |
+| `src/work-item/` | Work item and change request vocabulary before any provider-specific issue or pull request adapter exists. |
+| `src/scm/` | Source-control provider boundary. Provider implementations are future adapters, not core requirements. |
+| `src/agent/` | Agent provider boundary. Executor and assistant implementations are future adapters, not core requirements. |
+| `src/verification/` | Verification result vocabulary for repo-owned commands and check outcomes. |
+| `src/review/` | Review event vocabulary for human or tool review signals. |
+| `src/audit/` | Audit-facing durable state and journal surfaces. |
+| `src/evidence/` | Evidence bundle vocabulary tying work, verification, review, and notes into a reviewable handoff. |
+
+These modules may share the small contracts from `src/core/`, but the core model must not import implementation code from product-specific adapters.
+
+## Core Terms
+
+| Term | Definition |
+| --- | --- |
+| Work Item | A unit of lane work selected for execution. It has a stable identifier, title, source, and lifecycle status, but it is not tied to a specific issue tracker. |
+| Change Request | A proposed source change produced for a Work Item. It can later map to a pull request, patch, or another SCM-native review object through an adapter. |
+| Agent Provider | A boundary for an implementation that can perform lane work. The core model only requires an identifier and display name. |
+| SCM Provider | A boundary for source-control operations. The core model does not require any specific host, token, repository service, or remote API. |
+| Verification Result | The outcome of a repo-owned verification command or check, including the command, outcome, and summary. |
+| Review Event | A review signal attached to a Change Request, such as a comment, approval, requested change, or dismissal. |
+| Lane Journal | The short-horizon record for current lane work: hypothesis, commands, failures, changes, and next action. |
+| Durable State | Persisted lane facts that survive process restarts and future sessions. Derived summaries must not redefine this state. |
+| Evidence Bundle | The reviewable collection of work scope, verification results, review facts, and notes used to justify publication or repair. |
+| Lane Run | One execution attempt for a Work Item through lane states such as queued, running, verifying, reviewing, completed, or failed. |
+
+## Provider Posture
+
+GitHub and Codex are future adapter examples, not core model requirements. A future GitHub adapter may bind Work Items to issues and Change Requests to pull requests. A future Codex adapter may satisfy the Agent Provider boundary. Neither adapter is required for this repository to build, test, or explain its Phase 1 model.
+
+## Independence Rules
+
+- Ensen-loop must remain independently installable, buildable, and testable with `npm ci`, `npm run build`, and `npm test`.
+- Ensen-loop must not import implementation code from another Ensen product.
+- Integration with external products, services, or local checkouts must be optional and documented at an explicit adapter boundary.
+- Missing or malformed provenance, scope, auth context, verification, review, or durable state signals must fail closed in the module that owns the boundary.
+
+## Deferred Protocol Work
+
+This Phase 1 core model does not define later protocol request or result schemas. That work belongs in a later phase that defines protocol contracts and the enforcement boundary before runtime behavior depends on them.

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -1,0 +1,1 @@
+export type { AgentProvider } from "../core/index.js";

--- a/src/audit/index.ts
+++ b/src/audit/index.ts
@@ -1,0 +1,1 @@
+export type { DurableState, LaneJournal } from "../core/index.js";

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -75,6 +75,7 @@ export interface DurableState {
 
 export interface EvidenceBundle {
   readonly workItemId: WorkItem["id"];
+  readonly reviewEvents: readonly ReviewEvent[];
   readonly verification: readonly VerificationResult[];
   readonly notes: readonly string[];
 }

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,0 +1,86 @@
+export const CORE_MODEL_TERMS = [
+  "Work Item",
+  "Change Request",
+  "Agent Provider",
+  "SCM Provider",
+  "Verification Result",
+  "Review Event",
+  "Lane Journal",
+  "Durable State",
+  "Evidence Bundle",
+  "Lane Run",
+] as const;
+
+export type CoreModelTerm = (typeof CORE_MODEL_TERMS)[number];
+
+export const MODULE_BOUNDARIES = [
+  "src/core",
+  "src/lane",
+  "src/work-item",
+  "src/scm",
+  "src/agent",
+  "src/verification",
+  "src/review",
+  "src/audit",
+  "src/evidence",
+] as const;
+
+export type ModuleBoundary = (typeof MODULE_BOUNDARIES)[number];
+
+export interface WorkItem {
+  readonly id: string;
+  readonly title: string;
+  readonly source: string;
+  readonly status: "ready" | "blocked" | "running" | "completed" | "failed";
+}
+
+export interface ChangeRequest {
+  readonly id: string;
+  readonly workItemId: WorkItem["id"];
+  readonly status: "draft" | "open" | "merged" | "closed";
+}
+
+export interface AgentProvider {
+  readonly id: string;
+  readonly displayName: string;
+}
+
+export interface ScmProvider {
+  readonly id: string;
+  readonly displayName: string;
+}
+
+export interface VerificationResult {
+  readonly command: string;
+  readonly outcome: "passed" | "failed" | "skipped";
+  readonly summary: string;
+}
+
+export interface ReviewEvent {
+  readonly id: string;
+  readonly changeRequestId: ChangeRequest["id"];
+  readonly kind: "comment" | "approval" | "change-request" | "dismissal";
+}
+
+export interface LaneJournal {
+  readonly workItemId: WorkItem["id"];
+  readonly entries: readonly string[];
+}
+
+export interface DurableState {
+  readonly laneRunId: string;
+  readonly revision: number;
+  readonly updatedAt: string;
+}
+
+export interface EvidenceBundle {
+  readonly workItemId: WorkItem["id"];
+  readonly verification: readonly VerificationResult[];
+  readonly notes: readonly string[];
+}
+
+export interface LaneRun {
+  readonly id: string;
+  readonly workItemId: WorkItem["id"];
+  readonly state: "queued" | "running" | "verifying" | "reviewing" | "completed" | "failed";
+}

--- a/src/evidence/index.ts
+++ b/src/evidence/index.ts
@@ -1,0 +1,1 @@
+export type { EvidenceBundle, VerificationResult } from "../core/index.js";

--- a/src/evidence/index.ts
+++ b/src/evidence/index.ts
@@ -1,1 +1,1 @@
-export type { EvidenceBundle, VerificationResult } from "../core/index.js";
+export type { EvidenceBundle, ReviewEvent, VerificationResult } from "../core/index.js";

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,3 +15,5 @@ export const productIdentity: ProductIdentity = {
 export function describeProduct(): string {
   return `${productIdentity.name} is an independent ${productIdentity.role} and successor product to ${productIdentity.successorTo}.`;
 }
+
+export * from "./core/index.js";

--- a/src/lane/index.ts
+++ b/src/lane/index.ts
@@ -1,0 +1,1 @@
+export type { DurableState, LaneJournal, LaneRun } from "../core/index.js";

--- a/src/review/index.ts
+++ b/src/review/index.ts
@@ -1,0 +1,1 @@
+export type { ReviewEvent } from "../core/index.js";

--- a/src/scm/index.ts
+++ b/src/scm/index.ts
@@ -1,0 +1,1 @@
+export type { ChangeRequest, ScmProvider } from "../core/index.js";

--- a/src/verification/index.ts
+++ b/src/verification/index.ts
@@ -1,0 +1,1 @@
+export type { VerificationResult } from "../core/index.js";

--- a/src/work-item/index.ts
+++ b/src/work-item/index.ts
@@ -1,0 +1,1 @@
+export type { ChangeRequest, WorkItem } from "../core/index.js";

--- a/test/core-model.test.ts
+++ b/test/core-model.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { access, readFile } from "node:fs/promises";
+import { access, readFile, stat } from "node:fs/promises";
 import path from "node:path";
 import test from "node:test";
 
@@ -50,6 +50,8 @@ test("documents the Ensen-loop core model vocabulary", async () => {
 test("establishes Phase 1 source module boundaries", async () => {
   for (const directory of requiredModuleDirectories) {
     await access(path.resolve(directory));
+    const directoryInfo = await stat(path.resolve(directory));
+    assert.ok(directoryInfo.isDirectory(), `Expected ${directory} to be a directory`);
     assert.ok(MODULE_BOUNDARIES.includes(directory));
   }
 });

--- a/test/core-model.test.ts
+++ b/test/core-model.test.ts
@@ -1,0 +1,55 @@
+import assert from "node:assert/strict";
+import { access, readFile } from "node:fs/promises";
+import path from "node:path";
+import test from "node:test";
+
+import { CORE_MODEL_TERMS, MODULE_BOUNDARIES } from "../src/core/index.js";
+
+const requiredTerms = [
+  "Work Item",
+  "Change Request",
+  "Agent Provider",
+  "SCM Provider",
+  "Verification Result",
+  "Review Event",
+  "Lane Journal",
+  "Durable State",
+  "Evidence Bundle",
+  "Lane Run",
+] as const;
+
+const requiredModuleDirectories = [
+  "src/core",
+  "src/lane",
+  "src/work-item",
+  "src/scm",
+  "src/agent",
+  "src/verification",
+  "src/review",
+  "src/audit",
+  "src/evidence",
+] as const;
+
+async function readMarkdown(relativePath: string): Promise<string> {
+  return readFile(path.resolve(relativePath), "utf8");
+}
+
+test("documents the Ensen-loop core model vocabulary", async () => {
+  const coreModel = await readMarkdown("docs/architecture/core-model.md");
+
+  for (const term of requiredTerms) {
+    assert.match(coreModel, new RegExp(`\\b${term}\\b`, "i"));
+    assert.ok(CORE_MODEL_TERMS.includes(term));
+  }
+
+  assert.doesNotMatch(coreModel, /Ensen-flow checkout|Ensen-flow service|Ensen-flow package/i);
+  assert.doesNotMatch(coreModel, /\bRunRequest\b|\bRunResult\b/);
+  assert.match(coreModel, /GitHub and Codex are future adapter examples/i);
+});
+
+test("establishes Phase 1 source module boundaries", async () => {
+  for (const directory of requiredModuleDirectories) {
+    await access(path.resolve(directory));
+    assert.ok(MODULE_BOUNDARIES.includes(directory));
+  }
+});


### PR DESCRIPTION
## Summary
- add Phase 1 core-model documentation with required Ensen-loop terms
- establish strict TypeScript placeholder module boundaries under src/
- add focused tests for model vocabulary, module directories, adapter posture, and deferred protocol scope

## Verification
- npm run build
- npm test

Closes #4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added Phase 1 architecture docs defining module boundaries and a shared vocabulary; README and contributor guidance updated with links.

* **New Features**
  * Introduced a formal core model: typed definitions for work items, change requests, verification results, review events, lane/state tracking, and evidence bundles.

* **Tests**
  * Added tests to validate architecture docs and ensure declared module boundaries and vocabulary stay consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->