### PR TITLE
[codex] Reject blank local work item text

### DIFF
--- a/docs/reference/work-item-contract.md
+++ b/docs/reference/work-item-contract.md
@@ -9,11 +9,11 @@ The schema is tracked in `schemas/local-work-item.schema.json`.
 | Field | Type | Rule |
 | --- | --- | --- |
 | `id` | string | Stable identifier matching letters, numbers, dots, underscores, or hyphens. |
-| `title` | string | Non-empty operator-facing title. |
-| `source` | string | Non-empty local source label. |
+| `title` | string | Non-empty operator-facing title containing at least one non-whitespace character. |
+| `source` | string | Non-empty local source label containing at least one non-whitespace character. |
 | `status` | string | One of `ready`, `blocked`, `running`, `completed`, or `failed`. |
 
-Malformed inputs fail closed through `validateLocalWorkItem` or `parseLocalWorkItem` with field-specific issues. Unknown fields are rejected until a later contract version explicitly owns them.
+Malformed inputs fail closed through `validateLocalWorkItem` or `parseLocalWorkItem` with field-specific issues. Whitespace-only `title` and `source` values are rejected as blank operator-facing text. Unknown fields are rejected until a later contract version explicitly owns them.
 
 ## Deferred Protocol Boundary
 

--- a/schemas/local-work-item.schema.json
+++ b/schemas/local-work-item.schema.json
@@ -14,12 +14,14 @@
     "title": {
       "type": "string",
       "minLength": 1,
-      "description": "Human-readable work item title."
+      "pattern": "\\S",
+      "description": "Human-readable work item title containing at least one non-whitespace character."
     },
     "source": {
       "type": "string",
       "minLength": 1,
-      "description": "Local source label for the work item."
+      "pattern": "\\S",
+      "description": "Local source label containing at least one non-whitespace character."
     },
     "status": {
       "type": "string",

--- a/src/work-item/index.ts
+++ b/src/work-item/index.ts
@@ -105,18 +105,14 @@ function collectLocalWorkItemIssues(value: unknown): readonly WorkItemValidation
     });
   }
 
-  if (!isNonEmptyString(value.title)) {
-    issues.push({
-      path: "title",
-      message: "title is required and must be a non-empty string.",
-    });
+  const titleTextIssue = validateLocalWorkItemTextField("title", value.title);
+  if (titleTextIssue !== undefined) {
+    issues.push(titleTextIssue);
   }
 
-  if (!isNonEmptyString(value.source)) {
-    issues.push({
-      path: "source",
-      message: "source is required and must be a non-empty string.",
-    });
+  const sourceTextIssue = validateLocalWorkItemTextField("source", value.source);
+  if (sourceTextIssue !== undefined) {
+    issues.push(sourceTextIssue);
   }
 
   if (!localWorkItemStatuses.has(value.status)) {
@@ -129,12 +125,29 @@ function collectLocalWorkItemIssues(value: unknown): readonly WorkItemValidation
   return issues;
 }
 
-function isLocalWorkItemId(value: unknown): value is string {
-  return typeof value === "string" && localWorkItemIdPattern.test(value);
+function validateLocalWorkItemTextField(
+  path: "title" | "source",
+  value: unknown,
+): WorkItemValidationIssue | undefined {
+  if (typeof value !== "string" || value.length === 0) {
+    return {
+      path,
+      message: `${path} is required and must be a non-empty string.`,
+    };
+  }
+
+  if (value.trim().length === 0) {
+    return {
+      path,
+      message: `${path} is required and must contain non-whitespace text.`,
+    };
+  }
+
+  return undefined;
 }
 
-function isNonEmptyString(value: unknown): value is string {
-  return typeof value === "string" && value.length > 0;
+function isLocalWorkItemId(value: unknown): value is string {
+  return typeof value === "string" && localWorkItemIdPattern.test(value);
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/test/work-item-validation.test.ts
+++ b/test/work-item-validation.test.ts
@@ -57,6 +57,37 @@ test("returns actionable validation issues for malformed local work items", asyn
   ]);
 });
 
+test("rejects whitespace-only local work item text fields", () => {
+  const whitespaceTitle = validateLocalWorkItem({
+    id: "valid-id",
+    title: "   ",
+    source: "local",
+    status: "ready",
+  });
+  const whitespaceSource = validateLocalWorkItem({
+    id: "valid-id",
+    title: "Title",
+    source: "\t",
+    status: "ready",
+  });
+
+  assert.equal(whitespaceTitle.ok, false);
+  assert.deepEqual(whitespaceTitle.issues, [
+    {
+      path: "title",
+      message: "title is required and must contain non-whitespace text.",
+    },
+  ]);
+
+  assert.equal(whitespaceSource.ok, false);
+  assert.deepEqual(whitespaceSource.issues, [
+    {
+      path: "source",
+      message: "source is required and must contain non-whitespace text.",
+    },
+  ]);
+});
+
 test("rejects non-plain objects at the local work item boundary", () => {
   class PrototypeBackedWorkItem {
     readonly id = "local-work-item-1";


### PR DESCRIPTION
## Summary

- Reject whitespace-only Phase 1 local work item `title` and `source` values at runtime.
- Add regression coverage for blank-after-trim `title` and `source` inputs.
- Align the published local work item JSON schema and contract docs with the non-whitespace text rule.

## Root Cause

`validateLocalWorkItem` only required `title` and `source` to be strings with `length > 0`, so operator-facing text made entirely of whitespace passed validation.

## Validation

- `npm ci`
- `npm test` first reproduced the focused failure in `rejects whitespace-only local work item text fields` with `true !== false`
- `npm run typecheck`
- `npm run build`
- `npm test`
