### PR TITLE
LOOP-004: Add lane journal state skeleton

### DIFF
--- a/docs/architecture/core-model.md
+++ b/docs/architecture/core-model.md
@@ -46,7 +46,7 @@ Audit and evidence surfaces are represented as explicit reference lists on the L
 - `audit.eventRefs` reserves the relationship to future audit events without emitting a full EIP AuditEvent.
 - `evidence.bundleRefs` reserves the relationship to future evidence bundles without emitting a full EvidenceBundleRef.
 
-Local storage helpers must resolve lane run state paths below the configured state root and reject lane run identifiers containing path separators or traversal syntax. Derived summaries, detail projections, or operator-facing notes must be rebuilt from the Lane Run State instead of redefining the durable status.
+Local storage helpers must resolve lane run state paths below a real configured state root, reject lane run identifiers containing path separators or traversal syntax, and fail closed when existing storage components are symbolic links. Derived summaries, detail projections, or operator-facing notes must be rebuilt from the Lane Run State instead of redefining the durable status.
 
 ## Provider Posture
 

--- a/docs/architecture/core-model.md
+++ b/docs/architecture/core-model.md
@@ -33,6 +33,21 @@ These modules may share the small contracts from `src/core/`, but the core model
 | Evidence Bundle | The reviewable collection of work scope, verification results, review facts, and notes used to justify publication or repair. |
 | Lane Run | One execution attempt for a Work Item through lane states such as queued, running, verifying, reviewing, completed, or failed. |
 
+## Lane Journal and Durable State
+
+Phase 1 represents lane run resumability as a local JSON state file under a caller-provided state root. The concrete schema is documented in `schemas/lane-run.schema.json`.
+
+A Lane Run State record is the durable owner for one lane attempt. It stores the lane run identifier, work item binding, lifecycle status, revision, timestamps, and `startsAgentExecution: false` to make clear that this skeleton does not invoke an agent or start runtime execution.
+
+The Lane Journal is embedded in the Lane Run State for Phase 1. It records short-horizon operator context as typed entries: hypothesis, command, failure, change, and next-action. The journal is resumability context, not an authorization source and not an execution trigger.
+
+Audit and evidence surfaces are represented as explicit reference lists on the Lane Run State:
+
+- `audit.eventRefs` reserves the relationship to future audit events without emitting a full EIP AuditEvent.
+- `evidence.bundleRefs` reserves the relationship to future evidence bundles without emitting a full EvidenceBundleRef.
+
+Local storage helpers must resolve lane run state paths below the configured state root and reject lane run identifiers containing path separators or traversal syntax. Derived summaries, detail projections, or operator-facing notes must be rebuilt from the Lane Run State instead of redefining the durable status.
+
 ## Provider Posture
 
 GitHub and Codex are future adapter examples, not core model requirements. A future GitHub adapter may bind Work Items to issues and Change Requests to pull requests. A future Codex adapter may satisfy the Agent Provider boundary. Neither adapter is required for this repository to build, test, or explain its Phase 1 model.

--- a/schemas/lane-run.schema.json
+++ b/schemas/lane-run.schema.json
@@ -81,7 +81,8 @@
                 "enum": ["hypothesis", "command", "failure", "change", "next-action"]
               },
               "message": {
-                "type": "string"
+                "type": "string",
+                "minLength": 1
               }
             }
           }
@@ -96,7 +97,8 @@
         "eventRefs": {
           "type": "array",
           "items": {
-            "type": "string"
+            "type": "string",
+            "minLength": 1
           }
         }
       }
@@ -109,7 +111,8 @@
         "bundleRefs": {
           "type": "array",
           "items": {
-            "type": "string"
+            "type": "string",
+            "minLength": 1
           }
         }
       }

--- a/schemas/lane-run.schema.json
+++ b/schemas/lane-run.schema.json
@@ -1,0 +1,118 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ensen-loop.local/schemas/lane-run.schema.json",
+  "title": "Ensen-loop Lane Run State",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "id",
+    "workItemId",
+    "status",
+    "revision",
+    "createdAt",
+    "updatedAt",
+    "startsAgentExecution",
+    "journal",
+    "audit",
+    "evidence"
+  ],
+  "properties": {
+    "id": {
+      "type": "string",
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]*$"
+    },
+    "workItemId": {
+      "type": "string",
+      "minLength": 1
+    },
+    "status": {
+      "type": "string",
+      "enum": ["queued", "running", "verifying", "reviewing", "completed", "failed"]
+    },
+    "revision": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "createdAt": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "updatedAt": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "startsAgentExecution": {
+      "const": false
+    },
+    "journal": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "laneRunId", "workItemId", "entries"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "laneRunId": {
+          "type": "string",
+          "minLength": 1
+        },
+        "workItemId": {
+          "type": "string",
+          "minLength": 1
+        },
+        "entries": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["id", "recordedAt", "kind", "message"],
+            "properties": {
+              "id": {
+                "type": "string",
+                "minLength": 1
+              },
+              "recordedAt": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "kind": {
+                "type": "string",
+                "enum": ["hypothesis", "command", "failure", "change", "next-action"]
+              },
+              "message": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    },
+    "audit": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["eventRefs"],
+      "properties": {
+        "eventRefs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "evidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["bundleRefs"],
+      "properties": {
+        "bundleRefs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/audit/index.ts
+++ b/src/audit/index.ts
@@ -1,1 +1,3 @@
-export type { DurableState, LaneJournal } from "../core/index.js";
+export interface LaneAuditRefs {
+  readonly eventRefs: readonly string[];
+}

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -62,26 +62,9 @@ export interface ReviewEvent {
   readonly kind: "comment" | "approval" | "change-request" | "dismissal";
 }
 
-export interface LaneJournal {
-  readonly workItemId: WorkItem["id"];
-  readonly entries: readonly string[];
-}
-
-export interface DurableState {
-  readonly laneRunId: string;
-  readonly revision: number;
-  readonly updatedAt: string;
-}
-
 export interface EvidenceBundle {
   readonly workItemId: WorkItem["id"];
   readonly reviewEvents: readonly ReviewEvent[];
   readonly verification: readonly VerificationResult[];
   readonly notes: readonly string[];
-}
-
-export interface LaneRun {
-  readonly id: string;
-  readonly workItemId: WorkItem["id"];
-  readonly state: "queued" | "running" | "verifying" | "reviewing" | "completed" | "failed";
 }

--- a/src/evidence/index.ts
+++ b/src/evidence/index.ts
@@ -1,1 +1,5 @@
 export type { EvidenceBundle, ReviewEvent, VerificationResult } from "../core/index.js";
+
+export interface LaneEvidenceRefs {
+  readonly bundleRefs: readonly string[];
+}

--- a/src/lane/index.ts
+++ b/src/lane/index.ts
@@ -63,6 +63,8 @@ export interface CreateLaneRunStateInput {
 }
 
 const laneRunIdPattern = /^[A-Za-z0-9][A-Za-z0-9._-]*$/;
+const isoDateTimePattern =
+  /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.\d+)?(Z|[+-]\d{2}:\d{2})$/;
 const laneRunStatuses = new Set<unknown>([
   "queued",
   "running",
@@ -129,8 +131,17 @@ export async function writeLaneRunState(stateRoot: string, state: LaneRunState):
 export async function readLaneRunState(stateRoot: string, laneRunId: string): Promise<LaneRunState> {
   const statePath = resolveLaneRunStatePath(stateRoot, laneRunId);
   const parsed = JSON.parse(await readFile(statePath, "utf8")) as unknown;
+  const state = parseLaneRunState(parsed);
 
-  return parseLaneRunState(parsed);
+  if (
+    state.id !== laneRunId ||
+    state.journal.laneRunId !== laneRunId ||
+    state.journal.workItemId !== state.workItemId
+  ) {
+    throw new Error("Lane run state identifiers do not match the requested lane run.");
+  }
+
+  return state;
 }
 
 function parseLaneRunState(value: unknown): LaneRunState {
@@ -143,13 +154,26 @@ function parseLaneRunState(value: unknown): LaneRunState {
   }
 
   if (
-    typeof value.id !== "string" ||
-    typeof value.workItemId !== "string" ||
+    !hasExactKeys(value, [
+      "id",
+      "workItemId",
+      "status",
+      "revision",
+      "createdAt",
+      "updatedAt",
+      "startsAgentExecution",
+      "journal",
+      "audit",
+      "evidence",
+    ]) ||
+    !isLaneRunId(value.id) ||
+    !isNonEmptyString(value.workItemId) ||
     !laneRunStatuses.has(value.status) ||
     typeof value.revision !== "number" ||
     !Number.isInteger(value.revision) ||
-    typeof value.createdAt !== "string" ||
-    typeof value.updatedAt !== "string" ||
+    value.revision < 1 ||
+    !isIsoDateTime(value.createdAt) ||
+    !isIsoDateTime(value.updatedAt) ||
     !isLaneJournal(value.journal) ||
     !isAuditRefs(value.audit) ||
     !isEvidenceRefs(value.evidence)
@@ -163,9 +187,10 @@ function parseLaneRunState(value: unknown): LaneRunState {
 function isLaneJournal(value: unknown): value is LaneJournal {
   return (
     isRecord(value) &&
-    typeof value.id === "string" &&
-    typeof value.laneRunId === "string" &&
-    typeof value.workItemId === "string" &&
+    hasExactKeys(value, ["id", "laneRunId", "workItemId", "entries"]) &&
+    isNonEmptyString(value.id) &&
+    isNonEmptyString(value.laneRunId) &&
+    isNonEmptyString(value.workItemId) &&
     Array.isArray(value.entries) &&
     value.entries.every(isLaneJournalEntry)
   );
@@ -174,23 +199,92 @@ function isLaneJournal(value: unknown): value is LaneJournal {
 function isLaneJournalEntry(value: unknown): value is LaneJournalEntry {
   return (
     isRecord(value) &&
-    typeof value.id === "string" &&
-    typeof value.recordedAt === "string" &&
+    hasExactKeys(value, ["id", "recordedAt", "kind", "message"]) &&
+    isNonEmptyString(value.id) &&
+    isIsoDateTime(value.recordedAt) &&
     ["hypothesis", "command", "failure", "change", "next-action"].includes(String(value.kind)) &&
     typeof value.message === "string"
   );
 }
 
 function isAuditRefs(value: unknown): value is LaneAuditRefs {
-  return isRecord(value) && Array.isArray(value.eventRefs) && value.eventRefs.every(isString);
+  return (
+    isRecord(value) &&
+    hasExactKeys(value, ["eventRefs"]) &&
+    Array.isArray(value.eventRefs) &&
+    value.eventRefs.every(isString)
+  );
 }
 
 function isEvidenceRefs(value: unknown): value is LaneEvidenceRefs {
-  return isRecord(value) && Array.isArray(value.bundleRefs) && value.bundleRefs.every(isString);
+  return (
+    isRecord(value) &&
+    hasExactKeys(value, ["bundleRefs"]) &&
+    Array.isArray(value.bundleRefs) &&
+    value.bundleRefs.every(isString)
+  );
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function hasExactKeys(value: Record<string, unknown>, expectedKeys: readonly string[]): boolean {
+  const valueKeys = Object.keys(value);
+
+  return valueKeys.length === expectedKeys.length && expectedKeys.every((key) => Object.hasOwn(value, key));
+}
+
+function isLaneRunId(value: unknown): value is string {
+  return typeof value === "string" && laneRunIdPattern.test(value);
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.length > 0;
+}
+
+function isIsoDateTime(value: unknown): value is string {
+  if (typeof value !== "string") {
+    return false;
+  }
+
+  const match = isoDateTimePattern.exec(value);
+
+  if (!match) {
+    return false;
+  }
+
+  const [, year, month, day, hour, minute, second, timezone] = match;
+  const yearNumber = Number(year);
+  const monthNumber = Number(month);
+  const dayNumber = Number(day);
+  const hourNumber = Number(hour);
+  const minuteNumber = Number(minute);
+  const secondNumber = Number(second);
+
+  if (
+    monthNumber < 1 ||
+    monthNumber > 12 ||
+    dayNumber < 1 ||
+    hourNumber > 23 ||
+    minuteNumber > 59 ||
+    secondNumber > 59
+  ) {
+    return false;
+  }
+
+  if (timezone !== "Z") {
+    const timezoneHour = Number(timezone.slice(1, 3));
+    const timezoneMinute = Number(timezone.slice(4, 6));
+
+    if (timezoneHour > 23 || timezoneMinute > 59) {
+      return false;
+    }
+  }
+
+  const daysInMonth = new Date(Date.UTC(yearNumber, monthNumber, 0)).getUTCDate();
+
+  return dayNumber <= daysInMonth && Number.isFinite(Date.parse(value));
 }
 
 function isString(value: unknown): value is string {

--- a/src/lane/index.ts
+++ b/src/lane/index.ts
@@ -1,4 +1,5 @@
-import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { constants } from "node:fs";
+import { lstat, mkdir, open, realpath } from "node:fs/promises";
 import path from "node:path";
 
 import type { LaneAuditRefs } from "../audit/index.js";
@@ -120,17 +121,42 @@ export function resolveLaneRunStatePath(stateRoot: string, laneRunId: string): s
 }
 
 export async function writeLaneRunState(stateRoot: string, state: LaneRunState): Promise<string> {
-  const statePath = resolveLaneRunStatePath(stateRoot, state.id);
+  const validatedState = validateLaneRunStateForWrite(state);
+  const statePath = resolveLaneRunStatePath(stateRoot, validatedState.id);
 
+  await assertLaneRunStatePathSafeForWrite(stateRoot, statePath);
   await mkdir(path.dirname(statePath), { recursive: true });
-  await writeFile(statePath, `${serializeLaneRunState(state)}\n`, "utf8");
+  await assertLaneRunStatePathSafeForWrite(stateRoot, statePath);
+
+  const file = await open(
+    statePath,
+    constants.O_WRONLY | constants.O_CREAT | constants.O_TRUNC | noFollowFlag(),
+    0o600,
+  );
+
+  try {
+    await file.writeFile(`${serializeLaneRunState(validatedState)}\n`, "utf8");
+  } finally {
+    await file.close();
+  }
 
   return statePath;
 }
 
 export async function readLaneRunState(stateRoot: string, laneRunId: string): Promise<LaneRunState> {
   const statePath = resolveLaneRunStatePath(stateRoot, laneRunId);
-  const parsed = JSON.parse(await readFile(statePath, "utf8")) as unknown;
+  await assertLaneRunStatePathSafeForRead(stateRoot, statePath);
+
+  const file = await open(statePath, constants.O_RDONLY | noFollowFlag());
+  let contents: string;
+
+  try {
+    contents = await file.readFile("utf8");
+  } finally {
+    await file.close();
+  }
+
+  const parsed = JSON.parse(contents) as unknown;
   const state = parseLaneRunState(parsed);
 
   if (
@@ -142,6 +168,94 @@ export async function readLaneRunState(stateRoot: string, laneRunId: string): Pr
   }
 
   return state;
+}
+
+function validateLaneRunStateForWrite(state: LaneRunState): LaneRunState {
+  const parsed = parseLaneRunState(state);
+
+  if (parsed.journal.laneRunId !== parsed.id || parsed.journal.workItemId !== parsed.workItemId) {
+    throw new Error("Lane run state identifiers do not match the lane run being persisted.");
+  }
+
+  return parsed;
+}
+
+async function assertLaneRunStatePathSafeForWrite(stateRoot: string, statePath: string): Promise<void> {
+  const realRoot = await resolveCanonicalStateRoot(stateRoot);
+  const laneRunsRoot = path.join(path.resolve(stateRoot), "lane-runs");
+
+  await assertExistingPathSafe(realRoot, laneRunsRoot, "directory");
+  await assertExistingPathSafe(realRoot, statePath, "file");
+}
+
+async function assertLaneRunStatePathSafeForRead(stateRoot: string, statePath: string): Promise<void> {
+  const realRoot = await resolveCanonicalStateRoot(stateRoot);
+  const laneRunsRoot = path.join(path.resolve(stateRoot), "lane-runs");
+
+  await assertExistingPathSafe(realRoot, laneRunsRoot, "directory");
+  await assertExistingPathSafe(realRoot, statePath, "file");
+}
+
+async function resolveCanonicalStateRoot(stateRoot: string): Promise<string> {
+  const resolvedRoot = path.resolve(stateRoot);
+  const stats = await lstat(resolvedRoot).catch((error: unknown) => {
+    if (isNodeError(error) && error.code === "ENOENT") {
+      throw new Error("Configured state root must exist before lane run state is accessed.");
+    }
+
+    throw error;
+  });
+
+  if (stats.isSymbolicLink() || !stats.isDirectory()) {
+    throw new Error("Configured state root must be a real directory.");
+  }
+
+  return realpath(resolvedRoot);
+}
+
+async function assertExistingPathSafe(
+  realRoot: string,
+  candidatePath: string,
+  expectedKind: "directory" | "file",
+): Promise<void> {
+  const stats = await lstat(candidatePath).catch((error: unknown) => {
+    if (isNodeError(error) && error.code === "ENOENT") {
+      return undefined;
+    }
+
+    throw error;
+  });
+
+  if (!stats) {
+    return;
+  }
+
+  if (stats.isSymbolicLink()) {
+    throw new Error("Lane run state paths must not traverse symbolic links.");
+  }
+
+  if (expectedKind === "directory" && !stats.isDirectory()) {
+    throw new Error("Lane run state directory path must be a real directory.");
+  }
+
+  if (expectedKind === "file" && stats.isDirectory()) {
+    throw new Error("Lane run state file path must not be a directory.");
+  }
+
+  const realCandidate = await realpath(candidatePath);
+  const relativePath = path.relative(realRoot, realCandidate);
+
+  if (relativePath.startsWith("..") || path.isAbsolute(relativePath)) {
+    throw new Error("Lane run state paths must stay inside the configured state root.");
+  }
+}
+
+function noFollowFlag(): number {
+  return typeof constants.O_NOFOLLOW === "number" ? constants.O_NOFOLLOW : 0;
+}
+
+function isNodeError(error: unknown): error is NodeJS.ErrnoException {
+  return error instanceof Error && "code" in error;
 }
 
 function parseLaneRunState(value: unknown): LaneRunState {

--- a/src/lane/index.ts
+++ b/src/lane/index.ts
@@ -1,7 +1,201 @@
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+import type { LaneAuditRefs } from "../audit/index.js";
 import type { WorkItem } from "../core/index.js";
+import type { LaneEvidenceRefs } from "../evidence/index.js";
 import { sampleLocalWorkItem } from "../work-item/index.js";
 
-export type { DurableState, LaneJournal, LaneRun } from "../core/index.js";
+export type LaneRunStatus =
+  | "queued"
+  | "running"
+  | "verifying"
+  | "reviewing"
+  | "completed"
+  | "failed";
+
+export type LaneJournalEntryKind = "hypothesis" | "command" | "failure" | "change" | "next-action";
+
+export interface LaneJournalEntry {
+  readonly id: string;
+  readonly recordedAt: string;
+  readonly kind: LaneJournalEntryKind;
+  readonly message: string;
+}
+
+export interface LaneJournal {
+  readonly id: string;
+  readonly laneRunId: string;
+  readonly workItemId: WorkItem["id"];
+  readonly entries: readonly LaneJournalEntry[];
+}
+
+export interface LaneRunState {
+  readonly id: string;
+  readonly workItemId: WorkItem["id"];
+  readonly status: LaneRunStatus;
+  readonly revision: number;
+  readonly createdAt: string;
+  readonly updatedAt: string;
+  readonly startsAgentExecution: false;
+  readonly journal: LaneJournal;
+  readonly audit: LaneAuditRefs;
+  readonly evidence: LaneEvidenceRefs;
+}
+
+export interface CreateLaneJournalInput {
+  readonly id: string;
+  readonly laneRunId: string;
+  readonly workItemId: WorkItem["id"];
+  readonly entries?: readonly LaneJournalEntry[];
+}
+
+export interface CreateLaneRunStateInput {
+  readonly id: string;
+  readonly workItemId: WorkItem["id"];
+  readonly status: LaneRunStatus;
+  readonly revision: number;
+  readonly createdAt: string;
+  readonly updatedAt: string;
+  readonly journal: LaneJournal;
+  readonly audit?: LaneAuditRefs;
+  readonly evidence?: LaneEvidenceRefs;
+}
+
+const laneRunIdPattern = /^[A-Za-z0-9][A-Za-z0-9._-]*$/;
+const laneRunStatuses = new Set<unknown>([
+  "queued",
+  "running",
+  "verifying",
+  "reviewing",
+  "completed",
+  "failed",
+]);
+
+export function createLaneJournal(input: CreateLaneJournalInput): LaneJournal {
+  return {
+    id: input.id,
+    laneRunId: input.laneRunId,
+    workItemId: input.workItemId,
+    entries: input.entries ?? [],
+  };
+}
+
+export function createLaneRunState(input: CreateLaneRunStateInput): LaneRunState {
+  return {
+    id: input.id,
+    workItemId: input.workItemId,
+    status: input.status,
+    revision: input.revision,
+    createdAt: input.createdAt,
+    updatedAt: input.updatedAt,
+    startsAgentExecution: false,
+    journal: input.journal,
+    audit: input.audit ?? { eventRefs: [] },
+    evidence: input.evidence ?? { bundleRefs: [] },
+  };
+}
+
+export function serializeLaneRunState(state: LaneRunState): string {
+  return JSON.stringify(state, null, 2);
+}
+
+export function resolveLaneRunStatePath(stateRoot: string, laneRunId: string): string {
+  if (!laneRunIdPattern.test(laneRunId)) {
+    throw new Error("Lane run identifiers may only contain letters, numbers, dots, underscores, and hyphens.");
+  }
+
+  const resolvedRoot = path.resolve(stateRoot);
+  const laneRunsRoot = path.join(resolvedRoot, "lane-runs");
+  const statePath = path.join(laneRunsRoot, `${laneRunId}.json`);
+  const relativePath = path.relative(resolvedRoot, statePath);
+
+  if (relativePath.startsWith("..") || path.isAbsolute(relativePath)) {
+    throw new Error("Lane run state paths must stay inside the configured state root.");
+  }
+
+  return statePath;
+}
+
+export async function writeLaneRunState(stateRoot: string, state: LaneRunState): Promise<string> {
+  const statePath = resolveLaneRunStatePath(stateRoot, state.id);
+
+  await mkdir(path.dirname(statePath), { recursive: true });
+  await writeFile(statePath, `${serializeLaneRunState(state)}\n`, "utf8");
+
+  return statePath;
+}
+
+export async function readLaneRunState(stateRoot: string, laneRunId: string): Promise<LaneRunState> {
+  const statePath = resolveLaneRunStatePath(stateRoot, laneRunId);
+  const parsed = JSON.parse(await readFile(statePath, "utf8")) as unknown;
+
+  return parseLaneRunState(parsed);
+}
+
+function parseLaneRunState(value: unknown): LaneRunState {
+  if (!isRecord(value)) {
+    throw new Error("Lane run state must be a JSON object.");
+  }
+
+  if (value.startsAgentExecution !== false) {
+    throw new Error("Lane run state must not start agent execution.");
+  }
+
+  if (
+    typeof value.id !== "string" ||
+    typeof value.workItemId !== "string" ||
+    !laneRunStatuses.has(value.status) ||
+    typeof value.revision !== "number" ||
+    !Number.isInteger(value.revision) ||
+    typeof value.createdAt !== "string" ||
+    typeof value.updatedAt !== "string" ||
+    !isLaneJournal(value.journal) ||
+    !isAuditRefs(value.audit) ||
+    !isEvidenceRefs(value.evidence)
+  ) {
+    throw new Error("Lane run state is malformed.");
+  }
+
+  return value as unknown as LaneRunState;
+}
+
+function isLaneJournal(value: unknown): value is LaneJournal {
+  return (
+    isRecord(value) &&
+    typeof value.id === "string" &&
+    typeof value.laneRunId === "string" &&
+    typeof value.workItemId === "string" &&
+    Array.isArray(value.entries) &&
+    value.entries.every(isLaneJournalEntry)
+  );
+}
+
+function isLaneJournalEntry(value: unknown): value is LaneJournalEntry {
+  return (
+    isRecord(value) &&
+    typeof value.id === "string" &&
+    typeof value.recordedAt === "string" &&
+    ["hypothesis", "command", "failure", "change", "next-action"].includes(String(value.kind)) &&
+    typeof value.message === "string"
+  );
+}
+
+function isAuditRefs(value: unknown): value is LaneAuditRefs {
+  return isRecord(value) && Array.isArray(value.eventRefs) && value.eventRefs.every(isString);
+}
+
+function isEvidenceRefs(value: unknown): value is LaneEvidenceRefs {
+  return isRecord(value) && Array.isArray(value.bundleRefs) && value.bundleRefs.every(isString);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isString(value: unknown): value is string {
+  return typeof value === "string";
+}
 
 export interface DryRunExecutionPlan {
   readonly command: "dry-run";

--- a/src/lane/index.ts
+++ b/src/lane/index.ts
@@ -203,7 +203,7 @@ function isLaneJournalEntry(value: unknown): value is LaneJournalEntry {
     isNonEmptyString(value.id) &&
     isIsoDateTime(value.recordedAt) &&
     ["hypothesis", "command", "failure", "change", "next-action"].includes(String(value.kind)) &&
-    typeof value.message === "string"
+    isNonEmptyString(value.message)
   );
 }
 
@@ -212,7 +212,7 @@ function isAuditRefs(value: unknown): value is LaneAuditRefs {
     isRecord(value) &&
     hasExactKeys(value, ["eventRefs"]) &&
     Array.isArray(value.eventRefs) &&
-    value.eventRefs.every(isString)
+    value.eventRefs.every(isNonEmptyString)
   );
 }
 
@@ -221,7 +221,7 @@ function isEvidenceRefs(value: unknown): value is LaneEvidenceRefs {
     isRecord(value) &&
     hasExactKeys(value, ["bundleRefs"]) &&
     Array.isArray(value.bundleRefs) &&
-    value.bundleRefs.every(isString)
+    value.bundleRefs.every(isNonEmptyString)
   );
 }
 
@@ -285,10 +285,6 @@ function isIsoDateTime(value: unknown): value is string {
   const daysInMonth = new Date(Date.UTC(yearNumber, monthNumber, 0)).getUTCDate();
 
   return dayNumber <= daysInMonth && Number.isFinite(Date.parse(value));
-}
-
-function isString(value: unknown): value is string {
-  return typeof value === "string";
 }
 
 export interface DryRunExecutionPlan {

--- a/src/lane/index.ts
+++ b/src/lane/index.ts
@@ -1,5 +1,7 @@
 import { constants } from "node:fs";
+import type { Stats } from "node:fs";
 import { lstat, mkdir, open, realpath } from "node:fs/promises";
+import type { FileHandle } from "node:fs/promises";
 import path from "node:path";
 
 import type { LaneAuditRefs } from "../audit/index.js";
@@ -124,17 +126,19 @@ export async function writeLaneRunState(stateRoot: string, state: LaneRunState):
   const validatedState = validateLaneRunStateForWrite(state);
   const statePath = resolveLaneRunStatePath(stateRoot, validatedState.id);
 
-  await assertLaneRunStatePathSafeForWrite(stateRoot, statePath);
+  const realRoot = await assertLaneRunStatePathSafeForWrite(stateRoot, statePath);
   await mkdir(path.dirname(statePath), { recursive: true });
   await assertLaneRunStatePathSafeForWrite(stateRoot, statePath);
 
   const file = await open(
     statePath,
-    constants.O_WRONLY | constants.O_CREAT | constants.O_TRUNC | noFollowFlag(),
+    constants.O_RDWR | constants.O_CREAT | noFollowFlag() | nonBlockingFlag(),
     0o600,
   );
 
   try {
+    await assertOpenedLaneRunStateFileSafeForAccess(realRoot, statePath, file);
+    await file.truncate(0);
     await file.writeFile(`${serializeLaneRunState(validatedState)}\n`, "utf8");
   } finally {
     await file.close();
@@ -145,12 +149,13 @@ export async function writeLaneRunState(stateRoot: string, state: LaneRunState):
 
 export async function readLaneRunState(stateRoot: string, laneRunId: string): Promise<LaneRunState> {
   const statePath = resolveLaneRunStatePath(stateRoot, laneRunId);
-  await assertLaneRunStatePathSafeForRead(stateRoot, statePath);
+  const realRoot = await assertLaneRunStatePathSafeForRead(stateRoot, statePath);
 
-  const file = await open(statePath, constants.O_RDONLY | noFollowFlag());
+  const file = await open(statePath, constants.O_RDONLY | noFollowFlag() | nonBlockingFlag());
   let contents: string;
 
   try {
+    await assertOpenedLaneRunStateFileSafeForAccess(realRoot, statePath, file);
     contents = await file.readFile("utf8");
   } finally {
     await file.close();
@@ -180,20 +185,24 @@ function validateLaneRunStateForWrite(state: LaneRunState): LaneRunState {
   return parsed;
 }
 
-async function assertLaneRunStatePathSafeForWrite(stateRoot: string, statePath: string): Promise<void> {
+async function assertLaneRunStatePathSafeForWrite(stateRoot: string, statePath: string): Promise<string> {
   const realRoot = await resolveCanonicalStateRoot(stateRoot);
   const laneRunsRoot = path.join(path.resolve(stateRoot), "lane-runs");
 
   await assertExistingPathSafe(realRoot, laneRunsRoot, "directory");
   await assertExistingPathSafe(realRoot, statePath, "file");
+
+  return realRoot;
 }
 
-async function assertLaneRunStatePathSafeForRead(stateRoot: string, statePath: string): Promise<void> {
+async function assertLaneRunStatePathSafeForRead(stateRoot: string, statePath: string): Promise<string> {
   const realRoot = await resolveCanonicalStateRoot(stateRoot);
   const laneRunsRoot = path.join(path.resolve(stateRoot), "lane-runs");
 
   await assertExistingPathSafe(realRoot, laneRunsRoot, "directory");
   await assertExistingPathSafe(realRoot, statePath, "file");
+
+  return realRoot;
 }
 
 async function resolveCanonicalStateRoot(stateRoot: string): Promise<string> {
@@ -238,8 +247,8 @@ async function assertExistingPathSafe(
     throw new Error("Lane run state directory path must be a real directory.");
   }
 
-  if (expectedKind === "file" && stats.isDirectory()) {
-    throw new Error("Lane run state file path must not be a directory.");
+  if (expectedKind === "file" && !stats.isFile()) {
+    throw new Error("Lane run state file path must be a regular file.");
   }
 
   const realCandidate = await realpath(candidatePath);
@@ -252,6 +261,40 @@ async function assertExistingPathSafe(
 
 function noFollowFlag(): number {
   return typeof constants.O_NOFOLLOW === "number" ? constants.O_NOFOLLOW : 0;
+}
+
+function nonBlockingFlag(): number {
+  return typeof constants.O_NONBLOCK === "number" ? constants.O_NONBLOCK : 0;
+}
+
+async function assertOpenedLaneRunStateFileSafeForAccess(
+  realRoot: string,
+  statePath: string,
+  file: FileHandle,
+): Promise<void> {
+  const openedStats = await file.stat();
+
+  if (!openedStats.isFile()) {
+    throw new Error("Lane run state file path must be a regular file.");
+  }
+
+  const pathStats = await lstat(statePath).catch((error: unknown) => {
+    if (isNodeError(error) && error.code === "ENOENT") {
+      throw new Error("Lane run state file changed during access.");
+    }
+
+    throw error;
+  });
+
+  if (!sameFileStats(openedStats, pathStats)) {
+    throw new Error("Lane run state file changed during access.");
+  }
+
+  await assertExistingPathSafe(realRoot, statePath, "file");
+}
+
+function sameFileStats(left: Stats, right: Stats): boolean {
+  return left.dev === right.dev && left.ino === right.ino;
 }
 
 function isNodeError(error: unknown): error is NodeJS.ErrnoException {

--- a/test/lane-state.test.ts
+++ b/test/lane-state.test.ts
@@ -1,8 +1,10 @@
 import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
 import { mkdir, mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
+import { promisify } from "node:util";
 
 import {
   createLaneJournal,
@@ -12,6 +14,8 @@ import {
   serializeLaneRunState,
   writeLaneRunState,
 } from "../src/lane/index.js";
+
+const execFileAsync = promisify(execFile);
 
 test("serializes lane journal and durable state without starting execution", () => {
   const journal = createLaneJournal({
@@ -161,6 +165,32 @@ test("rejects lane run state access through symlinked storage paths", async () =
     await rm(outsideRoot, { recursive: true, force: true });
   }
 });
+
+test(
+  "rejects non-regular lane run state files",
+  { skip: process.platform === "win32" ? "mkfifo is not available on Windows." : false },
+  async () => {
+    const stateRoot = await mkdtemp(path.join(os.tmpdir(), "ensen-loop-state-"));
+
+    try {
+      const state = createTestLaneRunState("fifo-run");
+      const statePath = resolveLaneRunStatePath(stateRoot, state.id);
+      await mkdir(path.dirname(statePath), { recursive: true });
+      await execFileAsync("mkfifo", [statePath]);
+
+      await assert.rejects(
+        () => readLaneRunState(stateRoot, state.id),
+        /regular file/,
+      );
+      await assert.rejects(
+        () => writeLaneRunState(stateRoot, state),
+        /regular file/,
+      );
+    } finally {
+      await rm(stateRoot, { recursive: true, force: true });
+    }
+  },
+);
 
 test("rejects durable lane run state that does not match the requested run", async () => {
   const stateRoot = await mkdtemp(path.join(os.tmpdir(), "ensen-loop-state-"));

--- a/test/lane-state.test.ts
+++ b/test/lane-state.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -96,6 +96,69 @@ test("persists lane run state below the configured state root", async () => {
     assert.deepEqual(await readLaneRunState(stateRoot, state.id), state);
   } finally {
     await rm(stateRoot, { recursive: true, force: true });
+  }
+});
+
+test("validates lane run state before persisting", async () => {
+  const stateRoot = await mkdtemp(path.join(os.tmpdir(), "ensen-loop-state-"));
+
+  try {
+    const invalidRevisionState = {
+      ...createTestLaneRunState("invalid-write-revision"),
+      revision: 0,
+    } as ReturnType<typeof createTestLaneRunState>;
+    const invalidRevisionPath = resolveLaneRunStatePath(stateRoot, invalidRevisionState.id);
+
+    await assert.rejects(
+      () => writeLaneRunState(stateRoot, invalidRevisionState),
+      /Lane run state is malformed/,
+    );
+    await assert.rejects(() => readFile(invalidRevisionPath, "utf8"), /ENOENT/);
+
+    const mismatchedJournalState = {
+      ...createTestLaneRunState("invalid-write-journal"),
+      journal: createLaneJournal({
+        id: "journal-invalid-write-journal",
+        laneRunId: "different-lane-run",
+        workItemId: "work-item-invalid-write-journal",
+        entries: [],
+      }),
+    } as ReturnType<typeof createTestLaneRunState>;
+    const mismatchedJournalPath = resolveLaneRunStatePath(stateRoot, mismatchedJournalState.id);
+
+    await assert.rejects(
+      () => writeLaneRunState(stateRoot, mismatchedJournalState),
+      /Lane run state identifiers do not match the lane run being persisted/,
+    );
+    await assert.rejects(() => readFile(mismatchedJournalPath, "utf8"), /ENOENT/);
+  } finally {
+    await rm(stateRoot, { recursive: true, force: true });
+  }
+});
+
+test("rejects lane run state access through symlinked storage paths", async () => {
+  const stateRoot = await mkdtemp(path.join(os.tmpdir(), "ensen-loop-state-"));
+  const outsideRoot = await mkdtemp(path.join(os.tmpdir(), "ensen-loop-outside-state-"));
+
+  try {
+    await symlink(outsideRoot, path.join(stateRoot, "lane-runs"), "dir");
+
+    const state = createTestLaneRunState("symlink-escape-run");
+    const outsideStatePath = path.join(outsideRoot, `${state.id}.json`);
+    await writeFile(outsideStatePath, `${serializeLaneRunState(state)}\n`, "utf8");
+
+    await assert.rejects(
+      () => writeLaneRunState(stateRoot, state),
+      /symbolic links/,
+    );
+    await assert.rejects(
+      () => readLaneRunState(stateRoot, state.id),
+      /symbolic links/,
+    );
+    assert.equal(await readFile(outsideStatePath, "utf8"), `${serializeLaneRunState(state)}\n`);
+  } finally {
+    await rm(stateRoot, { recursive: true, force: true });
+    await rm(outsideRoot, { recursive: true, force: true });
   }
 });
 

--- a/test/lane-state.test.ts
+++ b/test/lane-state.test.ts
@@ -1,0 +1,154 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import {
+  createLaneJournal,
+  createLaneRunState,
+  readLaneRunState,
+  resolveLaneRunStatePath,
+  serializeLaneRunState,
+  writeLaneRunState,
+} from "../src/lane/index.js";
+
+test("serializes lane journal and durable state without starting execution", () => {
+  const journal = createLaneJournal({
+    id: "journal-1",
+    laneRunId: "lane-run-1",
+    workItemId: "work-item-1",
+    entries: [
+      {
+        id: "entry-1",
+        recordedAt: "2026-04-29T09:00:00.000Z",
+        kind: "hypothesis",
+        message: "Add a durable state skeleton before agent execution exists.",
+      },
+    ],
+  });
+
+  const state = createLaneRunState({
+    id: "lane-run-1",
+    workItemId: "work-item-1",
+    status: "queued",
+    revision: 1,
+    createdAt: "2026-04-29T09:00:00.000Z",
+    updatedAt: "2026-04-29T09:00:00.000Z",
+    journal,
+    audit: {
+      eventRefs: [],
+    },
+    evidence: {
+      bundleRefs: [],
+    },
+  });
+
+  assert.equal(state.startsAgentExecution, false);
+  assert.deepEqual(JSON.parse(serializeLaneRunState(state)), {
+    id: "lane-run-1",
+    workItemId: "work-item-1",
+    status: "queued",
+    revision: 1,
+    createdAt: "2026-04-29T09:00:00.000Z",
+    updatedAt: "2026-04-29T09:00:00.000Z",
+    startsAgentExecution: false,
+    journal,
+    audit: {
+      eventRefs: [],
+    },
+    evidence: {
+      bundleRefs: [],
+    },
+  });
+});
+
+test("persists lane run state below the configured state root", async () => {
+  const stateRoot = await mkdtemp(path.join(os.tmpdir(), "ensen-loop-state-"));
+
+  try {
+    const state = createLaneRunState({
+      id: "lane-run-2",
+      workItemId: "work-item-2",
+      status: "running",
+      revision: 2,
+      createdAt: "2026-04-29T09:00:00.000Z",
+      updatedAt: "2026-04-29T09:05:00.000Z",
+      journal: createLaneJournal({
+        id: "journal-2",
+        laneRunId: "lane-run-2",
+        workItemId: "work-item-2",
+        entries: [],
+      }),
+      audit: {
+        eventRefs: ["audit-placeholder"],
+      },
+      evidence: {
+        bundleRefs: ["evidence-placeholder"],
+      },
+    });
+
+    const statePath = await writeLaneRunState(stateRoot, state);
+
+    assert.equal(statePath, resolveLaneRunStatePath(stateRoot, state.id));
+    assert.equal(path.dirname(statePath), path.join(path.resolve(stateRoot), "lane-runs"));
+    assert.equal(await readFile(statePath, "utf8"), `${serializeLaneRunState(state)}\n`);
+    assert.deepEqual(await readLaneRunState(stateRoot, state.id), state);
+  } finally {
+    await rm(stateRoot, { recursive: true, force: true });
+  }
+});
+
+test("rejects lane run state paths outside the configured state root", () => {
+  const stateRoot = path.join(os.tmpdir(), "ensen-loop-state-root");
+
+  assert.throws(
+    () => resolveLaneRunStatePath(stateRoot, "../outside"),
+    /Lane run identifiers may only contain/,
+  );
+  assert.throws(
+    () => resolveLaneRunStatePath(stateRoot, "nested/outside"),
+    /Lane run identifiers may only contain/,
+  );
+});
+
+test("rejects malformed durable lane run state on read", async () => {
+  const stateRoot = await mkdtemp(path.join(os.tmpdir(), "ensen-loop-state-"));
+
+  try {
+    const statePath = resolveLaneRunStatePath(stateRoot, "malformed-run");
+    await mkdir(path.dirname(statePath), { recursive: true });
+    await writeFile(
+      statePath,
+      JSON.stringify({
+        id: "malformed-run",
+        workItemId: "work-item-3",
+        status: "queued",
+        revision: 1,
+        createdAt: "2026-04-29T09:00:00.000Z",
+        updatedAt: "2026-04-29T09:00:00.000Z",
+        startsAgentExecution: true,
+        journal: {
+          id: "journal-3",
+          laneRunId: "malformed-run",
+          workItemId: "work-item-3",
+          entries: [],
+        },
+        audit: {
+          eventRefs: [],
+        },
+        evidence: {
+          bundleRefs: [],
+        },
+      }),
+      "utf8",
+    );
+
+    await assert.rejects(
+      () => readLaneRunState(stateRoot, "malformed-run"),
+      /Lane run state must not start agent execution/,
+    );
+  } finally {
+    await rm(stateRoot, { recursive: true, force: true });
+  }
+});

--- a/test/lane-state.test.ts
+++ b/test/lane-state.test.ts
@@ -99,6 +99,61 @@ test("persists lane run state below the configured state root", async () => {
   }
 });
 
+test("rejects durable lane run state that does not match the requested run", async () => {
+  const stateRoot = await mkdtemp(path.join(os.tmpdir(), "ensen-loop-state-"));
+
+  try {
+    const statePath = resolveLaneRunStatePath(stateRoot, "requested-run");
+    const copiedState = createLaneRunState({
+      id: "copied-run",
+      workItemId: "work-item-copied",
+      status: "queued",
+      revision: 1,
+      createdAt: "2026-04-29T09:00:00.000Z",
+      updatedAt: "2026-04-29T09:00:00.000Z",
+      journal: createLaneJournal({
+        id: "journal-copied",
+        laneRunId: "copied-run",
+        workItemId: "work-item-copied",
+        entries: [],
+      }),
+    });
+
+    await mkdir(path.dirname(statePath), { recursive: true });
+    await writeFile(statePath, serializeLaneRunState(copiedState), "utf8");
+
+    await assert.rejects(
+      () => readLaneRunState(stateRoot, "requested-run"),
+      /Lane run state identifiers do not match the requested lane run/,
+    );
+
+    const workItemMismatchPath = resolveLaneRunStatePath(stateRoot, "work-item-mismatch-run");
+    const workItemMismatchState = createLaneRunState({
+      id: "work-item-mismatch-run",
+      workItemId: "work-item-state",
+      status: "queued",
+      revision: 1,
+      createdAt: "2026-04-29T09:00:00.000Z",
+      updatedAt: "2026-04-29T09:00:00.000Z",
+      journal: createLaneJournal({
+        id: "journal-work-item-mismatch",
+        laneRunId: "work-item-mismatch-run",
+        workItemId: "work-item-journal",
+        entries: [],
+      }),
+    });
+
+    await writeFile(workItemMismatchPath, serializeLaneRunState(workItemMismatchState), "utf8");
+
+    await assert.rejects(
+      () => readLaneRunState(stateRoot, "work-item-mismatch-run"),
+      /Lane run state identifiers do not match the requested lane run/,
+    );
+  } finally {
+    await rm(stateRoot, { recursive: true, force: true });
+  }
+});
+
 test("rejects lane run state paths outside the configured state root", () => {
   const stateRoot = path.join(os.tmpdir(), "ensen-loop-state-root");
 
@@ -110,6 +165,62 @@ test("rejects lane run state paths outside the configured state root", () => {
     () => resolveLaneRunStatePath(stateRoot, "nested/outside"),
     /Lane run identifiers may only contain/,
   );
+});
+
+test("rejects lane run state payloads that violate the published schema shape", async () => {
+  const stateRoot = await mkdtemp(path.join(os.tmpdir(), "ensen-loop-state-"));
+
+  const cases: readonly [string, (state: Record<string, unknown>) => void][] = [
+    ["revision-zero", (state) => {
+      state.revision = 0;
+    }],
+    ["empty-work-item", (state) => {
+      state.workItemId = "";
+    }],
+    ["invalid-created-at", (state) => {
+      state.createdAt = "2026-04-29";
+    }],
+    ["impossible-recorded-at", (state) => {
+      const journal = state.journal as Record<string, unknown>;
+      const entries = journal.entries as Record<string, unknown>[];
+      entries[0].recordedAt = "2026-02-31T09:00:00.000Z";
+    }],
+    ["extra-top-level-property", (state) => {
+      state.extra = true;
+    }],
+    ["extra-journal-property", (state) => {
+      (state.journal as Record<string, unknown>).extra = true;
+    }],
+    ["extra-entry-property", (state) => {
+      const journal = state.journal as Record<string, unknown>;
+      const entries = journal.entries as Record<string, unknown>[];
+      entries[0].extra = true;
+    }],
+    ["extra-audit-property", (state) => {
+      (state.audit as Record<string, unknown>).extra = true;
+    }],
+    ["extra-evidence-property", (state) => {
+      (state.evidence as Record<string, unknown>).extra = true;
+    }],
+  ];
+
+  try {
+    for (const [laneRunId, mutate] of cases) {
+      const statePath = resolveLaneRunStatePath(stateRoot, laneRunId);
+      const state = JSON.parse(serializeLaneRunState(createTestLaneRunState(laneRunId))) as Record<string, unknown>;
+      mutate(state);
+
+      await mkdir(path.dirname(statePath), { recursive: true });
+      await writeFile(statePath, JSON.stringify(state), "utf8");
+
+      await assert.rejects(
+        () => readLaneRunState(stateRoot, laneRunId),
+        /Lane run state is malformed|Lane run state identifiers do not match/,
+      );
+    }
+  } finally {
+    await rm(stateRoot, { recursive: true, force: true });
+  }
 });
 
 test("rejects malformed durable lane run state on read", async () => {
@@ -152,3 +263,33 @@ test("rejects malformed durable lane run state on read", async () => {
     await rm(stateRoot, { recursive: true, force: true });
   }
 });
+
+function createTestLaneRunState(laneRunId: string) {
+  return createLaneRunState({
+    id: laneRunId,
+    workItemId: `work-item-${laneRunId}`,
+    status: "queued",
+    revision: 1,
+    createdAt: "2026-04-29T09:00:00.000Z",
+    updatedAt: "2026-04-29T09:00:00.000Z",
+    journal: createLaneJournal({
+      id: `journal-${laneRunId}`,
+      laneRunId,
+      workItemId: `work-item-${laneRunId}`,
+      entries: [
+        {
+          id: `entry-${laneRunId}`,
+          recordedAt: "2026-04-29T09:00:00.000Z",
+          kind: "hypothesis",
+          message: "",
+        },
+      ],
+    }),
+    audit: {
+      eventRefs: [""],
+    },
+    evidence: {
+      bundleRefs: [""],
+    },
+  });
+}

--- a/test/lane-state.test.ts
+++ b/test/lane-state.test.ts
@@ -185,6 +185,21 @@ test("rejects lane run state payloads that violate the published schema shape", 
       const entries = journal.entries as Record<string, unknown>[];
       entries[0].recordedAt = "2026-02-31T09:00:00.000Z";
     }],
+    ["empty-journal-message", (state) => {
+      const journal = state.journal as Record<string, unknown>;
+      const entries = journal.entries as Record<string, unknown>[];
+      entries[0].message = "";
+    }],
+    ["empty-audit-ref", (state) => {
+      state.audit = {
+        eventRefs: [""],
+      };
+    }],
+    ["empty-evidence-ref", (state) => {
+      state.evidence = {
+        bundleRefs: [""],
+      };
+    }],
     ["extra-top-level-property", (state) => {
       state.extra = true;
     }],
@@ -281,15 +296,15 @@ function createTestLaneRunState(laneRunId: string) {
           id: `entry-${laneRunId}`,
           recordedAt: "2026-04-29T09:00:00.000Z",
           kind: "hypothesis",
-          message: "",
+          message: "Schema validation fixture.",
         },
       ],
     }),
     audit: {
-      eventRefs: [""],
+      eventRefs: ["audit-fixture"],
     },
     evidence: {
-      bundleRefs: [""],
+      bundleRefs: ["evidence-fixture"],
     },
   });
 }


### PR DESCRIPTION
## Summary
- Add Phase 1 LaneJournal and LaneRunState TypeScript contracts with local JSON serialization helpers.
- Add safe state-root path resolution plus read-side malformed-state rejection.
- Document the lane journal, durable state, audit refs, and evidence refs relationship and add a lane-run JSON schema.

## Verification
- npm run build
- npm test

Closes #6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Phase 1 lane run resumability via durable local JSON state with deterministic serialization and safe path resolution
  * Structured lane journal entries plus explicit audit/evidence reference lists for resumability and traceability

* **Bug Fixes / Validation**
  * Strict runtime and schema validation rejecting malformed or unsafe state, including disallowed execution flag

* **Documentation**
  * Architecture doc describing durable lane run state model and storage rules

* **Tests**
  * Comprehensive tests for persistence, validation, path safety, and serialization consistency
<!-- end of auto-generated comment: release notes by coderabbit.ai -->