### PR TITLE
LOOP-011: Add RunRequest input boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,13 @@ npm run typecheck
 npm run build
 npm test
 node dist/src/cli/index.js dry-run --sample
+node dist/src/cli/index.js run-request <run-request-json-file>
 ```
 
 `dry-run --sample` emits a deterministic local execution plan as JSON. It describes the work item, lane workspace, agent provider, SCM provider, verification, and evidence intents without creating worktrees, branches, commits, change requests, durable evidence, or invoking external providers.
 
+`run-request <run-request-json-file>` reads an EIP RunRequest v1 JSON file, validates it at the protocol input boundary, and emits either `{ "ok": true, "request": ... }` or `{ "ok": false, "issues": [...] }`. The `source` field is protocol input data, not trusted internal authority.
+
 ## Scope
 
-Ensen-loop must remain independently buildable and testable. EIP RunRequest and RunResult support is not implemented in this baseline and belongs to a later phase.
+Ensen-loop must remain independently buildable and testable. EIP RunRequest input support is limited to the explicit file validation boundary. RunResult support belongs to a later phase.

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,6 +1,9 @@
 #!/usr/bin/env node
 
+import { readFile } from "node:fs/promises";
+
 import { createSampleDryRunExecutionPlan, describeProduct } from "../index.js";
+import { validateRunRequest } from "../protocol/index.js";
 
 const [, , command, ...args] = process.argv;
 
@@ -8,21 +11,59 @@ function printJson(value: unknown): void {
   console.log(`${JSON.stringify(value, null, 2)}\n`);
 }
 
-if (command === "dry-run") {
-  if (args.length === 0 || (args.length === 1 && args[0] === "--sample")) {
-    printJson(createSampleDryRunExecutionPlan());
+async function readJsonFile(filePath: string): Promise<unknown> {
+  return JSON.parse(await readFile(filePath, "utf8")) as unknown;
+}
+
+async function main(): Promise<void> {
+  if (command === "dry-run") {
+    if (args.length === 0 || (args.length === 1 && args[0] === "--sample")) {
+      printJson(createSampleDryRunExecutionPlan());
+      process.exit(0);
+    }
+
+    console.error("Usage: ensen-loop dry-run [--sample]");
+    process.exit(1);
+  }
+
+  if (command === "run-request") {
+    if (args.length !== 1) {
+      console.error("Usage: ensen-loop run-request <run-request-json-file>");
+      process.exit(1);
+    }
+
+    const filePath = args[0];
+    if (filePath === undefined) {
+      console.error("Usage: ensen-loop run-request <run-request-json-file>");
+      process.exit(1);
+    }
+
+    const result = validateRunRequest(await readJsonFile(filePath));
+    printJson(result);
+    process.exit(result.ok ? 0 : 1);
+  }
+
+  if (command === undefined) {
+    console.log(describeProduct());
     process.exit(0);
   }
 
+  console.error(`Unknown command: ${command}`);
   console.error("Usage: ensen-loop dry-run [--sample]");
+  console.error("Usage: ensen-loop run-request <run-request-json-file>");
   process.exit(1);
 }
 
-if (command === undefined) {
-  console.log(describeProduct());
-  process.exit(0);
-}
-
-console.error(`Unknown command: ${command}`);
-console.error("Usage: ensen-loop dry-run [--sample]");
-process.exit(1);
+main().catch((error: unknown) => {
+  const message = error instanceof Error ? error.message : String(error);
+  printJson({
+    ok: false,
+    issues: [
+      {
+        path: "$",
+        message,
+      },
+    ],
+  });
+  process.exit(1);
+});

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -15,55 +15,59 @@ async function readJsonFile(filePath: string): Promise<unknown> {
   return JSON.parse(await readFile(filePath, "utf8")) as unknown;
 }
 
-async function main(): Promise<void> {
+async function main(): Promise<number> {
   if (command === "dry-run") {
     if (args.length === 0 || (args.length === 1 && args[0] === "--sample")) {
       printJson(createSampleDryRunExecutionPlan());
-      process.exit(0);
+      return 0;
     }
 
     console.error("Usage: ensen-loop dry-run [--sample]");
-    process.exit(1);
+    return 1;
   }
 
   if (command === "run-request") {
     if (args.length !== 1) {
       console.error("Usage: ensen-loop run-request <run-request-json-file>");
-      process.exit(1);
+      return 1;
     }
 
     const filePath = args[0];
     if (filePath === undefined) {
       console.error("Usage: ensen-loop run-request <run-request-json-file>");
-      process.exit(1);
+      return 1;
     }
 
     const result = validateRunRequest(await readJsonFile(filePath));
     printJson(result);
-    process.exit(result.ok ? 0 : 1);
+    return result.ok ? 0 : 1;
   }
 
   if (command === undefined) {
     console.log(describeProduct());
-    process.exit(0);
+    return 0;
   }
 
   console.error(`Unknown command: ${command}`);
   console.error("Usage: ensen-loop dry-run [--sample]");
   console.error("Usage: ensen-loop run-request <run-request-json-file>");
-  process.exit(1);
+  return 1;
 }
 
-main().catch((error: unknown) => {
-  const message = error instanceof Error ? error.message : String(error);
-  printJson({
-    ok: false,
-    issues: [
-      {
-        path: "$",
-        message,
-      },
-    ],
+main()
+  .then((exitCode) => {
+    process.exitCode = exitCode;
+  })
+  .catch((error: unknown) => {
+    const message = error instanceof Error ? error.message : String(error);
+    printJson({
+      ok: false,
+      issues: [
+        {
+          path: "$",
+          message,
+        },
+      ],
+    });
+    process.exitCode = 1;
   });
-  process.exit(1);
-});

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,4 +18,5 @@ export function describeProduct(): string {
 
 export * from "./core/index.js";
 export * from "./lane/index.js";
+export * from "./protocol/index.js";
 export * from "./work-item/index.js";

--- a/src/protocol/index.ts
+++ b/src/protocol/index.ts
@@ -1,0 +1,1 @@
+export * from "./run-request.js";

--- a/src/protocol/run-request.ts
+++ b/src/protocol/run-request.ts
@@ -106,13 +106,16 @@ const workItemKeys = new Set(["workItemId", "externalId", "title", "url"]);
 const targetKeys = new Set(["targetType", "targetId", "externalRef"]);
 const policyContextKeys = new Set(["policySetId", "riskClasses", "requiresApproval"]);
 
-const prefixedIdPattern =
-  /^(?:actor|artifact|corr|cr|evb|evt|flowstep|policy|pr|repo|req|run|source|sts|workitem)_[A-Za-z0-9][A-Za-z0-9._~-]{5,127}$/;
+const requestIdPattern = /^req_[A-Za-z0-9][A-Za-z0-9._~-]{5,127}$/;
+const sourceIdPattern = /^source_[A-Za-z0-9][A-Za-z0-9._~-]{5,127}$/;
+const actorIdPattern = /^actor_[A-Za-z0-9][A-Za-z0-9._~-]{5,127}$/;
+const workItemIdPattern = /^workitem_[A-Za-z0-9][A-Za-z0-9._~-]{5,127}$/;
+const repositoryIdPattern = /^repo_[A-Za-z0-9][A-Za-z0-9._~-]{5,127}$/;
+const policyIdPattern = /^policy_[A-Za-z0-9][A-Za-z0-9._~-]{5,127}$/;
 const correlationIdPattern = /^corr_[A-Za-z0-9][A-Za-z0-9._~-]{11,127}$/;
 const idempotencyKeyPattern = /^[A-Za-z0-9][A-Za-z0-9._:-]{11,159}$/;
 const sourceTypePattern = /^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$/;
 const isoDateTimeUtcPattern = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z$/;
-const httpsUrlPattern = /^https:\/\/[^\s]+$/;
 const riskClassPattern = /^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$/;
 const extensionKeyPattern = /^x-.+$/;
 
@@ -179,7 +182,7 @@ function collectRunRequestIssues(value: unknown): readonly RunRequestValidationI
   collectUnknownKeyIssues(issues, value, topLevelKeys, "$");
 
   collectConstIssue(issues, "schemaVersion", value.schemaVersion, "eip.run-request.v1");
-  collectPatternIssue(issues, "id", value.id, prefixedIdPattern, "id must be a valid EIP prefixed id.");
+  collectPatternIssue(issues, "id", value.id, requestIdPattern, "id must be a valid EIP request id.");
   collectPatternIssue(
     issues,
     "correlationId",
@@ -239,8 +242,8 @@ function collectSourceIssues(
     issues,
     "source.sourceId",
     value.sourceId,
-    prefixedIdPattern,
-    "sourceId must be a valid EIP prefixed id.",
+    sourceIdPattern,
+    "sourceId must be a valid EIP source id.",
   );
   collectStringLengthPatternIssue(
     issues,
@@ -271,8 +274,8 @@ function collectActorIssues(
     issues,
     "requestedBy.actorId",
     value.actorId,
-    prefixedIdPattern,
-    "actorId must be a valid EIP prefixed id.",
+    actorIdPattern,
+    "actorId must be a valid EIP actor id.",
   );
   collectEnumIssue(
     issues,
@@ -301,22 +304,14 @@ function collectWorkItemIssues(
     issues,
     "workItem.workItemId",
     value.workItemId,
-    prefixedIdPattern,
-    "workItemId must be a valid EIP prefixed id.",
+    workItemIdPattern,
+    "workItemId must be a valid EIP work item id.",
   );
   collectStringLengthIssue(issues, "workItem.externalId", value.externalId, 1, 240);
   collectOptionalStringLengthIssue(issues, "workItem.title", value.title, 1, 240);
 
   if (value.url !== undefined) {
-    collectStringLengthPatternIssue(
-      issues,
-      "workItem.url",
-      value.url,
-      1,
-      400,
-      httpsUrlPattern,
-      "url must be an HTTPS URL.",
-    );
+    collectHttpsUrlIssue(issues, "workItem.url", value.url);
   }
 }
 
@@ -348,8 +343,8 @@ function collectTargetIssues(
     issues,
     "target.targetId",
     value.targetId,
-    prefixedIdPattern,
-    "targetId must be a valid EIP prefixed id.",
+    repositoryIdPattern,
+    "targetId must be a valid EIP repository id.",
   );
   collectOptionalStringLengthIssue(issues, "target.externalRef", value.externalRef, 1, 240);
 }
@@ -377,8 +372,8 @@ function collectPolicyContextIssues(
       issues,
       "policyContext.policySetId",
       value.policySetId,
-      prefixedIdPattern,
-      "policySetId must be a valid EIP prefixed id.",
+      policyIdPattern,
+      "policySetId must be a valid EIP policy id.",
     );
   }
 
@@ -568,6 +563,40 @@ function collectStringLengthPatternIssue(
       path,
       message,
     });
+  }
+}
+
+function collectHttpsUrlIssue(
+  issues: RunRequestValidationIssue[],
+  path: string,
+  value: unknown,
+): void {
+  if (typeof value !== "string" || value.length < 1 || value.length > 400) {
+    issues.push({
+      path,
+      message: "url must be an HTTPS URL.",
+    });
+    return;
+  }
+
+  if (!isHttpsUrl(value)) {
+    issues.push({
+      path,
+      message: "url must be an HTTPS URL.",
+    });
+  }
+}
+
+function isHttpsUrl(value: string): boolean {
+  if (/\s/.test(value) || !value.startsWith("https://") || value.startsWith("https:///")) {
+    return false;
+  }
+
+  try {
+    const url = new URL(value);
+    return url.protocol === "https:" && url.hostname.length > 0;
+  } catch {
+    return false;
   }
 }
 

--- a/src/protocol/run-request.ts
+++ b/src/protocol/run-request.ts
@@ -1,0 +1,581 @@
+export interface RunRequestSource {
+  readonly sourceId: string;
+  readonly sourceType: string;
+  readonly externalRef?: string;
+}
+
+export interface RunRequestActor {
+  readonly actorId: string;
+  readonly actorType:
+    | "human"
+    | "workflow"
+    | "system"
+    | "api_client"
+    | "connector"
+    | "executor"
+    | "agent";
+  readonly displayName?: string;
+}
+
+export interface RunRequestWorkItem {
+  readonly workItemId: string;
+  readonly externalId: string;
+  readonly title?: string;
+  readonly url?: string;
+}
+
+export interface RunRequestTarget {
+  readonly targetType: "repository" | "workspace" | "environment" | "manual";
+  readonly targetId: string;
+  readonly externalRef?: string;
+}
+
+export interface RunRequestPolicyContext {
+  readonly policySetId?: string;
+  readonly riskClasses?: readonly string[];
+  readonly requiresApproval?: boolean;
+}
+
+export interface RunRequest {
+  readonly schemaVersion: "eip.run-request.v1";
+  readonly id: string;
+  readonly correlationId: string;
+  readonly idempotencyKey: string;
+  readonly source: RunRequestSource;
+  readonly requestedBy: RunRequestActor;
+  readonly workItem: RunRequestWorkItem;
+  readonly mode: "plan" | "apply" | "validate";
+  readonly createdAt: string;
+  readonly target?: RunRequestTarget;
+  readonly policyContext?: RunRequestPolicyContext;
+  readonly dataClassification?: "public" | "internal" | "confidential" | "restricted";
+  readonly extensions?: Record<string, unknown>;
+}
+
+export interface RunRequestValidationIssue {
+  readonly path: string;
+  readonly message: string;
+}
+
+export interface RunRequestValidationSuccess {
+  readonly ok: true;
+  readonly request: RunRequest;
+}
+
+export interface RunRequestValidationFailure {
+  readonly ok: false;
+  readonly issues: readonly RunRequestValidationIssue[];
+}
+
+export type RunRequestValidationResult =
+  | RunRequestValidationSuccess
+  | RunRequestValidationFailure;
+
+export class RunRequestValidationError extends Error {
+  readonly issues: readonly RunRequestValidationIssue[];
+
+  constructor(issues: readonly RunRequestValidationIssue[]) {
+    super(
+      `RunRequest is malformed: ${issues
+        .map((issue) => `${issue.path}: ${issue.message}`)
+        .join("; ")}`,
+    );
+    this.name = "RunRequestValidationError";
+    this.issues = issues;
+  }
+}
+
+const topLevelKeys = new Set([
+  "schemaVersion",
+  "id",
+  "correlationId",
+  "idempotencyKey",
+  "source",
+  "requestedBy",
+  "workItem",
+  "mode",
+  "createdAt",
+  "target",
+  "policyContext",
+  "dataClassification",
+  "extensions",
+]);
+const sourceKeys = new Set(["sourceId", "sourceType", "externalRef"]);
+const actorKeys = new Set(["actorId", "actorType", "displayName"]);
+const workItemKeys = new Set(["workItemId", "externalId", "title", "url"]);
+const targetKeys = new Set(["targetType", "targetId", "externalRef"]);
+const policyContextKeys = new Set(["policySetId", "riskClasses", "requiresApproval"]);
+
+const prefixedIdPattern =
+  /^(?:actor|artifact|corr|cr|evb|evt|flowstep|policy|pr|repo|req|run|source|sts|workitem)_[A-Za-z0-9][A-Za-z0-9._~-]{5,127}$/;
+const correlationIdPattern = /^corr_[A-Za-z0-9][A-Za-z0-9._~-]{11,127}$/;
+const idempotencyKeyPattern = /^[A-Za-z0-9][A-Za-z0-9._:-]{11,159}$/;
+const sourceTypePattern = /^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$/;
+const isoDateTimeUtcPattern = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z$/;
+const httpsUrlPattern = /^https:\/\/[^\s]+$/;
+const riskClassPattern = /^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$/;
+const extensionKeyPattern = /^x-.+$/;
+
+const modes = new Set<unknown>(["plan", "apply", "validate"]);
+const actorTypes = new Set<unknown>([
+  "human",
+  "workflow",
+  "system",
+  "api_client",
+  "connector",
+  "executor",
+  "agent",
+]);
+const targetTypes = new Set<unknown>([
+  "repository",
+  "workspace",
+  "environment",
+  "manual",
+]);
+const dataClassifications = new Set<unknown>([
+  "public",
+  "internal",
+  "confidential",
+  "restricted",
+]);
+
+export function validateRunRequest(value: unknown): RunRequestValidationResult {
+  const issues = collectRunRequestIssues(value);
+
+  if (issues.length > 0) {
+    return {
+      ok: false,
+      issues,
+    };
+  }
+
+  return {
+    ok: true,
+    request: value as RunRequest,
+  };
+}
+
+export function parseRunRequest(value: unknown): RunRequest {
+  const result = validateRunRequest(value);
+
+  if (!result.ok) {
+    throw new RunRequestValidationError(result.issues);
+  }
+
+  return result.request;
+}
+
+function collectRunRequestIssues(value: unknown): readonly RunRequestValidationIssue[] {
+  if (!isRecord(value)) {
+    return [
+      {
+        path: "$",
+        message: "RunRequest input must be a JSON object.",
+      },
+    ];
+  }
+
+  const issues: RunRequestValidationIssue[] = [];
+  collectUnknownKeyIssues(issues, value, topLevelKeys, "$");
+
+  collectConstIssue(issues, "schemaVersion", value.schemaVersion, "eip.run-request.v1");
+  collectPatternIssue(issues, "id", value.id, prefixedIdPattern, "id must be a valid EIP prefixed id.");
+  collectPatternIssue(
+    issues,
+    "correlationId",
+    value.correlationId,
+    correlationIdPattern,
+    "correlationId must be a valid EIP correlation id.",
+  );
+  collectStringLengthPatternIssue(
+    issues,
+    "idempotencyKey",
+    value.idempotencyKey,
+    12,
+    160,
+    idempotencyKeyPattern,
+    "idempotencyKey must be 12-160 characters and match the EIP idempotency key pattern.",
+  );
+  collectSourceIssues(issues, value.source);
+  collectActorIssues(issues, value.requestedBy);
+  collectWorkItemIssues(issues, value.workItem);
+  collectEnumIssue(issues, "mode", value.mode, modes, "mode must be one of: plan, apply, validate.");
+  collectPatternIssue(
+    issues,
+    "createdAt",
+    value.createdAt,
+    isoDateTimeUtcPattern,
+    "createdAt must be an ISO 8601 UTC timestamp ending in Z.",
+  );
+  collectTargetIssues(issues, value.target);
+  collectPolicyContextIssues(issues, value.policyContext);
+  collectEnumIssue(
+    issues,
+    "dataClassification",
+    value.dataClassification,
+    dataClassifications,
+    "dataClassification must be one of: public, internal, confidential, restricted.",
+    true,
+  );
+  collectExtensionsIssues(issues, value.extensions);
+
+  return issues;
+}
+
+function collectSourceIssues(
+  issues: RunRequestValidationIssue[],
+  value: unknown,
+): void {
+  if (!isRecord(value)) {
+    issues.push({
+      path: "source",
+      message: "source must be a JSON object.",
+    });
+    return;
+  }
+
+  collectUnknownKeyIssues(issues, value, sourceKeys, "source");
+  collectPatternIssue(
+    issues,
+    "source.sourceId",
+    value.sourceId,
+    prefixedIdPattern,
+    "sourceId must be a valid EIP prefixed id.",
+  );
+  collectStringLengthPatternIssue(
+    issues,
+    "source.sourceType",
+    value.sourceType,
+    1,
+    80,
+    sourceTypePattern,
+    "sourceType must be 1-80 lowercase kebab-case characters.",
+  );
+  collectOptionalStringLengthIssue(issues, "source.externalRef", value.externalRef, 1, 240);
+}
+
+function collectActorIssues(
+  issues: RunRequestValidationIssue[],
+  value: unknown,
+): void {
+  if (!isRecord(value)) {
+    issues.push({
+      path: "requestedBy",
+      message: "requestedBy must be a JSON object.",
+    });
+    return;
+  }
+
+  collectUnknownKeyIssues(issues, value, actorKeys, "requestedBy");
+  collectPatternIssue(
+    issues,
+    "requestedBy.actorId",
+    value.actorId,
+    prefixedIdPattern,
+    "actorId must be a valid EIP prefixed id.",
+  );
+  collectEnumIssue(
+    issues,
+    "requestedBy.actorType",
+    value.actorType,
+    actorTypes,
+    "actorType must be one of: human, workflow, system, api_client, connector, executor, agent.",
+  );
+  collectOptionalStringLengthIssue(issues, "requestedBy.displayName", value.displayName, 1, 160);
+}
+
+function collectWorkItemIssues(
+  issues: RunRequestValidationIssue[],
+  value: unknown,
+): void {
+  if (!isRecord(value)) {
+    issues.push({
+      path: "workItem",
+      message: "workItem must be a JSON object.",
+    });
+    return;
+  }
+
+  collectUnknownKeyIssues(issues, value, workItemKeys, "workItem");
+  collectPatternIssue(
+    issues,
+    "workItem.workItemId",
+    value.workItemId,
+    prefixedIdPattern,
+    "workItemId must be a valid EIP prefixed id.",
+  );
+  collectStringLengthIssue(issues, "workItem.externalId", value.externalId, 1, 240);
+  collectOptionalStringLengthIssue(issues, "workItem.title", value.title, 1, 240);
+
+  if (value.url !== undefined) {
+    collectStringLengthPatternIssue(
+      issues,
+      "workItem.url",
+      value.url,
+      1,
+      400,
+      httpsUrlPattern,
+      "url must be an HTTPS URL.",
+    );
+  }
+}
+
+function collectTargetIssues(
+  issues: RunRequestValidationIssue[],
+  value: unknown,
+): void {
+  if (value === undefined) {
+    return;
+  }
+
+  if (!isRecord(value)) {
+    issues.push({
+      path: "target",
+      message: "target must be a JSON object.",
+    });
+    return;
+  }
+
+  collectUnknownKeyIssues(issues, value, targetKeys, "target");
+  collectEnumIssue(
+    issues,
+    "target.targetType",
+    value.targetType,
+    targetTypes,
+    "targetType must be one of: repository, workspace, environment, manual.",
+  );
+  collectPatternIssue(
+    issues,
+    "target.targetId",
+    value.targetId,
+    prefixedIdPattern,
+    "targetId must be a valid EIP prefixed id.",
+  );
+  collectOptionalStringLengthIssue(issues, "target.externalRef", value.externalRef, 1, 240);
+}
+
+function collectPolicyContextIssues(
+  issues: RunRequestValidationIssue[],
+  value: unknown,
+): void {
+  if (value === undefined) {
+    return;
+  }
+
+  if (!isRecord(value)) {
+    issues.push({
+      path: "policyContext",
+      message: "policyContext must be a JSON object.",
+    });
+    return;
+  }
+
+  collectUnknownKeyIssues(issues, value, policyContextKeys, "policyContext");
+
+  if (value.policySetId !== undefined) {
+    collectPatternIssue(
+      issues,
+      "policyContext.policySetId",
+      value.policySetId,
+      prefixedIdPattern,
+      "policySetId must be a valid EIP prefixed id.",
+    );
+  }
+
+  if (value.riskClasses !== undefined) {
+    if (!Array.isArray(value.riskClasses)) {
+      issues.push({
+        path: "policyContext.riskClasses",
+        message: "riskClasses must be an array.",
+      });
+    } else {
+      if (value.riskClasses.length > 20) {
+        issues.push({
+          path: "policyContext.riskClasses",
+          message: "riskClasses must contain at most 20 items.",
+        });
+      }
+
+      const seen = new Set<string>();
+      for (const [index, riskClass] of value.riskClasses.entries()) {
+        collectStringLengthPatternIssue(
+          issues,
+          `policyContext.riskClasses.${index}`,
+          riskClass,
+          1,
+          80,
+          riskClassPattern,
+          "risk class must be 1-80 lowercase kebab-case characters.",
+        );
+
+        if (typeof riskClass === "string") {
+          if (seen.has(riskClass)) {
+            issues.push({
+              path: `policyContext.riskClasses.${index}`,
+              message: "riskClasses entries must be unique.",
+            });
+          }
+          seen.add(riskClass);
+        }
+      }
+    }
+  }
+
+  if (value.requiresApproval !== undefined && typeof value.requiresApproval !== "boolean") {
+    issues.push({
+      path: "policyContext.requiresApproval",
+      message: "requiresApproval must be a boolean.",
+    });
+  }
+}
+
+function collectExtensionsIssues(
+  issues: RunRequestValidationIssue[],
+  value: unknown,
+): void {
+  if (value === undefined) {
+    return;
+  }
+
+  if (!isRecord(value)) {
+    issues.push({
+      path: "extensions",
+      message: "extensions must be a JSON object.",
+    });
+    return;
+  }
+
+  for (const key of Object.keys(value)) {
+    if (!extensionKeyPattern.test(key)) {
+      issues.push({
+        path: `extensions.${key}`,
+        message: "extension keys must start with x-.",
+      });
+    }
+  }
+}
+
+function collectUnknownKeyIssues(
+  issues: RunRequestValidationIssue[],
+  value: Record<string, unknown>,
+  allowedKeys: ReadonlySet<string>,
+  basePath: string,
+): void {
+  for (const key of Object.keys(value)) {
+    if (!allowedKeys.has(key)) {
+      issues.push({
+        path: basePath === "$" ? key : `${basePath}.${key}`,
+        message: "field is not part of the RunRequest v1 contract.",
+      });
+    }
+  }
+}
+
+function collectConstIssue(
+  issues: RunRequestValidationIssue[],
+  path: string,
+  value: unknown,
+  expected: string,
+): void {
+  if (value !== expected) {
+    issues.push({
+      path,
+      message: `${path} must be ${expected}.`,
+    });
+  }
+}
+
+function collectEnumIssue(
+  issues: RunRequestValidationIssue[],
+  path: string,
+  value: unknown,
+  allowed: ReadonlySet<unknown>,
+  message: string,
+  optional = false,
+): void {
+  if (value === undefined && optional) {
+    return;
+  }
+
+  if (!allowed.has(value)) {
+    issues.push({
+      path,
+      message,
+    });
+  }
+}
+
+function collectPatternIssue(
+  issues: RunRequestValidationIssue[],
+  path: string,
+  value: unknown,
+  pattern: RegExp,
+  message: string,
+): void {
+  if (typeof value !== "string" || !pattern.test(value)) {
+    issues.push({
+      path,
+      message,
+    });
+  }
+}
+
+function collectStringLengthIssue(
+  issues: RunRequestValidationIssue[],
+  path: string,
+  value: unknown,
+  minLength: number,
+  maxLength: number,
+): void {
+  if (typeof value !== "string" || value.length < minLength || value.length > maxLength) {
+    issues.push({
+      path,
+      message: `${path.split(".").at(-1) ?? path} must be ${minLength}-${maxLength} characters.`,
+    });
+  }
+}
+
+function collectOptionalStringLengthIssue(
+  issues: RunRequestValidationIssue[],
+  path: string,
+  value: unknown,
+  minLength: number,
+  maxLength: number,
+): void {
+  if (value === undefined) {
+    return;
+  }
+
+  collectStringLengthIssue(issues, path, value, minLength, maxLength);
+}
+
+function collectStringLengthPatternIssue(
+  issues: RunRequestValidationIssue[],
+  path: string,
+  value: unknown,
+  minLength: number,
+  maxLength: number,
+  pattern: RegExp,
+  message: string,
+): void {
+  if (
+    typeof value !== "string" ||
+    value.length < minLength ||
+    value.length > maxLength ||
+    !pattern.test(value)
+  ) {
+    issues.push({
+      path,
+      message,
+    });
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return false;
+  }
+
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}

--- a/src/protocol/run-request.ts
+++ b/src/protocol/run-request.ts
@@ -112,10 +112,12 @@ const actorIdPattern = /^actor_[A-Za-z0-9][A-Za-z0-9._~-]{5,127}$/;
 const workItemIdPattern = /^workitem_[A-Za-z0-9][A-Za-z0-9._~-]{5,127}$/;
 const repositoryIdPattern = /^repo_[A-Za-z0-9][A-Za-z0-9._~-]{5,127}$/;
 const policyIdPattern = /^policy_[A-Za-z0-9][A-Za-z0-9._~-]{5,127}$/;
+const prefixedIdPattern =
+  /^(?:actor|artifact|corr|cr|evb|evt|flowstep|policy|pr|repo|req|run|source|sts|workitem)_[A-Za-z0-9][A-Za-z0-9._~-]{5,127}$/;
 const correlationIdPattern = /^corr_[A-Za-z0-9][A-Za-z0-9._~-]{11,127}$/;
 const idempotencyKeyPattern = /^[A-Za-z0-9][A-Za-z0-9._:-]{11,159}$/;
-const sourceTypePattern = /^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$/;
 const isoDateTimeUtcPattern = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z$/;
+const sourceTypePattern = /^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$/;
 const riskClassPattern = /^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$/;
 const extensionKeyPattern = /^x-.+$/;
 
@@ -203,13 +205,7 @@ function collectRunRequestIssues(value: unknown): readonly RunRequestValidationI
   collectActorIssues(issues, value.requestedBy);
   collectWorkItemIssues(issues, value.workItem);
   collectEnumIssue(issues, "mode", value.mode, modes, "mode must be one of: plan, apply, validate.");
-  collectPatternIssue(
-    issues,
-    "createdAt",
-    value.createdAt,
-    isoDateTimeUtcPattern,
-    "createdAt must be an ISO 8601 UTC timestamp ending in Z.",
-  );
+  collectUtcTimestampIssue(issues, "createdAt", value.createdAt);
   collectTargetIssues(issues, value.target);
   collectPolicyContextIssues(issues, value.policyContext);
   collectEnumIssue(
@@ -339,13 +335,7 @@ function collectTargetIssues(
     targetTypes,
     "targetType must be one of: repository, workspace, environment, manual.",
   );
-  collectPatternIssue(
-    issues,
-    "target.targetId",
-    value.targetId,
-    repositoryIdPattern,
-    "targetId must be a valid EIP repository id.",
-  );
+  collectTargetIdIssue(issues, value.targetType, value.targetId);
   collectOptionalStringLengthIssue(issues, "target.externalRef", value.externalRef, 1, 240);
 }
 
@@ -566,6 +556,37 @@ function collectStringLengthPatternIssue(
   }
 }
 
+function collectUtcTimestampIssue(
+  issues: RunRequestValidationIssue[],
+  path: string,
+  value: unknown,
+): void {
+  if (typeof value !== "string" || !isIsoDateTimeUtc(value)) {
+    issues.push({
+      path,
+      message: `${path} must be a valid ISO 8601 UTC timestamp ending in Z.`,
+    });
+  }
+}
+
+function collectTargetIdIssue(
+  issues: RunRequestValidationIssue[],
+  targetType: unknown,
+  value: unknown,
+): void {
+  const isRepository = targetType === "repository";
+
+  collectPatternIssue(
+    issues,
+    "target.targetId",
+    value,
+    isRepository ? repositoryIdPattern : prefixedIdPattern,
+    isRepository
+      ? "targetId must be a valid EIP repository id."
+      : "targetId must be a valid EIP target id.",
+  );
+}
+
 function collectHttpsUrlIssue(
   issues: RunRequestValidationIssue[],
   path: string,
@@ -585,6 +606,30 @@ function collectHttpsUrlIssue(
       message: "url must be an HTTPS URL.",
     });
   }
+}
+
+function isIsoDateTimeUtc(value: string): boolean {
+  const match = isoDateTimeUtcPattern.exec(value);
+  if (!match) {
+    return false;
+  }
+
+  const timestamp = Date.parse(value);
+  if (Number.isNaN(timestamp)) {
+    return false;
+  }
+
+  const fraction = value.match(/\.(\d+)Z$/)?.[1];
+  if (fraction !== undefined && fraction.length > 3) {
+    return false;
+  }
+
+  const normalized =
+    fraction === undefined
+      ? value.replace(/Z$/, ".000Z")
+      : value.replace(/\.(\d+)Z$/, `.${fraction.padEnd(3, "0")}Z`);
+
+  return new Date(timestamp).toISOString() === normalized;
 }
 
 function isHttpsUrl(value: string): boolean {

--- a/test/run-request-input.test.ts
+++ b/test/run-request-input.test.ts
@@ -35,6 +35,18 @@ async function readJson(filePath: string): Promise<unknown> {
   return JSON.parse(await readFile(filePath, "utf8")) as unknown;
 }
 
+function assertRecord(value: unknown, label: string): asserts value is Record<string, unknown> {
+  assert.equal(typeof value, "object", `${label} must be an object`);
+  assert.notEqual(value, null, `${label} must not be null`);
+  assert.equal(Array.isArray(value), false, `${label} must not be an array`);
+}
+
+function childRecord(parent: Record<string, unknown>, key: string): Record<string, unknown> {
+  const value = parent[key];
+  assertRecord(value, key);
+  return value;
+}
+
 test("accepts vendored RunRequest v1 valid fixtures", async () => {
   const fixturePaths = await listJsonFixtures("valid");
 
@@ -59,6 +71,95 @@ test("rejects vendored RunRequest v1 invalid fixtures with actionable diagnostic
     assert.ok(
       result.issues.every((issue) => issue.path.length > 0 && issue.message.length > 0),
       `${fixturePath} diagnostics must identify paths and messages`,
+    );
+  }
+});
+
+test("rejects semantically wrong RunRequest id prefixes", async () => {
+  const fixture = path.join(runRequestFixtureRoot, "valid", "github-issue-request.json");
+  const base = await readJson(fixture);
+  assertRecord(base, "fixture");
+
+  const cases: readonly {
+    readonly name: string;
+    readonly mutate: (request: Record<string, unknown>) => void;
+    readonly path: string;
+  }[] = [
+    {
+      name: "request id",
+      mutate: (request) => {
+        request.id = "actor_01HV7Y8M8F2KQ5W3P9R6T4N2AB";
+      },
+      path: "id",
+    },
+    {
+      name: "source id",
+      mutate: (request) => {
+        childRecord(request, "source").sourceId = "repo_01HV7Y8M8F2KQ5W3P9R6T4N2AD";
+      },
+      path: "source.sourceId",
+    },
+    {
+      name: "actor id",
+      mutate: (request) => {
+        childRecord(request, "requestedBy").actorId = "repo_01HV7Y8M8F2KQ5W3P9R6T4N2AE";
+      },
+      path: "requestedBy.actorId",
+    },
+    {
+      name: "work item id",
+      mutate: (request) => {
+        childRecord(request, "workItem").workItemId = "actor_01HV7Y8M8F2KQ5W3P9R6T4N2AF";
+      },
+      path: "workItem.workItemId",
+    },
+    {
+      name: "target id",
+      mutate: (request) => {
+        childRecord(request, "target").targetId = "actor_01HV7Y8M8F2KQ5W3P9R6T4N2AG";
+      },
+      path: "target.targetId",
+    },
+    {
+      name: "policy set id",
+      mutate: (request) => {
+        childRecord(request, "policyContext").policySetId = "repo_01HV7Y8M8F2KQ5W3P9R6T4N2AH";
+      },
+      path: "policyContext.policySetId",
+    },
+  ];
+
+  for (const testCase of cases) {
+    const request = structuredClone(base);
+    assertRecord(request, testCase.name);
+    testCase.mutate(request);
+
+    const result = validateRunRequest(request);
+
+    assert.equal(result.ok, false, `${testCase.name} must be rejected`);
+    assert.ok(
+      result.issues.some((issue) => issue.path === testCase.path),
+      `${testCase.name} must include a ${testCase.path} diagnostic`,
+    );
+  }
+});
+
+test("rejects malformed and non-HTTPS RunRequest work item URLs", async () => {
+  const fixture = path.join(runRequestFixtureRoot, "valid", "github-issue-request.json");
+  const base = await readJson(fixture);
+  assertRecord(base, "fixture");
+
+  for (const url of ["https:///repo", "https://?q=1", "http://example.com", " https://example.com"]) {
+    const request = structuredClone(base);
+    assertRecord(request, "request");
+    childRecord(request, "workItem").url = url;
+
+    const result = validateRunRequest(request);
+
+    assert.equal(result.ok, false, `${url} must be rejected`);
+    assert.ok(
+      result.issues.some((issue) => issue.path === "workItem.url"),
+      `${url} must include a workItem.url diagnostic`,
     );
   }
 });

--- a/test/run-request-input.test.ts
+++ b/test/run-request-input.test.ts
@@ -144,6 +144,66 @@ test("rejects semantically wrong RunRequest id prefixes", async () => {
   }
 });
 
+test("rejects impossible RunRequest createdAt timestamps", async () => {
+  const fixture = path.join(runRequestFixtureRoot, "valid", "github-issue-request.json");
+  const base = await readJson(fixture);
+  assertRecord(base, "fixture");
+
+  for (const createdAt of [
+    "2026-13-40T25:61:61Z",
+    "2026-04-31T00:00:00Z",
+    "2026-04-29T01:45:45.1234Z",
+  ]) {
+    const request = structuredClone(base);
+    assertRecord(request, "request");
+    request.createdAt = createdAt;
+
+    const result = validateRunRequest(request);
+
+    assert.equal(result.ok, false, `${createdAt} must be rejected`);
+    assert.ok(
+      result.issues.some((issue) => issue.path === "createdAt"),
+      `${createdAt} must include a createdAt diagnostic`,
+    );
+  }
+});
+
+test("accepts non-repository RunRequest targets with protocol prefixed ids", async () => {
+  const fixture = path.join(runRequestFixtureRoot, "valid", "github-issue-request.json");
+  const base = await readJson(fixture);
+  assertRecord(base, "fixture");
+
+  const cases: readonly {
+    readonly targetType: "workspace" | "environment" | "manual";
+    readonly targetId: string;
+  }[] = [
+    {
+      targetType: "workspace",
+      targetId: "source_01HV7Y8M8F2KQ5W3P9R6T4N2WA",
+    },
+    {
+      targetType: "environment",
+      targetId: "sts_01HV7Y8M8F2KQ5W3P9R6T4N2EA",
+    },
+    {
+      targetType: "manual",
+      targetId: "req_01HV7Y8M8F2KQ5W3P9R6T4N2MA",
+    },
+  ];
+
+  for (const testCase of cases) {
+    const request = structuredClone(base);
+    assertRecord(request, "request");
+    const target = childRecord(request, "target");
+    target.targetType = testCase.targetType;
+    target.targetId = testCase.targetId;
+
+    const result = validateRunRequest(request);
+
+    assert.equal(result.ok, true, `${testCase.targetType} target must be accepted`);
+  }
+});
+
 test("rejects malformed and non-HTTPS RunRequest work item URLs", async () => {
   const fixture = path.join(runRequestFixtureRoot, "valid", "github-issue-request.json");
   const base = await readJson(fixture);

--- a/test/run-request-input.test.ts
+++ b/test/run-request-input.test.ts
@@ -1,0 +1,109 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { readdir, readFile } from "node:fs/promises";
+import path from "node:path";
+import test from "node:test";
+import { promisify } from "node:util";
+
+import {
+  parseRunRequest,
+  validateRunRequest,
+} from "../src/protocol/run-request.js";
+
+const execFileAsync = promisify(execFile);
+const runRequestFixtureRoot = path.join(
+  "protocol-snapshots",
+  "ensen-protocol",
+  "v0.1.0",
+  "fixtures",
+  "run-request",
+  "v1",
+);
+
+async function listJsonFixtures(kind: "valid" | "invalid"): Promise<string[]> {
+  const entries = await readdir(path.join(runRequestFixtureRoot, kind), {
+    withFileTypes: true,
+  });
+
+  return entries
+    .filter((entry) => entry.isFile() && entry.name.endsWith(".json"))
+    .map((entry) => path.join(runRequestFixtureRoot, kind, entry.name))
+    .sort();
+}
+
+async function readJson(filePath: string): Promise<unknown> {
+  return JSON.parse(await readFile(filePath, "utf8")) as unknown;
+}
+
+test("accepts vendored RunRequest v1 valid fixtures", async () => {
+  const fixturePaths = await listJsonFixtures("valid");
+
+  for (const fixturePath of fixturePaths) {
+    const request = parseRunRequest(await readJson(fixturePath));
+
+    assert.equal(request.schemaVersion, "eip.run-request.v1");
+    assert.match(request.id, /^req_/);
+    assert.equal(typeof request.source.sourceType, "string");
+    assert.equal(typeof request.workItem.externalId, "string");
+  }
+});
+
+test("rejects vendored RunRequest v1 invalid fixtures with actionable diagnostics", async () => {
+  const fixturePaths = await listJsonFixtures("invalid");
+
+  for (const fixturePath of fixturePaths) {
+    const result = validateRunRequest(await readJson(fixturePath));
+
+    assert.equal(result.ok, false, `${fixturePath} must be rejected`);
+    assert.ok(result.issues.length > 0, `${fixturePath} must include diagnostics`);
+    assert.ok(
+      result.issues.every((issue) => issue.path.length > 0 && issue.message.length > 0),
+      `${fixturePath} diagnostics must identify paths and messages`,
+    );
+  }
+});
+
+test("CLI reports accepted or rejected RunRequest files", async () => {
+  const validFixture = path.join(runRequestFixtureRoot, "valid", "manual-request.json");
+  const invalidFixture = path.join(runRequestFixtureRoot, "invalid", "source-string.json");
+
+  const accepted = await execFileAsync(process.execPath, [
+    "dist/src/cli/index.js",
+    "run-request",
+    validFixture,
+  ]);
+  assert.equal(accepted.stderr, "");
+  assert.deepEqual(JSON.parse(accepted.stdout) as unknown, {
+    ok: true,
+    request: parseRunRequest(await readJson(validFixture)),
+  });
+
+  await assert.rejects(
+    execFileAsync(process.execPath, [
+      "dist/src/cli/index.js",
+      "run-request",
+      invalidFixture,
+    ]),
+    (error: unknown) => {
+      assert.ok(error && typeof error === "object");
+      assert.ok("code" in error);
+      assert.equal(error.code, 1);
+      assert.ok("stdout" in error && typeof error.stdout === "string");
+
+      const rejected = JSON.parse(error.stdout) as {
+        ok: boolean;
+        issues: readonly { path: string; message: string }[];
+      };
+
+      assert.equal(rejected.ok, false);
+      assert.deepEqual(rejected.issues, [
+        {
+          path: "source",
+          message: "source must be a JSON object.",
+        },
+      ]);
+
+      return true;
+    },
+  );
+});


### PR DESCRIPTION
## Summary
- add standalone EIP RunRequest v1 parser/validator for the vendored protocol snapshot
- expose `run-request <run-request-json-file>` CLI JSON output for accepted and rejected inputs
- document the minimal command and keep `source` as protocol data, not trusted authority

## Verification
- `npm run typecheck`
- `npm run build`
- `npm test`

Closes #22

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a CLI subcommand to validate EIP RunRequest v1 JSON files, producing structured success/failure output and appropriate exit codes.

* **Documentation**
  * README updated with run-request usage examples, observed validation output shapes, note that source is untrusted, and scope of RunRequest vs RunResult support.

* **Improvements**
  * Clearer CLI error handling and consistent non-zero exit behavior; uncaught errors emit structured JSON.

* **Tests**
  * Added test suite covering RunRequest validation and CLI behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->