### PR TITLE
LOOP-010: Vendor protocol v0.1.0 fixture snapshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ The Ensen-loop mission and development charter alignment are summarized in [docs
 
 The Phase 1 local Work Item validation skeleton is documented in [docs/reference/work-item-contract.md](docs/reference/work-item-contract.md).
 
+The copied Ensen-protocol v0.1.0 schema and conformance fixture snapshot is documented in [protocol-snapshots/ensen-protocol/v0.1.0/README.md](protocol-snapshots/ensen-protocol/v0.1.0/README.md). It is repo-owned fixture data, not a mutable shared runtime dependency.
+
 ## Commands
 
 ```sh

--- a/protocol-snapshots/ensen-protocol/v0.1.0/README.md
+++ b/protocol-snapshots/ensen-protocol/v0.1.0/README.md
@@ -1,6 +1,6 @@
 # Ensen-protocol v0.1.0 Snapshot
 
-This directory is a copied snapshot of the public Ensen Interop Protocol artifacts from `TommyKammy/Ensen-protocol` release tag `v0.1.0`, protocol version `0.1.0`.
+This directory is a copied snapshot of the public Ensen Interop Protocol artifacts from `TommyKammy/Ensen-protocol` release tag `v0.1.0`, protocol version `0.1.0`, with the local corrections listed in `manifest.json`.
 
 It is intentionally repo-owned by Ensen-loop. Ensen-loop must not require an Ensen-protocol checkout, package, service, fixture path, or runtime dependency to build, test, or operate.
 
@@ -18,3 +18,5 @@ It is intentionally repo-owned by Ensen-loop. Ensen-loop must not require an Ens
 Treat this directory as read-only protocol fixture data. Runtime code should access it only through explicit test or protocol helper boundaries.
 
 To update the snapshot, replace this versioned directory from a tagged Ensen-protocol release and update `manifest.json` in the same change. Do not point tests or runtime code at a sibling checkout as a mutable shared dependency.
+
+If the next tagged Ensen-protocol release already includes the local corrections recorded in `manifest.json`, remove those correction entries during the replacement.

--- a/protocol-snapshots/ensen-protocol/v0.1.0/README.md
+++ b/protocol-snapshots/ensen-protocol/v0.1.0/README.md
@@ -1,0 +1,20 @@
+# Ensen-protocol v0.1.0 Snapshot
+
+This directory is a copied snapshot of the public Ensen Interop Protocol artifacts from `TommyKammy/Ensen-protocol` release tag `v0.1.0`, protocol version `0.1.0`.
+
+It is intentionally repo-owned by Ensen-loop. Ensen-loop must not require an Ensen-protocol checkout, package, service, fixture path, or runtime dependency to build, test, or operate.
+
+## Contents
+
+- `schemas/eip.run-request.v1.schema.json`
+- `schemas/eip.run-status.v1.schema.json`
+- `schemas/eip.run-result.v1.schema.json`
+- `schemas/eip.evidence-bundle-ref.v1.schema.json`
+- `schemas/eip.common.v1.schema.json`, copied as schema support for `$ref` resolution
+- valid and invalid public conformance fixtures for RunRequest, RunStatusSnapshot, RunResult, and EvidenceBundleRef
+
+## Update Policy
+
+Treat this directory as read-only protocol fixture data. Runtime code should access it only through explicit test or protocol helper boundaries.
+
+To update the snapshot, replace this versioned directory from a tagged Ensen-protocol release and update `manifest.json` in the same change. Do not point tests or runtime code at a sibling checkout as a mutable shared dependency.

--- a/protocol-snapshots/ensen-protocol/v0.1.0/fixtures/evidence-bundle-ref/v1/invalid/bad-checksum.json
+++ b/protocol-snapshots/ensen-protocol/v0.1.0/fixtures/evidence-bundle-ref/v1/invalid/bad-checksum.json
@@ -1,0 +1,12 @@
+{
+  "schemaVersion": "eip.evidence-bundle-ref.v1",
+  "id": "evb_01HV9ZX8J2K6T3QW4R5Y7M8N9V",
+  "correlationId": "corr_01HV9ZX8J2K6T3QW4R5Y7M8N9R",
+  "type": "local_path",
+  "uri": "artifacts/evidence/run-01HV9ZX8J2K6T3QW4R5Y7M8N9Q/bundle.json",
+  "createdAt": "2026-04-29T00:15:00Z",
+  "checksum": {
+    "algorithm": "md5",
+    "value": "not-a-sha256-digest"
+  }
+}

--- a/protocol-snapshots/ensen-protocol/v0.1.0/fixtures/evidence-bundle-ref/v1/invalid/raw-secret-uri.json
+++ b/protocol-snapshots/ensen-protocol/v0.1.0/fixtures/evidence-bundle-ref/v1/invalid/raw-secret-uri.json
@@ -1,0 +1,8 @@
+{
+  "schemaVersion": "eip.evidence-bundle-ref.v1",
+  "id": "evb_01HV9ZX8J2K6T3QW4R5Y7M8N9U",
+  "correlationId": "corr_01HV9ZX8J2K6T3QW4R5Y7M8N9R",
+  "type": "file_uri",
+  "uri": "file://user:REDACTED_FIXTURE_SECRET_PLACEHOLDER@evidence.example.test/bundle.json",
+  "createdAt": "2026-04-29T00:10:00Z"
+}

--- a/protocol-snapshots/ensen-protocol/v0.1.0/fixtures/evidence-bundle-ref/v1/invalid/raw-secret-uri.json
+++ b/protocol-snapshots/ensen-protocol/v0.1.0/fixtures/evidence-bundle-ref/v1/invalid/raw-secret-uri.json
@@ -3,6 +3,6 @@
   "id": "evb_01HV9ZX8J2K6T3QW4R5Y7M8N9U",
   "correlationId": "corr_01HV9ZX8J2K6T3QW4R5Y7M8N9R",
   "type": "file_uri",
-  "uri": "file://user:REDACTED_FIXTURE_SECRET_PLACEHOLDER@evidence.example.test/bundle.json",
+  "uri": "file://evidence.example.test/bundle.json?placeholder=REDACTED_FIXTURE_SECRET_PLACEHOLDER",
   "createdAt": "2026-04-29T00:10:00Z"
 }

--- a/protocol-snapshots/ensen-protocol/v0.1.0/fixtures/evidence-bundle-ref/v1/valid/file-uri.json
+++ b/protocol-snapshots/ensen-protocol/v0.1.0/fixtures/evidence-bundle-ref/v1/valid/file-uri.json
@@ -1,0 +1,9 @@
+{
+  "schemaVersion": "eip.evidence-bundle-ref.v1",
+  "id": "evb_01HV9ZX8J2K6T3QW4R5Y7M8N9T",
+  "correlationId": "corr_01HV9ZX8J2K6T3QW4R5Y7M8N9R",
+  "type": "file_uri",
+  "uri": "file:///var/lib/ensen/evidence/run-01HV9ZX8J2K6T3QW4R5Y7M8N9Q/bundle.json",
+  "createdAt": "2026-04-29T00:05:00Z",
+  "contentType": "application/json"
+}

--- a/protocol-snapshots/ensen-protocol/v0.1.0/fixtures/evidence-bundle-ref/v1/valid/local-path.json
+++ b/protocol-snapshots/ensen-protocol/v0.1.0/fixtures/evidence-bundle-ref/v1/valid/local-path.json
@@ -1,0 +1,18 @@
+{
+  "schemaVersion": "eip.evidence-bundle-ref.v1",
+  "id": "evb_01HV9ZX8J2K6T3QW4R5Y7M8N9S",
+  "correlationId": "corr_01HV9ZX8J2K6T3QW4R5Y7M8N9R",
+  "type": "local_path",
+  "uri": "artifacts/evidence/run-01HV9ZX8J2K6T3QW4R5Y7M8N9Q/bundle.json",
+  "createdAt": "2026-04-29T00:00:00Z",
+  "contentType": "application/json",
+  "checksum": {
+    "algorithm": "sha256",
+    "value": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+  },
+  "metadata": {
+    "producer": "ensen-loop",
+    "command": "npm test",
+    "redacted": true
+  }
+}

--- a/protocol-snapshots/ensen-protocol/v0.1.0/fixtures/run-request/v1/invalid/bad-schema-version.json
+++ b/protocol-snapshots/ensen-protocol/v0.1.0/fixtures/run-request/v1/invalid/bad-schema-version.json
@@ -1,0 +1,20 @@
+{
+  "schemaVersion": "eip.run-request.v2",
+  "id": "req_01HV7Y8M8F2KQ5W3P9R6T4N2CA",
+  "correlationId": "corr_01HV7Y8M8F2KQ5W3P9R6T4N2CB",
+  "idempotencyKey": "github-issue-4-attempt-1",
+  "source": {
+    "sourceId": "source_01HV7Y8M8F2KQ5W3P9R6T4N2CC",
+    "sourceType": "github"
+  },
+  "requestedBy": {
+    "actorId": "actor_01HV7Y8M8F2KQ5W3P9R6T4N2CD",
+    "actorType": "api_client"
+  },
+  "workItem": {
+    "workItemId": "workitem_01HV7Y8M8F2KQ5W3P9R6T4N2CE",
+    "externalId": "4"
+  },
+  "mode": "plan",
+  "createdAt": "2026-04-29T01:45:45Z"
+}

--- a/protocol-snapshots/ensen-protocol/v0.1.0/fixtures/run-request/v1/invalid/raw-secret.json
+++ b/protocol-snapshots/ensen-protocol/v0.1.0/fixtures/run-request/v1/invalid/raw-secret.json
@@ -1,0 +1,23 @@
+{
+  "schemaVersion": "eip.run-request.v1",
+  "id": "req_01HV7Y8M8F2KQ5W3P9R6T4N2DA",
+  "correlationId": "corr_01HV7Y8M8F2KQ5W3P9R6T4N2DB",
+  "idempotencyKey": "manual-request-20260429-2",
+  "source": {
+    "sourceId": "source_01HV7Y8M8F2KQ5W3P9R6T4N2DC",
+    "sourceType": "manual"
+  },
+  "requestedBy": {
+    "actorId": "actor_01HV7Y8M8F2KQ5W3P9R6T4N2DD",
+    "actorType": "human"
+  },
+  "workItem": {
+    "workItemId": "workitem_01HV7Y8M8F2KQ5W3P9R6T4N2DE",
+    "externalId": "manual-secret-check"
+  },
+  "mode": "validate",
+  "createdAt": "2026-04-29T02:00:00Z",
+  "extensions": {
+    "x-raw-secret": "REDACTED_FIXTURE_SECRET_PLACEHOLDER"
+  }
+}

--- a/protocol-snapshots/ensen-protocol/v0.1.0/fixtures/run-request/v1/invalid/raw-secret.json
+++ b/protocol-snapshots/ensen-protocol/v0.1.0/fixtures/run-request/v1/invalid/raw-secret.json
@@ -18,6 +18,6 @@
   "mode": "validate",
   "createdAt": "2026-04-29T02:00:00Z",
   "extensions": {
-    "x-raw-secret": "REDACTED_FIXTURE_SECRET_PLACEHOLDER"
+    "raw-secret": "REDACTED_FIXTURE_SECRET_PLACEHOLDER"
   }
 }

--- a/protocol-snapshots/ensen-protocol/v0.1.0/fixtures/run-request/v1/invalid/source-string.json
+++ b/protocol-snapshots/ensen-protocol/v0.1.0/fixtures/run-request/v1/invalid/source-string.json
@@ -1,0 +1,17 @@
+{
+  "schemaVersion": "eip.run-request.v1",
+  "id": "req_01HV7Y8M8F2KQ5W3P9R6T4N2EA",
+  "correlationId": "corr_01HV7Y8M8F2KQ5W3P9R6T4N2EB",
+  "idempotencyKey": "manual-request-20260429-3",
+  "source": "github",
+  "requestedBy": {
+    "actorId": "actor_01HV7Y8M8F2KQ5W3P9R6T4N2EC",
+    "actorType": "api_client"
+  },
+  "workItem": {
+    "workItemId": "workitem_01HV7Y8M8F2KQ5W3P9R6T4N2ED",
+    "externalId": "4"
+  },
+  "mode": "plan",
+  "createdAt": "2026-04-29T01:45:45Z"
+}

--- a/protocol-snapshots/ensen-protocol/v0.1.0/fixtures/run-request/v1/invalid/unknown-top-level-field.json
+++ b/protocol-snapshots/ensen-protocol/v0.1.0/fixtures/run-request/v1/invalid/unknown-top-level-field.json
@@ -1,0 +1,21 @@
+{
+  "schemaVersion": "eip.run-request.v1",
+  "id": "req_01HV7Y8M8F2KQ5W3P9R6T4N2FA",
+  "correlationId": "corr_01HV7Y8M8F2KQ5W3P9R6T4N2FB",
+  "idempotencyKey": "github-issue-4-attempt-1",
+  "source": {
+    "sourceId": "source_01HV7Y8M8F2KQ5W3P9R6T4N2FC",
+    "sourceType": "github"
+  },
+  "requestedBy": {
+    "actorId": "actor_01HV7Y8M8F2KQ5W3P9R6T4N2FD",
+    "actorType": "api_client"
+  },
+  "workItem": {
+    "workItemId": "workitem_01HV7Y8M8F2KQ5W3P9R6T4N2FE",
+    "externalId": "4"
+  },
+  "mode": "plan",
+  "createdAt": "2026-04-29T01:45:45Z",
+  "transport": "github-webhook"
+}

--- a/protocol-snapshots/ensen-protocol/v0.1.0/fixtures/run-request/v1/valid/github-issue-request.json
+++ b/protocol-snapshots/ensen-protocol/v0.1.0/fixtures/run-request/v1/valid/github-issue-request.json
@@ -1,0 +1,38 @@
+{
+  "schemaVersion": "eip.run-request.v1",
+  "id": "req_01HV7Y8M8F2KQ5W3P9R6T4N2AB",
+  "correlationId": "corr_01HV7Y8M8F2KQ5W3P9R6T4N2AC",
+  "idempotencyKey": "github-issue-4",
+  "source": {
+    "sourceId": "source_01HV7Y8M8F2KQ5W3P9R6T4N2AD",
+    "sourceType": "github",
+    "externalRef": "TommyKammy/Ensen-protocol"
+  },
+  "requestedBy": {
+    "actorId": "actor_01HV7Y8M8F2KQ5W3P9R6T4N2AE",
+    "actorType": "api_client",
+    "displayName": "Ensen issue dispatcher"
+  },
+  "workItem": {
+    "workItemId": "workitem_01HV7Y8M8F2KQ5W3P9R6T4N2AF",
+    "externalId": "4",
+    "title": "EIP-0001: Define RunRequest v1 schema",
+    "url": "https://github.com/TommyKammy/Ensen-protocol/issues/4"
+  },
+  "mode": "plan",
+  "createdAt": "2026-04-29T01:45:45Z",
+  "target": {
+    "targetType": "repository",
+    "targetId": "repo_01HV7Y8M8F2KQ5W3P9R6T4N2AG",
+    "externalRef": "TommyKammy/Ensen-protocol"
+  },
+  "policyContext": {
+    "policySetId": "policy_01HV7Y8M8F2KQ5W3P9R6T4N2AH",
+    "riskClasses": ["secrets"],
+    "requiresApproval": true
+  },
+  "dataClassification": "public",
+  "extensions": {
+    "x-fixture-note": "synthetic GitHub issue request"
+  }
+}

--- a/protocol-snapshots/ensen-protocol/v0.1.0/fixtures/run-request/v1/valid/manual-request.json
+++ b/protocol-snapshots/ensen-protocol/v0.1.0/fixtures/run-request/v1/valid/manual-request.json
@@ -1,0 +1,24 @@
+{
+  "schemaVersion": "eip.run-request.v1",
+  "id": "req_01HV7Y8M8F2KQ5W3P9R6T4N2BA",
+  "correlationId": "corr_01HV7Y8M8F2KQ5W3P9R6T4N2BB",
+  "idempotencyKey": "manual-request-20260429-1",
+  "source": {
+    "sourceId": "source_01HV7Y8M8F2KQ5W3P9R6T4N2BC",
+    "sourceType": "manual",
+    "externalRef": "operator-intake"
+  },
+  "requestedBy": {
+    "actorId": "actor_01HV7Y8M8F2KQ5W3P9R6T4N2BD",
+    "actorType": "human",
+    "displayName": "Example Operator"
+  },
+  "workItem": {
+    "workItemId": "workitem_01HV7Y8M8F2KQ5W3P9R6T4N2BE",
+    "externalId": "manual-2026-04-29-001",
+    "title": "Review protocol fixture coverage"
+  },
+  "mode": "validate",
+  "createdAt": "2026-04-29T02:00:00Z",
+  "dataClassification": "public"
+}

--- a/protocol-snapshots/ensen-protocol/v0.1.0/fixtures/run-result/v1/invalid/missing-request-id.json
+++ b/protocol-snapshots/ensen-protocol/v0.1.0/fixtures/run-result/v1/invalid/missing-request-id.json
@@ -1,0 +1,7 @@
+{
+  "schemaVersion": "eip.run-result.v1",
+  "id": "run_01HV9ZX8J2K6T3QW4R5Y7M8N9V",
+  "correlationId": "corr_01HV9ZX8J2K6T3QW4R5Y7M8N9W",
+  "status": "succeeded",
+  "completedAt": "2026-04-29T03:00:00Z"
+}

--- a/protocol-snapshots/ensen-protocol/v0.1.0/fixtures/run-result/v1/invalid/running-status.json
+++ b/protocol-snapshots/ensen-protocol/v0.1.0/fixtures/run-result/v1/invalid/running-status.json
@@ -1,0 +1,8 @@
+{
+  "schemaVersion": "eip.run-result.v1",
+  "id": "run_01HV9ZX8J2K6T3QW4R5Y7M8N9X",
+  "requestId": "req_01HV7Y8M8F2KQ5W3P9R6T4N2DA",
+  "correlationId": "corr_01HV9ZX8J2K6T3QW4R5Y7M8N9Y",
+  "status": "running",
+  "completedAt": "2026-04-29T03:10:00Z"
+}

--- a/protocol-snapshots/ensen-protocol/v0.1.0/fixtures/run-result/v1/valid/blocked-result.json
+++ b/protocol-snapshots/ensen-protocol/v0.1.0/fixtures/run-result/v1/valid/blocked-result.json
@@ -1,0 +1,22 @@
+{
+  "schemaVersion": "eip.run-result.v1",
+  "id": "run_01HV9ZX8J2K6T3QW4R5Y7M8N9S",
+  "requestId": "req_01HV7Y8M8F2KQ5W3P9R6T4N2BA",
+  "correlationId": "corr_01HV7Y8M8F2KQ5W3P9R6T4N2BB",
+  "status": "blocked",
+  "completedAt": "2026-04-29T02:40:00Z",
+  "verification": {
+    "status": "blocked",
+    "summary": "Required approval was not available."
+  },
+  "warnings": [
+    {
+      "code": "APPROVAL_REQUIRED",
+      "message": "The run stopped before making changes because approval was required."
+    }
+  ],
+  "metrics": {
+    "durationMs": 30000,
+    "attempts": 1
+  }
+}

--- a/protocol-snapshots/ensen-protocol/v0.1.0/fixtures/run-result/v1/valid/failed-result.json
+++ b/protocol-snapshots/ensen-protocol/v0.1.0/fixtures/run-result/v1/valid/failed-result.json
@@ -1,0 +1,31 @@
+{
+  "schemaVersion": "eip.run-result.v1",
+  "id": "run_01HV9ZX8J2K6T3QW4R5Y7M8N9T",
+  "requestId": "req_01HV7Y8M8F2KQ5W3P9R6T4N2CA",
+  "correlationId": "corr_01HV9ZX8J2K6T3QW4R5Y7M8N9U",
+  "status": "failed",
+  "completedAt": "2026-04-29T02:50:00Z",
+  "verification": {
+    "status": "failed",
+    "commands": [
+      {
+        "command": "npm test",
+        "status": "failed",
+        "completedAt": "2026-04-29T02:49:50Z",
+        "summary": "A schema validation test failed."
+      }
+    ],
+    "summary": "Run failed during verification."
+  },
+  "errors": [
+    {
+      "code": "VERIFICATION_FAILED",
+      "message": "Focused verification failed.",
+      "retryable": true
+    }
+  ],
+  "metrics": {
+    "durationMs": 120000,
+    "attempts": 2
+  }
+}

--- a/protocol-snapshots/ensen-protocol/v0.1.0/fixtures/run-result/v1/valid/succeeded-result.json
+++ b/protocol-snapshots/ensen-protocol/v0.1.0/fixtures/run-result/v1/valid/succeeded-result.json
@@ -1,0 +1,41 @@
+{
+  "schemaVersion": "eip.run-result.v1",
+  "id": "run_01HV9ZX8J2K6T3QW4R5Y7M8N9P",
+  "requestId": "req_01HV7Y8M8F2KQ5W3P9R6T4N2AB",
+  "correlationId": "corr_01HV7Y8M8F2KQ5W3P9R6T4N2AC",
+  "status": "succeeded",
+  "completedAt": "2026-04-29T02:30:00Z",
+  "changeRequests": [
+    {
+      "changeRequestId": "cr_01HV9ZX8J2K6T3QW4R5Y7M8N9Q",
+      "status": "open"
+    }
+  ],
+  "evidenceBundles": [
+    {
+      "evidenceBundleId": "evb_01HV9ZX8J2K6T3QW4R5Y7M8N9R",
+      "digest": "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+    }
+  ],
+  "verification": {
+    "status": "passed",
+    "commands": [
+      {
+        "command": "npm test",
+        "status": "passed",
+        "completedAt": "2026-04-29T02:29:45Z",
+        "summary": "Contract tests passed."
+      }
+    ],
+    "summary": "Run completed and verification passed."
+  },
+  "metrics": {
+    "durationMs": 180000,
+    "attempts": 1,
+    "tokensInput": 2400,
+    "tokensOutput": 900
+  },
+  "extensions": {
+    "x-fixture-note": "synthetic succeeded result"
+  }
+}

--- a/protocol-snapshots/ensen-protocol/v0.1.0/fixtures/run-status/v1/invalid/final-result-only-fields.json
+++ b/protocol-snapshots/ensen-protocol/v0.1.0/fixtures/run-status/v1/invalid/final-result-only-fields.json
@@ -1,0 +1,14 @@
+{
+  "schemaVersion": "eip.run-status.v1",
+  "id": "sts_01HV9ZX8J2K6T3QW4R5Y7M8N9W",
+  "requestId": "req_01HV9ZX8J2K6T3QW4R5Y7M8N9Q",
+  "correlationId": "corr_01HV9ZX8J2K6T3QW4R5Y7M8N9R",
+  "status": "completed",
+  "observedAt": "2026-04-29T00:05:00Z",
+  "completedAt": "2026-04-29T00:05:00Z",
+  "changeRequests": [
+    {
+      "changeRequestId": "pr_01HV9ZX8J2K6T3QW4R5Y7M8N9X"
+    }
+  ]
+}

--- a/protocol-snapshots/ensen-protocol/v0.1.0/fixtures/run-status/v1/valid/accepted-snapshot.json
+++ b/protocol-snapshots/ensen-protocol/v0.1.0/fixtures/run-status/v1/valid/accepted-snapshot.json
@@ -1,0 +1,9 @@
+{
+  "schemaVersion": "eip.run-status.v1",
+  "id": "sts_01HV9ZX8J2K6T3QW4R5Y7M8N9S",
+  "requestId": "req_01HV9ZX8J2K6T3QW4R5Y7M8N9Q",
+  "correlationId": "corr_01HV9ZX8J2K6T3QW4R5Y7M8N9R",
+  "status": "accepted",
+  "observedAt": "2026-04-29T00:00:00Z",
+  "message": "Run request accepted by the executor boundary."
+}

--- a/protocol-snapshots/ensen-protocol/v0.1.0/fixtures/run-status/v1/valid/completed-snapshot.json
+++ b/protocol-snapshots/ensen-protocol/v0.1.0/fixtures/run-status/v1/valid/completed-snapshot.json
@@ -1,0 +1,10 @@
+{
+  "schemaVersion": "eip.run-status.v1",
+  "id": "sts_01HV9ZX8J2K6T3QW4R5Y7M8N9U",
+  "requestId": "req_01HV9ZX8J2K6T3QW4R5Y7M8N9Q",
+  "correlationId": "corr_01HV9ZX8J2K6T3QW4R5Y7M8N9R",
+  "runId": "run_01HV9ZX8J2K6T3QW4R5Y7M8N9V",
+  "status": "completed",
+  "observedAt": "2026-04-29T00:05:00Z",
+  "message": "Run completed. Retrieve final details from RunResult."
+}

--- a/protocol-snapshots/ensen-protocol/v0.1.0/fixtures/run-status/v1/valid/running-snapshot.json
+++ b/protocol-snapshots/ensen-protocol/v0.1.0/fixtures/run-status/v1/valid/running-snapshot.json
@@ -1,0 +1,16 @@
+{
+  "schemaVersion": "eip.run-status.v1",
+  "id": "sts_01HV9ZX8J2K6T3QW4R5Y7M8N9T",
+  "requestId": "req_01HV9ZX8J2K6T3QW4R5Y7M8N9Q",
+  "correlationId": "corr_01HV9ZX8J2K6T3QW4R5Y7M8N9R",
+  "runId": "run_01HV9ZX8J2K6T3QW4R5Y7M8N9V",
+  "status": "running",
+  "observedAt": "2026-04-29T00:01:00Z",
+  "message": "Executor is running validation.",
+  "progress": {
+    "current": 2,
+    "total": 5,
+    "percent": 40,
+    "unit": "steps"
+  }
+}

--- a/protocol-snapshots/ensen-protocol/v0.1.0/manifest.json
+++ b/protocol-snapshots/ensen-protocol/v0.1.0/manifest.json
@@ -6,7 +6,21 @@
   },
   "policy": {
     "updatePolicy": "Copied snapshot. Update only by replacing this directory from a tagged Ensen-protocol release.",
-    "runtimeDependency": false
+    "runtimeDependency": false,
+    "localCorrections": [
+      {
+        "path": "fixtures/evidence-bundle-ref/v1/invalid/raw-secret-uri.json",
+        "reason": "Use a scanner-safe invalid URI placeholder."
+      },
+      {
+        "path": "fixtures/run-request/v1/invalid/raw-secret.json",
+        "reason": "Keep the invalid fixture deterministically invalid under ExtensionMap rules."
+      },
+      {
+        "path": "schemas/eip.run-result.v1.schema.json",
+        "reason": "Require VerificationSummary.status for unambiguous verification payloads."
+      }
+    ]
   },
   "includes": {
     "schemas": [

--- a/protocol-snapshots/ensen-protocol/v0.1.0/manifest.json
+++ b/protocol-snapshots/ensen-protocol/v0.1.0/manifest.json
@@ -1,0 +1,28 @@
+{
+  "source": {
+    "repository": "TommyKammy/Ensen-protocol",
+    "releaseTag": "v0.1.0",
+    "protocolVersion": "0.1.0"
+  },
+  "policy": {
+    "updatePolicy": "Copied snapshot. Update only by replacing this directory from a tagged Ensen-protocol release.",
+    "runtimeDependency": false
+  },
+  "includes": {
+    "schemas": [
+      "schemas/eip.evidence-bundle-ref.v1.schema.json",
+      "schemas/eip.run-request.v1.schema.json",
+      "schemas/eip.run-result.v1.schema.json",
+      "schemas/eip.run-status.v1.schema.json"
+    ],
+    "supportSchemas": [
+      "schemas/eip.common.v1.schema.json"
+    ],
+    "fixtureFamilies": [
+      "evidence-bundle-ref",
+      "run-request",
+      "run-result",
+      "run-status"
+    ]
+  }
+}

--- a/protocol-snapshots/ensen-protocol/v0.1.0/schemas/eip.common.v1.schema.json
+++ b/protocol-snapshots/ensen-protocol/v0.1.0/schemas/eip.common.v1.schema.json
@@ -1,0 +1,208 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://eip.ensen.dev/schemas/eip.common.v1.schema.json",
+  "title": "EIP Common v1 Fixture Envelope",
+  "description": "Common schema conventions and reusable v1 type definitions for EIP artifacts.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "artifactId",
+    "correlationId",
+    "createdAt",
+    "actor",
+    "source",
+    "workItem",
+    "changeRequest",
+    "evidenceBundle",
+    "classification"
+  ],
+  "properties": {
+    "artifactId": {
+      "$ref": "#/$defs/PrefixedId"
+    },
+    "correlationId": {
+      "$ref": "#/$defs/CorrelationId"
+    },
+    "createdAt": {
+      "$ref": "#/$defs/IsoDateTimeUtc"
+    },
+    "actor": {
+      "$ref": "#/$defs/ActorRef"
+    },
+    "source": {
+      "$ref": "#/$defs/SourceRef"
+    },
+    "workItem": {
+      "$ref": "#/$defs/WorkItemRef"
+    },
+    "changeRequest": {
+      "$ref": "#/$defs/ChangeRequestRef"
+    },
+    "evidenceBundle": {
+      "$ref": "#/$defs/EvidenceBundleRef"
+    },
+    "classification": {
+      "$ref": "#/$defs/DataClassification"
+    },
+    "error": {
+      "$ref": "#/$defs/ErrorInfo"
+    },
+    "extensions": {
+      "$ref": "#/$defs/ExtensionMap"
+    }
+  },
+  "$defs": {
+    "PrefixedId": {
+      "type": "string",
+      "description": "Stable protocol identifier with a registered 2-8 character lowercase semantic prefix, underscore separator, and opaque suffix.",
+      "pattern": "^(?:actor|artifact|corr|cr|evb|evt|flowstep|policy|pr|repo|req|run|source|sts|workitem)_[A-Za-z0-9][A-Za-z0-9._~-]{5,127}$"
+    },
+    "CorrelationId": {
+      "type": "string",
+      "description": "Opaque idempotency and tracing identifier shared by related protocol artifacts.",
+      "pattern": "^corr_[A-Za-z0-9][A-Za-z0-9._~-]{11,127}$"
+    },
+    "IsoDateTimeUtc": {
+      "type": "string",
+      "description": "UTC timestamp using ISO 8601 extended format with a literal Z offset.",
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?Z$"
+    },
+    "ActorRef": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["actorId", "actorType"],
+      "properties": {
+        "actorId": {
+          "$ref": "#/$defs/PrefixedId"
+        },
+        "actorType": {
+          "type": "string",
+          "enum": ["human", "workflow", "system", "api_client", "connector", "executor", "agent"]
+        },
+        "displayName": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 160
+        }
+      }
+    },
+    "SourceRef": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["sourceId", "sourceType"],
+      "properties": {
+        "sourceId": {
+          "$ref": "#/$defs/PrefixedId"
+        },
+        "sourceType": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 80,
+          "pattern": "^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$"
+        },
+        "externalRef": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 240
+        }
+      }
+    },
+    "WorkItemRef": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["workItemId"],
+      "properties": {
+        "workItemId": {
+          "$ref": "#/$defs/PrefixedId"
+        },
+        "title": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 240
+        }
+      }
+    },
+    "ChangeRequestRef": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["changeRequestId"],
+      "properties": {
+        "changeRequestId": {
+          "$ref": "#/$defs/PrefixedId"
+        },
+        "status": {
+          "type": "string",
+          "enum": ["draft", "open", "accepted", "rejected", "superseded"]
+        }
+      }
+    },
+    "EvidenceBundleRef": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["evidenceBundleId"],
+      "properties": {
+        "evidenceBundleId": {
+          "$ref": "#/$defs/PrefixedId"
+        },
+        "digest": {
+          "type": "string",
+          "pattern": "^sha256:[a-f0-9]{64}$"
+        }
+      }
+    },
+    "ErrorInfo": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["code", "message"],
+      "properties": {
+        "code": {
+          "type": "string",
+          "pattern": "^[A-Z][A-Z0-9_]{2,63}$"
+        },
+        "message": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 1000
+        },
+        "retryable": {
+          "type": "boolean"
+        },
+        "details": {
+          "type": "object",
+          "additionalProperties": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "integer"
+              },
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        }
+      }
+    },
+    "ExtensionMap": {
+      "type": "object",
+      "description": "Vendor or artifact-specific extension values. Extension keys must use the x- prefix.",
+      "propertyNames": {
+        "pattern": "^x-.+$"
+      },
+      "additionalProperties": true
+    },
+    "DataClassification": {
+      "type": "string",
+      "description": "Classification label for fixture and production data handling.",
+      "enum": ["public", "internal", "confidential", "restricted"]
+    }
+  }
+}

--- a/protocol-snapshots/ensen-protocol/v0.1.0/schemas/eip.evidence-bundle-ref.v1.schema.json
+++ b/protocol-snapshots/ensen-protocol/v0.1.0/schemas/eip.evidence-bundle-ref.v1.schema.json
@@ -1,0 +1,140 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://eip.ensen.dev/schemas/eip.evidence-bundle-ref.v1.schema.json",
+  "title": "EIP-0004 EvidenceBundleRef v1",
+  "description": "Transport-neutral reference to durable evidence material. This artifact identifies where evidence can be found; it does not embed the evidence body.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "id",
+    "correlationId",
+    "type",
+    "uri",
+    "createdAt"
+  ],
+  "properties": {
+    "schemaVersion": {
+      "const": "eip.evidence-bundle-ref.v1"
+    },
+    "id": {
+      "$ref": "eip.common.v1.schema.json#/$defs/PrefixedId"
+    },
+    "correlationId": {
+      "$ref": "eip.common.v1.schema.json#/$defs/CorrelationId"
+    },
+    "type": {
+      "type": "string",
+      "enum": ["local_path", "file_uri"]
+    },
+    "uri": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 1000,
+      "not": {
+        "pattern": "^[A-Za-z][A-Za-z0-9+.-]*://[^/?#\\s]*[^/?#\\s:@]+:[^/?#\\s:@]+@"
+      }
+    },
+    "createdAt": {
+      "$ref": "eip.common.v1.schema.json#/$defs/IsoDateTimeUtc"
+    },
+    "contentType": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 160,
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9!#$&^_.+-]*/[A-Za-z0-9][A-Za-z0-9!#$&^_.+-]*(?:; ?[A-Za-z0-9_.-]+=[A-Za-z0-9_.+-]+)*$"
+    },
+    "checksum": {
+      "$ref": "#/$defs/Checksum"
+    },
+    "metadata": {
+      "$ref": "#/$defs/Metadata"
+    }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "local_path"
+          }
+        },
+        "required": ["type"]
+      },
+      "then": {
+        "properties": {
+          "uri": {
+            "type": "string",
+            "pattern": "^(?![A-Za-z][A-Za-z0-9+.-]*://)(?!/)(?!.*(?:^|/)\\.\\.(?:/|$))[A-Za-z0-9._~@/-]+$"
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "file_uri"
+          }
+        },
+        "required": ["type"]
+      },
+      "then": {
+        "properties": {
+          "uri": {
+            "type": "string",
+            "pattern": "^file:///(?!.*(?:^|/)\\.\\.(?:/|$))[^\\s?#]+$"
+          }
+        }
+      }
+    }
+  ],
+  "$defs": {
+    "Checksum": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["algorithm", "value"],
+      "properties": {
+        "algorithm": {
+          "type": "string",
+          "enum": ["sha256"]
+        },
+        "value": {
+          "type": "string",
+          "pattern": "^[a-f0-9]{64}$"
+        }
+      }
+    },
+    "Metadata": {
+      "type": "object",
+      "description": "Small public descriptors about the referenced evidence. Do not put evidence bodies or credentials here.",
+      "propertyNames": {
+        "pattern": "^[a-z][a-z0-9]*(?:[A-Z][a-z0-9]*)*$"
+      },
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 500
+          },
+          {
+            "type": "number"
+          },
+          {
+            "type": "integer"
+          },
+          {
+            "type": "boolean"
+          },
+          {
+            "type": "null"
+          }
+        ]
+      },
+      "maxProperties": 20
+    }
+  }
+}

--- a/protocol-snapshots/ensen-protocol/v0.1.0/schemas/eip.run-request.v1.schema.json
+++ b/protocol-snapshots/ensen-protocol/v0.1.0/schemas/eip.run-request.v1.schema.json
@@ -1,0 +1,134 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://eip.ensen.dev/schemas/eip.run-request.v1.schema.json",
+  "title": "EIP-0001 RunRequest v1",
+  "description": "Transport-neutral request contract for asking an Ensen-compatible executor to run work.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "id",
+    "correlationId",
+    "idempotencyKey",
+    "source",
+    "requestedBy",
+    "workItem",
+    "mode",
+    "createdAt"
+  ],
+  "properties": {
+    "schemaVersion": {
+      "const": "eip.run-request.v1"
+    },
+    "id": {
+      "$ref": "eip.common.v1.schema.json#/$defs/PrefixedId"
+    },
+    "correlationId": {
+      "$ref": "eip.common.v1.schema.json#/$defs/CorrelationId"
+    },
+    "idempotencyKey": {
+      "type": "string",
+      "minLength": 12,
+      "maxLength": 160,
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._:-]{11,159}$"
+    },
+    "source": {
+      "$ref": "eip.common.v1.schema.json#/$defs/SourceRef"
+    },
+    "requestedBy": {
+      "$ref": "eip.common.v1.schema.json#/$defs/ActorRef"
+    },
+    "workItem": {
+      "$ref": "#/$defs/RunRequestWorkItem"
+    },
+    "mode": {
+      "type": "string",
+      "enum": ["plan", "apply", "validate"]
+    },
+    "createdAt": {
+      "$ref": "eip.common.v1.schema.json#/$defs/IsoDateTimeUtc"
+    },
+    "target": {
+      "$ref": "#/$defs/RunTarget"
+    },
+    "policyContext": {
+      "$ref": "#/$defs/PolicyContext"
+    },
+    "dataClassification": {
+      "$ref": "eip.common.v1.schema.json#/$defs/DataClassification"
+    },
+    "extensions": {
+      "$ref": "eip.common.v1.schema.json#/$defs/ExtensionMap"
+    }
+  },
+  "$defs": {
+    "RunRequestWorkItem": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["workItemId", "externalId"],
+      "properties": {
+        "workItemId": {
+          "$ref": "eip.common.v1.schema.json#/$defs/PrefixedId"
+        },
+        "externalId": {
+          "type": "string",
+          "description": "Identifier used by the external source system, such as a GitHub issue number or manual ticket id.",
+          "minLength": 1,
+          "maxLength": 240
+        },
+        "title": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 240
+        },
+        "url": {
+          "type": "string",
+          "pattern": "^https://[^\\s]+$",
+          "maxLength": 400
+        }
+      }
+    },
+    "RunTarget": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["targetType", "targetId"],
+      "properties": {
+        "targetType": {
+          "type": "string",
+          "enum": ["repository", "workspace", "environment", "manual"]
+        },
+        "targetId": {
+          "$ref": "eip.common.v1.schema.json#/$defs/PrefixedId"
+        },
+        "externalRef": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 240
+        }
+      }
+    },
+    "PolicyContext": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policySetId": {
+          "$ref": "eip.common.v1.schema.json#/$defs/PrefixedId"
+        },
+        "riskClasses": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 80,
+            "pattern": "^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$"
+          },
+          "uniqueItems": true,
+          "maxItems": 20
+        },
+        "requiresApproval": {
+          "type": "boolean"
+        }
+      }
+    }
+  }
+}

--- a/protocol-snapshots/ensen-protocol/v0.1.0/schemas/eip.run-result.v1.schema.json
+++ b/protocol-snapshots/ensen-protocol/v0.1.0/schemas/eip.run-result.v1.schema.json
@@ -1,0 +1,163 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://eip.ensen.dev/schemas/eip.run-result.v1.schema.json",
+  "title": "EIP-0002 RunResult v1",
+  "description": "Transport-neutral terminal result contract for completed Ensen-compatible executor runs.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "id",
+    "requestId",
+    "correlationId",
+    "status",
+    "completedAt"
+  ],
+  "properties": {
+    "schemaVersion": {
+      "const": "eip.run-result.v1"
+    },
+    "id": {
+      "$ref": "eip.common.v1.schema.json#/$defs/PrefixedId"
+    },
+    "requestId": {
+      "$ref": "eip.common.v1.schema.json#/$defs/PrefixedId"
+    },
+    "correlationId": {
+      "$ref": "eip.common.v1.schema.json#/$defs/CorrelationId"
+    },
+    "status": {
+      "$ref": "#/$defs/RunResultStatus"
+    },
+    "completedAt": {
+      "$ref": "eip.common.v1.schema.json#/$defs/IsoDateTimeUtc"
+    },
+    "changeRequests": {
+      "type": "array",
+      "items": {
+        "$ref": "eip.common.v1.schema.json#/$defs/ChangeRequestRef"
+      },
+      "maxItems": 50
+    },
+    "evidenceBundles": {
+      "type": "array",
+      "items": {
+        "$ref": "eip.common.v1.schema.json#/$defs/EvidenceBundleRef"
+      },
+      "maxItems": 50
+    },
+    "verification": {
+      "$ref": "#/$defs/VerificationSummary"
+    },
+    "errors": {
+      "type": "array",
+      "items": {
+        "$ref": "eip.common.v1.schema.json#/$defs/ErrorInfo"
+      },
+      "maxItems": 50
+    },
+    "warnings": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/WarningInfo"
+      },
+      "maxItems": 50
+    },
+    "metrics": {
+      "$ref": "#/$defs/RunMetrics"
+    },
+    "extensions": {
+      "$ref": "eip.common.v1.schema.json#/$defs/ExtensionMap"
+    }
+  },
+  "$defs": {
+    "RunResultStatus": {
+      "type": "string",
+      "enum": ["succeeded", "failed", "blocked", "needs_review", "cancelled"]
+    },
+    "VerificationSummary": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "status": {
+          "type": "string",
+          "enum": ["passed", "failed", "blocked", "not_run"]
+        },
+        "commands": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/VerificationCommand"
+          },
+          "maxItems": 50
+        },
+        "summary": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 1000
+        }
+      }
+    },
+    "VerificationCommand": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["command", "status"],
+      "properties": {
+        "command": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 240
+        },
+        "status": {
+          "type": "string",
+          "enum": ["passed", "failed", "blocked", "not_run"]
+        },
+        "completedAt": {
+          "$ref": "eip.common.v1.schema.json#/$defs/IsoDateTimeUtc"
+        },
+        "summary": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 500
+        }
+      }
+    },
+    "WarningInfo": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["code", "message"],
+      "properties": {
+        "code": {
+          "type": "string",
+          "pattern": "^[A-Z][A-Z0-9_]{2,63}$"
+        },
+        "message": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 1000
+        }
+      }
+    },
+    "RunMetrics": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "durationMs": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "attempts": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "tokensInput": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "tokensOutput": {
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    }
+  }
+}

--- a/protocol-snapshots/ensen-protocol/v0.1.0/schemas/eip.run-result.v1.schema.json
+++ b/protocol-snapshots/ensen-protocol/v0.1.0/schemas/eip.run-result.v1.schema.json
@@ -78,6 +78,7 @@
     "VerificationSummary": {
       "type": "object",
       "additionalProperties": false,
+      "required": ["status"],
       "properties": {
         "status": {
           "type": "string",

--- a/protocol-snapshots/ensen-protocol/v0.1.0/schemas/eip.run-status.v1.schema.json
+++ b/protocol-snapshots/ensen-protocol/v0.1.0/schemas/eip.run-status.v1.schema.json
@@ -1,0 +1,91 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://eip.ensen.dev/schemas/eip.run-status.v1.schema.json",
+  "title": "EIP-0005 RunStatusSnapshot v1",
+  "description": "Transport-neutral polling snapshot contract for Ensen-compatible async executor runs.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "id",
+    "requestId",
+    "correlationId",
+    "status",
+    "observedAt"
+  ],
+  "properties": {
+    "schemaVersion": {
+      "const": "eip.run-status.v1"
+    },
+    "id": {
+      "$ref": "eip.common.v1.schema.json#/$defs/PrefixedId"
+    },
+    "requestId": {
+      "$ref": "eip.common.v1.schema.json#/$defs/PrefixedId"
+    },
+    "correlationId": {
+      "$ref": "eip.common.v1.schema.json#/$defs/CorrelationId"
+    },
+    "runId": {
+      "$ref": "eip.common.v1.schema.json#/$defs/PrefixedId"
+    },
+    "status": {
+      "$ref": "#/$defs/RunStatus"
+    },
+    "observedAt": {
+      "$ref": "eip.common.v1.schema.json#/$defs/IsoDateTimeUtc"
+    },
+    "message": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 1000
+    },
+    "progress": {
+      "$ref": "#/$defs/RunProgress"
+    },
+    "extensions": {
+      "$ref": "eip.common.v1.schema.json#/$defs/ExtensionMap"
+    }
+  },
+  "$defs": {
+    "RunStatus": {
+      "type": "string",
+      "enum": [
+        "accepted",
+        "queued",
+        "running",
+        "cancelling",
+        "cancelled",
+        "completed",
+        "failed",
+        "blocked",
+        "unknown"
+      ]
+    },
+    "RunProgress": {
+      "type": "object",
+      "additionalProperties": false,
+      "minProperties": 1,
+      "properties": {
+        "current": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "total": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "percent": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 100
+        },
+        "unit": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 80
+        }
+      }
+    }
+  }
+}

--- a/test/protocol-snapshot.test.ts
+++ b/test/protocol-snapshot.test.ts
@@ -29,6 +29,10 @@ async function readJson(relativePath: string): Promise<unknown> {
   return JSON.parse(await readFile(path.join(snapshotRoot, relativePath), "utf8")) as unknown;
 }
 
+function assertJsonObject(value: unknown, message: string): asserts value is Record<string, unknown> {
+  assert.ok(value !== null && typeof value === "object" && !Array.isArray(value), message);
+}
+
 async function listJsonFixtures(relativePath: string): Promise<string[]> {
   const entries = await readdir(path.join(snapshotRoot, relativePath), {
     withFileTypes: true,
@@ -53,6 +57,22 @@ test("vendors the Ensen-protocol v0.1.0 protocol snapshot with provenance", asyn
       updatePolicy:
         "Copied snapshot. Update only by replacing this directory from a tagged Ensen-protocol release.",
       runtimeDependency: false,
+      localCorrections: [
+        {
+          path: "fixtures/evidence-bundle-ref/v1/invalid/raw-secret-uri.json",
+          reason: "Use a scanner-safe invalid URI placeholder.",
+        },
+        {
+          path: "fixtures/run-request/v1/invalid/raw-secret.json",
+          reason:
+            "Keep the invalid fixture deterministically invalid under ExtensionMap rules.",
+        },
+        {
+          path: "schemas/eip.run-result.v1.schema.json",
+          reason:
+            "Require VerificationSummary.status for unambiguous verification payloads.",
+        },
+      ],
     },
     includes: {
       schemas: expectedSchemas,
@@ -64,8 +84,55 @@ test("vendors the Ensen-protocol v0.1.0 protocol snapshot with provenance", asyn
   for (const schemaPath of [...expectedSchemas, ...supportSchemas]) {
     const schema = await readJson(schemaPath);
 
-    assert.equal(typeof schema, "object", `${schemaPath} must contain a JSON object`);
+    assertJsonObject(schema, `${schemaPath} must contain a non-null JSON object`);
   }
+});
+
+test("keeps local protocol snapshot corrections explicit", async () => {
+  const evidenceBundleRef = await readJson(
+    "fixtures/evidence-bundle-ref/v1/invalid/raw-secret-uri.json",
+  );
+  assertJsonObject(evidenceBundleRef, "raw-secret-uri fixture must be a JSON object");
+  const uri = evidenceBundleRef.uri;
+
+  assert.ok(typeof uri === "string", "raw-secret-uri fixture must contain a URI string");
+  assert.doesNotMatch(
+    uri,
+    /:\/\/[^/?#\s]+:[^/?#\s]+@/,
+    "raw-secret-uri fixture must not use a credential-shaped URI",
+  );
+
+  const rawSecretRunRequest = await readJson("fixtures/run-request/v1/invalid/raw-secret.json");
+  assertJsonObject(rawSecretRunRequest, "raw-secret fixture must be a JSON object");
+  const extensions = rawSecretRunRequest.extensions;
+  assertJsonObject(extensions, "raw-secret fixture extensions must be a JSON object");
+
+  assert.equal(
+    extensions["raw-secret"],
+    "REDACTED_FIXTURE_SECRET_PLACEHOLDER",
+    "raw-secret fixture must use a schema-invalid extension key",
+  );
+  assert.equal(
+    Object.hasOwn(extensions, "x-raw-secret"),
+    false,
+    "raw-secret fixture must not use the valid x-* extension key pattern",
+  );
+
+  const runResultSchema = await readJson("schemas/eip.run-result.v1.schema.json");
+  assertJsonObject(runResultSchema, "RunResult schema must be a JSON object");
+  const defs = runResultSchema.$defs;
+  assertJsonObject(defs, "RunResult schema must define $defs");
+  const verificationSummary = defs.VerificationSummary;
+  assertJsonObject(
+    verificationSummary,
+    "RunResult schema must define VerificationSummary as a JSON object",
+  );
+
+  assert.deepEqual(
+    verificationSummary.required,
+    ["status"],
+    "VerificationSummary must require status",
+  );
 });
 
 test("includes valid and invalid fixtures for each required EIP surface", async () => {

--- a/test/protocol-snapshot.test.ts
+++ b/test/protocol-snapshot.test.ts
@@ -1,0 +1,89 @@
+import assert from "node:assert/strict";
+import { readdir, readFile } from "node:fs/promises";
+import path from "node:path";
+import test from "node:test";
+
+const snapshotRoot = path.join(
+  "protocol-snapshots",
+  "ensen-protocol",
+  "v0.1.0",
+);
+
+const expectedSchemas = [
+  "schemas/eip.evidence-bundle-ref.v1.schema.json",
+  "schemas/eip.run-request.v1.schema.json",
+  "schemas/eip.run-result.v1.schema.json",
+  "schemas/eip.run-status.v1.schema.json",
+];
+
+const supportSchemas = ["schemas/eip.common.v1.schema.json"];
+
+const expectedFixtureFamilies = [
+  "evidence-bundle-ref",
+  "run-request",
+  "run-result",
+  "run-status",
+];
+
+async function readJson(relativePath: string): Promise<unknown> {
+  return JSON.parse(await readFile(path.join(snapshotRoot, relativePath), "utf8")) as unknown;
+}
+
+async function listJsonFixtures(relativePath: string): Promise<string[]> {
+  const entries = await readdir(path.join(snapshotRoot, relativePath), {
+    withFileTypes: true,
+  });
+
+  return entries
+    .filter((entry) => entry.isFile() && entry.name.endsWith(".json"))
+    .map((entry) => entry.name)
+    .sort();
+}
+
+test("vendors the Ensen-protocol v0.1.0 protocol snapshot with provenance", async () => {
+  const manifest = await readJson("manifest.json");
+
+  assert.deepEqual(manifest, {
+    source: {
+      repository: "TommyKammy/Ensen-protocol",
+      releaseTag: "v0.1.0",
+      protocolVersion: "0.1.0",
+    },
+    policy: {
+      updatePolicy:
+        "Copied snapshot. Update only by replacing this directory from a tagged Ensen-protocol release.",
+      runtimeDependency: false,
+    },
+    includes: {
+      schemas: expectedSchemas,
+      supportSchemas,
+      fixtureFamilies: expectedFixtureFamilies,
+    },
+  });
+
+  for (const schemaPath of [...expectedSchemas, ...supportSchemas]) {
+    const schema = await readJson(schemaPath);
+
+    assert.equal(typeof schema, "object", `${schemaPath} must contain a JSON object`);
+  }
+});
+
+test("includes valid and invalid fixtures for each required EIP surface", async () => {
+  for (const fixtureFamily of expectedFixtureFamilies) {
+    const validFixtures = await listJsonFixtures(
+      path.join("fixtures", fixtureFamily, "v1", "valid"),
+    );
+    const invalidFixtures = await listJsonFixtures(
+      path.join("fixtures", fixtureFamily, "v1", "invalid"),
+    );
+
+    assert.ok(
+      validFixtures.length > 0,
+      `${fixtureFamily} must include at least one valid fixture`,
+    );
+    assert.ok(
+      invalidFixtures.length > 0,
+      `${fixtureFamily} must include at least one invalid fixture`,
+    );
+  }
+});


### PR DESCRIPTION
## Summary
- vendor Ensen-protocol v0.1.0 schemas and public conformance fixtures under a repo-owned snapshot path
- add manifest/provenance metadata and snapshot update policy docs
- add a focused regression test for snapshot presence and valid/invalid fixture coverage

## Verification
- npm run typecheck
- npm run build
- npm test
- tag-vs-snapshot diff from Ensen-protocol v0.1.0 (excluding local manifest/README)

Closes #21

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Ensen-protocol v0.1.0 snapshot with schemas and numerous valid/invalid fixtures covering evidence references, run requests, run results, and run status.

* **Documentation**
  * Added README explaining snapshot contents, read-only handling, and update policy.

* **Tests**
  * Added validation tests to verify manifest, schema loading, correction rules, and fixture family completeness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->