### PR TITLE
LOOP-003: Add local dry-run execution plan command

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,10 @@ The Phase 1 module boundaries and vocabulary are defined in [docs/architecture/c
 npm ci
 npm run build
 npm test
+node dist/src/cli/index.js dry-run --sample
 ```
+
+`dry-run --sample` emits a deterministic local execution plan as JSON. It describes the work item, lane workspace, agent provider, SCM provider, verification, and evidence intents without creating worktrees, branches, commits, change requests, durable evidence, or invoking external providers.
 
 ## Scope
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,5 +1,28 @@
 #!/usr/bin/env node
 
-import { describeProduct } from "../index.js";
+import { createSampleDryRunExecutionPlan, describeProduct } from "../index.js";
 
-console.log(describeProduct());
+const [, , command, ...args] = process.argv;
+
+function printJson(value: unknown): void {
+  console.log(`${JSON.stringify(value, null, 2)}\n`);
+}
+
+if (command === "dry-run") {
+  if (args.length === 0 || (args.length === 1 && args[0] === "--sample")) {
+    printJson(createSampleDryRunExecutionPlan());
+    process.exit(0);
+  }
+
+  console.error("Usage: ensen-loop dry-run [--sample]");
+  process.exit(1);
+}
+
+if (command === undefined) {
+  console.log(describeProduct());
+  process.exit(0);
+}
+
+console.error(`Unknown command: ${command}`);
+console.error("Usage: ensen-loop dry-run [--sample]");
+process.exit(1);

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,3 +17,5 @@ export function describeProduct(): string {
 }
 
 export * from "./core/index.js";
+export * from "./lane/index.js";
+export * from "./work-item/index.js";

--- a/src/lane/index.ts
+++ b/src/lane/index.ts
@@ -1,1 +1,60 @@
+import type { WorkItem } from "../core/index.js";
+import { sampleLocalWorkItem } from "../work-item/index.js";
+
 export type { DurableState, LaneJournal, LaneRun } from "../core/index.js";
+
+export interface DryRunExecutionPlan {
+  readonly command: "dry-run";
+  readonly mode: "sample";
+  readonly workItem: WorkItem;
+  readonly laneWorkspace: {
+    readonly intent: string;
+    readonly mutatesFilesystem: false;
+  };
+  readonly agentProvider: {
+    readonly intent: string;
+    readonly invokesProvider: false;
+  };
+  readonly scmProvider: {
+    readonly intent: string;
+    readonly createsBranch: false;
+    readonly opensChangeRequest: false;
+  };
+  readonly verification: {
+    readonly intent: string;
+    readonly commands: readonly string[];
+  };
+  readonly evidence: {
+    readonly intent: string;
+    readonly writesDurableEvidence: false;
+  };
+}
+
+export function createSampleDryRunExecutionPlan(): DryRunExecutionPlan {
+  return {
+    command: "dry-run",
+    mode: "sample",
+    workItem: sampleLocalWorkItem,
+    laneWorkspace: {
+      intent: "describe lane workspace preparation without creating a worktree",
+      mutatesFilesystem: false,
+    },
+    agentProvider: {
+      intent: "describe agent selection without invoking an agent provider",
+      invokesProvider: false,
+    },
+    scmProvider: {
+      intent: "describe SCM actions without creating branches, commits, or change requests",
+      createsBranch: false,
+      opensChangeRequest: false,
+    },
+    verification: {
+      intent: "describe repo-owned verification commands without running them",
+      commands: ["npm run build", "npm test"],
+    },
+    evidence: {
+      intent: "describe evidence capture without writing durable evidence",
+      writesDurableEvidence: false,
+    },
+  };
+}

--- a/src/work-item/index.ts
+++ b/src/work-item/index.ts
@@ -1,1 +1,10 @@
+import type { WorkItem } from "../core/index.js";
+
 export type { ChangeRequest, WorkItem } from "../core/index.js";
+
+export const sampleLocalWorkItem: WorkItem = {
+  id: "sample-local-work-item",
+  title: "Sample local work item",
+  source: "local-sample",
+  status: "ready",
+};

--- a/test/dry-run-cli.test.ts
+++ b/test/dry-run-cli.test.ts
@@ -1,0 +1,78 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import test from "node:test";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+test("dry-run sample emits a normalized execution plan", async () => {
+  const { stdout, stderr } = await execFileAsync(process.execPath, [
+    "dist/src/cli/index.js",
+    "dry-run",
+    "--sample",
+  ]);
+
+  assert.equal(stderr, "");
+
+  const plan = JSON.parse(stdout) as {
+    command: string;
+    mode: string;
+    workItem: {
+      id: string;
+      title: string;
+      source: string;
+      status: string;
+    };
+    laneWorkspace: {
+      intent: string;
+      mutatesFilesystem: boolean;
+    };
+    agentProvider: {
+      intent: string;
+      invokesProvider: boolean;
+    };
+    scmProvider: {
+      intent: string;
+      createsBranch: boolean;
+      opensChangeRequest: boolean;
+    };
+    verification: {
+      intent: string;
+      commands: readonly string[];
+    };
+    evidence: {
+      intent: string;
+      writesDurableEvidence: boolean;
+    };
+  };
+
+  assert.equal(plan.command, "dry-run");
+  assert.equal(plan.mode, "sample");
+  assert.deepEqual(plan.workItem, {
+    id: "sample-local-work-item",
+    title: "Sample local work item",
+    source: "local-sample",
+    status: "ready",
+  });
+  assert.deepEqual(plan.laneWorkspace, {
+    intent: "describe lane workspace preparation without creating a worktree",
+    mutatesFilesystem: false,
+  });
+  assert.deepEqual(plan.agentProvider, {
+    intent: "describe agent selection without invoking an agent provider",
+    invokesProvider: false,
+  });
+  assert.deepEqual(plan.scmProvider, {
+    intent: "describe SCM actions without creating branches, commits, or change requests",
+    createsBranch: false,
+    opensChangeRequest: false,
+  });
+  assert.deepEqual(plan.verification, {
+    intent: "describe repo-owned verification commands without running them",
+    commands: ["npm run build", "npm test"],
+  });
+  assert.deepEqual(plan.evidence, {
+    intent: "describe evidence capture without writing durable evidence",
+    writesDurableEvidence: false,
+  });
+});


### PR DESCRIPTION
## Summary
- add a lane-owned dry-run execution plan for the built-in sample local work item
- expose `ensen-loop dry-run [--sample]` via the CLI as deterministic JSON
- document the command and cover the output shape with a CLI smoke test

## Verification
- `npm test`
- `npm run build`
- `node dist/src/cli/index.js dry-run --sample`

Part of #2
Closes #5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `dry-run --sample` subcommand to output a deterministic JSON execution plan showing intended actions without performing external calls or state changes.
  * Expanded public API surface with additional module re-exports.

* **Documentation**
  * Updated README with baseline command for running the CLI in dry-run sample mode and documentation of its behavior.

* **Tests**
  * Added comprehensive test coverage for the dry-run CLI functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->