### PR TITLE
Canonicalize LaneRunState serialization

### DIFF
--- a/src/lane/index.ts
+++ b/src/lane/index.ts
@@ -102,7 +102,7 @@ export function createLaneRunState(input: CreateLaneRunStateInput): LaneRunState
 }
 
 export function serializeLaneRunState(state: LaneRunState): string {
-  return JSON.stringify(state, null, 2);
+  return JSON.stringify(toSerializableLaneRunState(state), null, 2);
 }
 
 export function resolveLaneRunStatePath(stateRoot: string, laneRunId: string): string {
@@ -299,6 +299,35 @@ function sameFileStats(left: Stats, right: Stats): boolean {
 
 function isNodeError(error: unknown): error is NodeJS.ErrnoException {
   return error instanceof Error && "code" in error;
+}
+
+function toSerializableLaneRunState(state: LaneRunState): LaneRunState {
+  return {
+    id: state.id,
+    workItemId: state.workItemId,
+    status: state.status,
+    revision: state.revision,
+    createdAt: state.createdAt,
+    updatedAt: state.updatedAt,
+    startsAgentExecution: state.startsAgentExecution,
+    journal: {
+      id: state.journal.id,
+      laneRunId: state.journal.laneRunId,
+      workItemId: state.journal.workItemId,
+      entries: state.journal.entries.map((entry) => ({
+        id: entry.id,
+        recordedAt: entry.recordedAt,
+        kind: entry.kind,
+        message: entry.message,
+      })),
+    },
+    audit: {
+      eventRefs: [...state.audit.eventRefs],
+    },
+    evidence: {
+      bundleRefs: [...state.evidence.bundleRefs],
+    },
+  };
 }
 
 function parseLaneRunState(value: unknown): LaneRunState {

--- a/test/lane-state.test.ts
+++ b/test/lane-state.test.ts
@@ -67,6 +67,45 @@ test("serializes lane journal and durable state without starting execution", () 
   });
 });
 
+test("serializes equivalent lane run states canonically", () => {
+  const canonicalState = createTestLaneRunState("canonical-run");
+  const canonicalEntry = canonicalState.journal.entries[0];
+
+  assert.ok(canonicalEntry);
+
+  const reorderedState = {
+    evidence: {
+      bundleRefs: canonicalState.evidence.bundleRefs,
+    },
+    audit: {
+      eventRefs: canonicalState.audit.eventRefs,
+    },
+    journal: {
+      entries: [
+        {
+          message: canonicalEntry.message,
+          kind: canonicalEntry.kind,
+          recordedAt: canonicalEntry.recordedAt,
+          id: canonicalEntry.id,
+        },
+      ],
+      workItemId: canonicalState.journal.workItemId,
+      laneRunId: canonicalState.journal.laneRunId,
+      id: canonicalState.journal.id,
+    },
+    startsAgentExecution: canonicalState.startsAgentExecution,
+    updatedAt: canonicalState.updatedAt,
+    createdAt: canonicalState.createdAt,
+    revision: canonicalState.revision,
+    status: canonicalState.status,
+    workItemId: canonicalState.workItemId,
+    id: canonicalState.id,
+  } as ReturnType<typeof createTestLaneRunState>;
+
+  assert.deepEqual(reorderedState, canonicalState);
+  assert.equal(serializeLaneRunState(reorderedState), serializeLaneRunState(canonicalState));
+});
+
 test("persists lane run state below the configured state root", async () => {
   const stateRoot = await mkdtemp(path.join(os.tmpdir(), "ensen-loop-state-"));
 


### PR DESCRIPTION
## Summary
- canonicalize LaneRunState JSON output through an explicit schema-ordered DTO
- preserve journal entry array order while normalizing object key order
- add a regression test for equivalent state objects built with different insertion order

## Verification
- npm ci
- npm test -- --test-name-pattern "serializes equivalent" (reproduced failure before fix, passes after fix)
- npm run typecheck
- npm run build
- npm test

Closes #15

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced state serialization to improve the consistency and reliability of how application state is stored, transformed, and processed during operations.

* **Tests**
  * Added test coverage to verify that state serialization produces deterministic, consistent results regardless of how state properties are internally arranged or ordered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->