### PR TITLE
Clarify Phase 1 typecheck quality gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Typecheck
+        run: npm run typecheck
+
       - name: Build
         run: npm run build
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,7 @@ Use the repo-owned commands:
 
 ```sh
 npm ci
+npm run typecheck
 npm run build
 npm test
 ```

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ The Phase 1 local Work Item validation skeleton is documented in [docs/reference
 
 ```sh
 npm ci
+npm run typecheck
 npm run build
 npm test
 node dist/src/cli/index.js dry-run --sample

--- a/docs/architecture/core-model.md
+++ b/docs/architecture/core-model.md
@@ -54,7 +54,7 @@ GitHub and Codex are future adapter examples, not core model requirements. A fut
 
 ## Independence Rules
 
-- Ensen-loop must remain independently installable, buildable, and testable with `npm ci`, `npm run build`, and `npm test`.
+- Ensen-loop must remain independently installable, typecheckable, buildable, and testable with `npm ci`, `npm run typecheck`, `npm run build`, and `npm test`.
 - Ensen-loop must not import implementation code from another Ensen product.
 - Integration with external products, services, or local checkouts must be optional and documented at an explicit adapter boundary.
 - Missing or malformed provenance, scope, auth context, verification, review, or durable state signals must fail closed in the module that owns the boundary.

--- a/docs/reference/quality-kit.md
+++ b/docs/reference/quality-kit.md
@@ -17,7 +17,7 @@ The Ensen-loop quality kit is the repo-owned vocabulary for keeping AI-assisted 
 | Issue readiness | The issue is specific enough to execute without inferring hidden scope. | Scope, acceptance criteria, verification, dependency posture, and execution order are explicit. |
 | Lane workspace | The isolated filesystem context for one unit of lane work. | The workspace maps to one issue or lane and excludes unrelated local changes from the evidence story. |
 | Lane journal | The short-horizon handoff record for active work. | Current hypothesis, changed files, focused commands, failures, rollback concerns, and next action are recorded. |
-| Verification gate | The repo-owned commands that prove the work locally. | For this baseline, `npm run build` and `npm test` are the required checks after `npm ci` has installed dependencies. |
+| Verification gate | The repo-owned commands that prove the work locally. | For this baseline, `npm run typecheck`, `npm run build`, and `npm test` are the required checks after `npm ci` has installed dependencies. |
 | Evidence bundle | The collected facts that justify publication or repair. | Issue scope, branch/head state, changed files, test output, review facts, and PR state are linked without relying on chat memory. |
 | Reviewability | The ability for humans and tools to inspect the change safely. | The PR or handoff names the behavior delta, verification performed, unresolved risks, and review signal state. |
 | Lane introspection | Operator-facing status and explanation surfaces. | Summaries must be derived from authoritative lane state rather than stale display text. |
@@ -43,6 +43,7 @@ The repo-owned verification sequence is:
 
 ```sh
 npm ci
+npm run typecheck
 npm run build
 npm test
 ```

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "ensen-loop": "./dist/src/cli/index.js"
   },
   "scripts": {
+    "typecheck": "tsc -p tsconfig.json --noEmit",
     "build": "tsc -p tsconfig.json",
     "test": "npm run build && node scripts/run-tests.mjs"
   },

--- a/test/quality-kit-docs.test.ts
+++ b/test/quality-kit-docs.test.ts
@@ -54,7 +54,16 @@ test("wires the Phase 1 typecheck quality gate through package, CI, and docs", a
   const agents = await readMarkdown("AGENTS.md");
 
   assert.equal(packageJson.scripts?.typecheck, "tsc -p tsconfig.json --noEmit");
-  assert.match(ciWorkflow, /run:\s*npm run typecheck\b/);
+
+  const typecheckRun = ciWorkflow.search(/run:\s*npm run typecheck\b/);
+  const buildRun = ciWorkflow.search(/run:\s*npm run build\b/);
+  const testRun = ciWorkflow.search(/run:\s*npm (?:run test|test)\b/);
+
+  assert.notEqual(typecheckRun, -1, "CI workflow must run npm run typecheck");
+  assert.notEqual(buildRun, -1, "CI workflow must run npm run build");
+  assert.notEqual(testRun, -1, "CI workflow must run npm test or npm run test");
+  assert.ok(typecheckRun < buildRun, "CI workflow must typecheck before build");
+  assert.ok(typecheckRun < testRun, "CI workflow must typecheck before test");
 
   for (const document of [qualityKit, readme, agents]) {
     assert.match(document, /\bnpm run typecheck\b/);

--- a/test/quality-kit-docs.test.ts
+++ b/test/quality-kit-docs.test.ts
@@ -7,6 +7,10 @@ async function readMarkdown(relativePath: string): Promise<string> {
   return readFile(path.resolve(relativePath), "utf8");
 }
 
+async function readText(relativePath: string): Promise<string> {
+  return readFile(path.resolve(relativePath), "utf8");
+}
+
 test("documents the codex-supervisor handoff boundary", async () => {
   const handoff = await readMarkdown("docs/migration/codex-supervisor-handoff.md");
 
@@ -37,6 +41,23 @@ test("documents the quality kit verification and evidence vocabulary", async () 
 
   for (const term of ["verification", "evidence", "reviewability"]) {
     assert.match(qualityKit, new RegExp(term, "i"));
+  }
+});
+
+test("wires the Phase 1 typecheck quality gate through package, CI, and docs", async () => {
+  const packageJson = JSON.parse(await readText("package.json")) as {
+    scripts?: Record<string, string>;
+  };
+  const ciWorkflow = await readText(".github/workflows/ci.yml");
+  const qualityKit = await readMarkdown("docs/reference/quality-kit.md");
+  const readme = await readMarkdown("README.md");
+  const agents = await readMarkdown("AGENTS.md");
+
+  assert.equal(packageJson.scripts?.typecheck, "tsc -p tsconfig.json --noEmit");
+  assert.match(ciWorkflow, /run:\s*npm run typecheck\b/);
+
+  for (const document of [qualityKit, readme, agents]) {
+    assert.match(document, /\bnpm run typecheck\b/);
   }
 });
 


### PR DESCRIPTION
## Summary
- add `npm run typecheck` as the lightweight Phase 1 quality gate
- run the gate in CI before build/test
- document the gate in README, AGENTS, and quality/core docs
- add a regression test that checks package, CI, and docs stay aligned

## Verification
- `npm ci`
- `npm run typecheck`
- `npm test`
- `npm run build`

Closes #14

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `npm run typecheck` command for explicit TypeScript type validation.

* **Documentation**
  * Updated setup and verification instructions to include the type-check step.

* **Chores**
  * Integrated type-checking into the CI pipeline.
  * Added automated verification tests for configuration consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->