### PR TITLE
LOOP-005: Add work item contract validation skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ This repository starts as a minimal TypeScript/Node project with a build, smoke 
 
 The Phase 1 module boundaries and vocabulary are defined in [docs/architecture/core-model.md](docs/architecture/core-model.md).
 
+The Phase 1 local Work Item validation skeleton is documented in [docs/reference/work-item-contract.md](docs/reference/work-item-contract.md).
+
 ## Commands
 
 ```sh

--- a/docs/reference/work-item-contract.md
+++ b/docs/reference/work-item-contract.md
@@ -1,0 +1,20 @@
+# Local Work Item Contract
+
+Phase 1 accepts local Work Item JSON as the input shape for dry-run planning. The contract is intentionally small and does not start lane execution, invoke providers, or require a protocol runtime.
+
+The schema is tracked in `schemas/local-work-item.schema.json`.
+
+## Required Fields
+
+| Field | Type | Rule |
+| --- | --- | --- |
+| `id` | string | Stable identifier matching letters, numbers, dots, underscores, or hyphens. |
+| `title` | string | Non-empty operator-facing title. |
+| `source` | string | Non-empty local source label. |
+| `status` | string | One of `ready`, `blocked`, `running`, `completed`, or `failed`. |
+
+Malformed inputs fail closed through `validateLocalWorkItem` or `parseLocalWorkItem` with field-specific issues. Unknown fields are rejected until a later contract version explicitly owns them.
+
+## Deferred Protocol Boundary
+
+This local contract is not an EIP RunRequest. EIP request and result support remains deferred to Phase 2, where the protocol schema, authorization boundary, provenance checks, and adapter mapping rules can be defined explicitly.

--- a/schemas/local-work-item.schema.json
+++ b/schemas/local-work-item.schema.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ensen-loop.local/schemas/local-work-item.schema.json",
+  "title": "Ensen-loop Phase 1 Local Work Item",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["id", "title", "source", "status"],
+  "properties": {
+    "id": {
+      "type": "string",
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]*$",
+      "description": "Stable local work item identifier."
+    },
+    "title": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Human-readable work item title."
+    },
+    "source": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Local source label for the work item."
+    },
+    "status": {
+      "type": "string",
+      "enum": ["ready", "blocked", "running", "completed", "failed"],
+      "description": "Local lifecycle status understood by Phase 1 dry-run planning."
+    }
+  }
+}

--- a/src/work-item/index.ts
+++ b/src/work-item/index.ts
@@ -2,9 +2,141 @@ import type { WorkItem } from "../core/index.js";
 
 export type { ChangeRequest, WorkItem } from "../core/index.js";
 
+export interface WorkItemValidationIssue {
+  readonly path: string;
+  readonly message: string;
+}
+
+export interface WorkItemValidationSuccess {
+  readonly ok: true;
+  readonly workItem: WorkItem;
+}
+
+export interface WorkItemValidationFailure {
+  readonly ok: false;
+  readonly issues: readonly WorkItemValidationIssue[];
+}
+
+export type WorkItemValidationResult = WorkItemValidationSuccess | WorkItemValidationFailure;
+
+const localWorkItemIdPattern = /^[A-Za-z0-9][A-Za-z0-9._-]*$/;
+const localWorkItemStatuses = new Set<unknown>([
+  "ready",
+  "blocked",
+  "running",
+  "completed",
+  "failed",
+]);
+
+export class WorkItemValidationError extends Error {
+  readonly issues: readonly WorkItemValidationIssue[];
+
+  constructor(issues: readonly WorkItemValidationIssue[]) {
+    super(
+      `Local work item is malformed: ${issues
+        .map((issue) => `${issue.path}: ${issue.message}`)
+        .join("; ")}`,
+    );
+    this.name = "WorkItemValidationError";
+    this.issues = issues;
+  }
+}
+
 export const sampleLocalWorkItem: WorkItem = {
   id: "sample-local-work-item",
   title: "Sample local work item",
   source: "local-sample",
   status: "ready",
 };
+
+export function validateLocalWorkItem(value: unknown): WorkItemValidationResult {
+  const issues = collectLocalWorkItemIssues(value);
+
+  if (issues.length > 0) {
+    return {
+      ok: false,
+      issues,
+    };
+  }
+
+  return {
+    ok: true,
+    workItem: value as WorkItem,
+  };
+}
+
+export function parseLocalWorkItem(value: unknown): WorkItem {
+  const result = validateLocalWorkItem(value);
+
+  if (!result.ok) {
+    throw new WorkItemValidationError(result.issues);
+  }
+
+  return result.workItem;
+}
+
+function collectLocalWorkItemIssues(value: unknown): readonly WorkItemValidationIssue[] {
+  if (!isRecord(value)) {
+    return [
+      {
+        path: "$",
+        message: "Local work item input must be a JSON object.",
+      },
+    ];
+  }
+
+  const issues: WorkItemValidationIssue[] = [];
+  const allowedKeys = new Set(["id", "title", "source", "status"]);
+
+  for (const key of Object.keys(value)) {
+    if (!allowedKeys.has(key)) {
+      issues.push({
+        path: key,
+        message: "field is not part of the Phase 1 local work item contract.",
+      });
+    }
+  }
+
+  if (!isLocalWorkItemId(value.id)) {
+    issues.push({
+      path: "id",
+      message:
+        "id is required and must be a non-empty string matching letters, numbers, dots, underscores, or hyphens.",
+    });
+  }
+
+  if (!isNonEmptyString(value.title)) {
+    issues.push({
+      path: "title",
+      message: "title is required and must be a non-empty string.",
+    });
+  }
+
+  if (!isNonEmptyString(value.source)) {
+    issues.push({
+      path: "source",
+      message: "source is required and must be a non-empty string.",
+    });
+  }
+
+  if (!localWorkItemStatuses.has(value.status)) {
+    issues.push({
+      path: "status",
+      message: "status must be one of: ready, blocked, running, completed, failed.",
+    });
+  }
+
+  return issues;
+}
+
+function isLocalWorkItemId(value: unknown): value is string {
+  return typeof value === "string" && localWorkItemIdPattern.test(value);
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.length > 0;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/src/work-item/index.ts
+++ b/src/work-item/index.ts
@@ -138,5 +138,10 @@ function isNonEmptyString(value: unknown): value is string {
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return false;
+  }
+
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
 }

--- a/test/fixtures/work-items/malformed-status.json
+++ b/test/fixtures/work-items/malformed-status.json
@@ -1,0 +1,6 @@
+{
+  "id": "malformed-status",
+  "title": "Malformed status",
+  "source": "local-fixture",
+  "status": "done"
+}

--- a/test/fixtures/work-items/missing-title.json
+++ b/test/fixtures/work-items/missing-title.json
@@ -1,0 +1,5 @@
+{
+  "id": "missing-title",
+  "source": "local-fixture",
+  "status": "ready"
+}

--- a/test/fixtures/work-items/non-object.json
+++ b/test/fixtures/work-items/non-object.json
@@ -1,0 +1,5 @@
+[
+  {
+    "id": "not-an-object"
+  }
+]

--- a/test/fixtures/work-items/valid-local-work-item.json
+++ b/test/fixtures/work-items/valid-local-work-item.json
@@ -1,0 +1,6 @@
+{
+  "id": "local-work-item-1",
+  "title": "Validate local work item contracts",
+  "source": "local-fixture",
+  "status": "ready"
+}

--- a/test/work-item-validation.test.ts
+++ b/test/work-item-validation.test.ts
@@ -57,6 +57,41 @@ test("returns actionable validation issues for malformed local work items", asyn
   ]);
 });
 
+test("rejects non-plain objects at the local work item boundary", () => {
+  class PrototypeBackedWorkItem {
+    readonly id = "local-work-item-1";
+    readonly title = "Prototype-backed work item";
+    readonly source = "local-fixture";
+    readonly status = "ready";
+  }
+
+  const classInstance = validateLocalWorkItem(new PrototypeBackedWorkItem());
+  const inheritedFields = validateLocalWorkItem(
+    Object.create({
+      id: "local-work-item-1",
+      title: "Inherited fields work item",
+      source: "local-fixture",
+      status: "ready",
+    }) as unknown,
+  );
+
+  assert.equal(classInstance.ok, false);
+  assert.deepEqual(classInstance.issues, [
+    {
+      path: "$",
+      message: "Local work item input must be a JSON object.",
+    },
+  ]);
+
+  assert.equal(inheritedFields.ok, false);
+  assert.deepEqual(inheritedFields.issues, [
+    {
+      path: "$",
+      message: "Local work item input must be a JSON object.",
+    },
+  ]);
+});
+
 test("throws a validation error that preserves individual local work item issues", async () => {
   assert.throws(
     () => parseLocalWorkItem({
@@ -83,4 +118,3 @@ test("throws a validation error that preserves individual local work item issues
     },
   );
 });
-

--- a/test/work-item-validation.test.ts
+++ b/test/work-item-validation.test.ts
@@ -1,0 +1,86 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import test from "node:test";
+
+import {
+  WorkItemValidationError,
+  parseLocalWorkItem,
+  validateLocalWorkItem,
+} from "../src/work-item/index.js";
+
+async function readFixture(name: string): Promise<unknown> {
+  return JSON.parse(
+    await readFile(path.join("test", "fixtures", "work-items", name), "utf8"),
+  ) as unknown;
+}
+
+test("accepts a valid local work item fixture", async () => {
+  const parsed = parseLocalWorkItem(await readFixture("valid-local-work-item.json"));
+
+  assert.deepEqual(parsed, {
+    id: "local-work-item-1",
+    title: "Validate local work item contracts",
+    source: "local-fixture",
+    status: "ready",
+  });
+});
+
+test("returns actionable validation issues for malformed local work items", async () => {
+  const missingTitle = validateLocalWorkItem(await readFixture("missing-title.json"));
+  const malformedStatus = validateLocalWorkItem(await readFixture("malformed-status.json"));
+  const nonObject = validateLocalWorkItem(await readFixture("non-object.json"));
+
+  assert.equal(missingTitle.ok, false);
+  assert.deepEqual(missingTitle.issues, [
+    {
+      path: "title",
+      message: "title is required and must be a non-empty string.",
+    },
+  ]);
+
+  assert.equal(malformedStatus.ok, false);
+  assert.deepEqual(malformedStatus.issues, [
+    {
+      path: "status",
+      message:
+        "status must be one of: ready, blocked, running, completed, failed.",
+    },
+  ]);
+
+  assert.equal(nonObject.ok, false);
+  assert.deepEqual(nonObject.issues, [
+    {
+      path: "$",
+      message: "Local work item input must be a JSON object.",
+    },
+  ]);
+});
+
+test("throws a validation error that preserves individual local work item issues", async () => {
+  assert.throws(
+    () => parseLocalWorkItem({
+      id: "",
+      title: "Missing source and invalid id",
+      status: "ready",
+    }),
+    (error: unknown) => {
+      assert.ok(error instanceof WorkItemValidationError);
+      assert.match(error.message, /Local work item is malformed/);
+      assert.deepEqual(error.issues, [
+        {
+          path: "id",
+          message:
+            "id is required and must be a non-empty string matching letters, numbers, dots, underscores, or hyphens.",
+        },
+        {
+          path: "source",
+          message: "source is required and must be a non-empty string.",
+        },
+      ]);
+
+      return true;
+    },
+  );
+});
+


### PR DESCRIPTION
## Summary
- add Phase 1 local Work Item runtime validation helpers and typed validation errors
- add valid and invalid local Work Item fixtures with focused tests
- document the local Work Item contract and keep EIP request/result support deferred to Phase 2

## Verification
- npm run build
- npm test

Part of #2
Closes #7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added local work item validation that validates required fields (`id`, `title`, `source`, `status`), enforces proper field types, and restricts status to allowed values, with detailed field-level error reporting for invalid inputs.

* **Documentation**
  * Added Phase 1 work item contract specification and JSON validation schema reference for local work item validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->