### PR TITLE
LOOP-012: Add normalized RunRequest execution plans

### DIFF
--- a/src/protocol/run-request.ts
+++ b/src/protocol/run-request.ts
@@ -249,7 +249,7 @@ export function createRunRequestExecutionPlan(request: RunRequest): RunRequestEx
       idempotencyKey: request.idempotencyKey,
       schemaVersion: request.schemaVersion,
       createdAt: request.createdAt,
-      source: request.source,
+      source: { ...request.source },
     },
     workItem: {
       id: request.workItem.workItemId,
@@ -299,7 +299,7 @@ function createRunRequestIdentity(
   request: RunRequest,
 ): RunRequestExecutionPlan["requestIdentity"] {
   const identity: RunRequestExecutionPlan["requestIdentity"] = {
-    requestedBy: request.requestedBy,
+    requestedBy: { ...request.requestedBy },
     workItemExternalId: request.workItem.externalId,
   };
 
@@ -324,7 +324,7 @@ function collectBoundedInputFacts(
   pushOptionalFact(facts, "target.externalRef", request.target?.externalRef);
 
   for (const [key, value] of Object.entries(request.extensions ?? {}).sort(([left], [right]) =>
-    left.localeCompare(right),
+    compareCodePoints(left, right),
   )) {
     pushOptionalFact(facts, `extensions.${key}`, value);
   }
@@ -359,7 +359,7 @@ function createLaneWorkspacePlan(
   if (request.target !== undefined) {
     return {
       ...plan,
-      target: request.target,
+      target: { ...request.target },
     };
   }
 
@@ -371,9 +371,17 @@ function createPolicyPlan(request: RunRequest): RunRequestExecutionPlan["policy"
     intent: "record policy hints without granting execution authority",
     trustedAuthority: false,
     policySetId: request.policyContext?.policySetId,
-    riskClasses: request.policyContext?.riskClasses ?? [],
+    riskClasses: [...(request.policyContext?.riskClasses ?? [])],
     requiresApproval: request.policyContext?.requiresApproval ?? false,
   };
+}
+
+function compareCodePoints(left: string, right: string): number {
+  if (left === right) {
+    return 0;
+  }
+
+  return left < right ? -1 : 1;
 }
 
 function collectRunRequestIssues(value: unknown): readonly RunRequestValidationIssue[] {

--- a/src/protocol/run-request.ts
+++ b/src/protocol/run-request.ts
@@ -57,6 +57,69 @@ export interface RunRequestValidationIssue {
   readonly message: string;
 }
 
+export interface BoundedRunRequestInputFact {
+  readonly name: string;
+  readonly value: unknown;
+  readonly trustedAuthority: false;
+}
+
+export interface RunRequestExecutionPlan {
+  readonly command: "run-request";
+  readonly mode: RunRequest["mode"];
+  readonly source: "eip.run-request";
+  readonly status: "ready" | "blocked";
+  readonly blockedReasons: readonly string[];
+  readonly provenance: {
+    readonly requestId: string;
+    readonly correlationId: string;
+    readonly idempotencyKey: string;
+    readonly schemaVersion: RunRequest["schemaVersion"];
+    readonly createdAt: string;
+    readonly source: RunRequestSource;
+  };
+  readonly workItem: {
+    readonly id: string;
+    readonly title: string;
+    readonly source: string;
+    readonly status: "ready" | "blocked";
+  };
+  readonly requestIdentity: {
+    readonly requestedBy: RunRequestActor;
+    readonly workItemExternalId: string;
+    readonly workItemUrl?: string;
+  };
+  readonly boundedInputFacts: readonly BoundedRunRequestInputFact[];
+  readonly laneWorkspace: {
+    readonly intent: string;
+    readonly mutatesFilesystem: false;
+    readonly target?: RunRequestTarget;
+  };
+  readonly agentProvider: {
+    readonly intent: string;
+    readonly invokesProvider: false;
+  };
+  readonly scmProvider: {
+    readonly intent: string;
+    readonly createsBranch: false;
+    readonly opensChangeRequest: false;
+  };
+  readonly policy: {
+    readonly intent: string;
+    readonly trustedAuthority: false;
+    readonly policySetId?: string;
+    readonly riskClasses: readonly string[];
+    readonly requiresApproval: boolean;
+  };
+  readonly verification: {
+    readonly intent: string;
+    readonly commands: readonly string[];
+  };
+  readonly evidence: {
+    readonly intent: string;
+    readonly writesDurableEvidence: false;
+  };
+}
+
 export interface RunRequestValidationSuccess {
   readonly ok: true;
   readonly request: RunRequest;
@@ -168,6 +231,149 @@ export function parseRunRequest(value: unknown): RunRequest {
   }
 
   return result.request;
+}
+
+export function createRunRequestExecutionPlan(request: RunRequest): RunRequestExecutionPlan {
+  const blockedReasons = collectRunRequestPlanBlockedReasons(request);
+  const status = blockedReasons.length === 0 ? "ready" : "blocked";
+
+  return {
+    command: "run-request",
+    mode: request.mode,
+    source: "eip.run-request",
+    status,
+    blockedReasons,
+    provenance: {
+      requestId: request.id,
+      correlationId: request.correlationId,
+      idempotencyKey: request.idempotencyKey,
+      schemaVersion: request.schemaVersion,
+      createdAt: request.createdAt,
+      source: request.source,
+    },
+    workItem: {
+      id: request.workItem.workItemId,
+      title: request.workItem.title ?? request.workItem.externalId,
+      source: `eip.run-request:${request.source.sourceType}`,
+      status,
+    },
+    requestIdentity: createRunRequestIdentity(request),
+    boundedInputFacts: collectBoundedInputFacts(request),
+    laneWorkspace: createLaneWorkspacePlan(request),
+    agentProvider: {
+      intent: "normalize agent intent without invoking a provider",
+      invokesProvider: false,
+    },
+    scmProvider: {
+      intent: "normalize repository intent without creating branches, commits, or change requests",
+      createsBranch: false,
+      opensChangeRequest: false,
+    },
+    policy: createPolicyPlan(request),
+    verification: {
+      intent: "normalize verification intent without running checks",
+      commands: [],
+    },
+    evidence: {
+      intent: "normalize evidence intent without writing durable evidence",
+      writesDurableEvidence: false,
+    },
+  };
+}
+
+function collectRunRequestPlanBlockedReasons(request: RunRequest): readonly string[] {
+  const reasons: string[] = [];
+
+  if (request.target === undefined) {
+    reasons.push("target is required before execution can be planned");
+  }
+
+  if (request.policyContext === undefined) {
+    reasons.push("policyContext is required before execution can be planned");
+  }
+
+  return reasons;
+}
+
+function createRunRequestIdentity(
+  request: RunRequest,
+): RunRequestExecutionPlan["requestIdentity"] {
+  const identity: RunRequestExecutionPlan["requestIdentity"] = {
+    requestedBy: request.requestedBy,
+    workItemExternalId: request.workItem.externalId,
+  };
+
+  if (request.workItem.url !== undefined) {
+    return {
+      ...identity,
+      workItemUrl: request.workItem.url,
+    };
+  }
+
+  return identity;
+}
+
+function collectBoundedInputFacts(
+  request: RunRequest,
+): readonly BoundedRunRequestInputFact[] {
+  const facts: BoundedRunRequestInputFact[] = [];
+
+  pushOptionalFact(facts, "source.externalRef", request.source.externalRef);
+  pushOptionalFact(facts, "workItem.externalId", request.workItem.externalId);
+  pushOptionalFact(facts, "workItem.url", request.workItem.url);
+  pushOptionalFact(facts, "target.externalRef", request.target?.externalRef);
+
+  for (const [key, value] of Object.entries(request.extensions ?? {}).sort(([left], [right]) =>
+    left.localeCompare(right),
+  )) {
+    pushOptionalFact(facts, `extensions.${key}`, value);
+  }
+
+  return facts;
+}
+
+function pushOptionalFact(
+  facts: BoundedRunRequestInputFact[],
+  name: string,
+  value: unknown,
+): void {
+  if (value === undefined) {
+    return;
+  }
+
+  facts.push({
+    name,
+    value,
+    trustedAuthority: false,
+  });
+}
+
+function createLaneWorkspacePlan(
+  request: RunRequest,
+): RunRequestExecutionPlan["laneWorkspace"] {
+  const plan: RunRequestExecutionPlan["laneWorkspace"] = {
+    intent: "normalize request scope without preparing a workspace",
+    mutatesFilesystem: false,
+  };
+
+  if (request.target !== undefined) {
+    return {
+      ...plan,
+      target: request.target,
+    };
+  }
+
+  return plan;
+}
+
+function createPolicyPlan(request: RunRequest): RunRequestExecutionPlan["policy"] {
+  return {
+    intent: "record policy hints without granting execution authority",
+    trustedAuthority: false,
+    policySetId: request.policyContext?.policySetId,
+    riskClasses: request.policyContext?.riskClasses ?? [],
+    requiresApproval: request.policyContext?.requiresApproval ?? false,
+  };
 }
 
 function collectRunRequestIssues(value: unknown): readonly RunRequestValidationIssue[] {

--- a/test/run-request-execution-plan.test.ts
+++ b/test/run-request-execution-plan.test.ts
@@ -1,0 +1,148 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import test from "node:test";
+
+import {
+  createRunRequestExecutionPlan,
+  parseRunRequest,
+} from "../src/protocol/index.js";
+
+const runRequestFixtureRoot = path.join(
+  "protocol-snapshots",
+  "ensen-protocol",
+  "v0.1.0",
+  "fixtures",
+  "run-request",
+  "v1",
+  "valid",
+);
+
+async function readRunRequestFixture(name: string) {
+  return parseRunRequest(
+    JSON.parse(await readFile(path.join(runRequestFixtureRoot, name), "utf8")) as unknown,
+  );
+}
+
+test("maps an issue-like RunRequest into a bounded execution plan", async () => {
+  const request = await readRunRequestFixture("github-issue-request.json");
+
+  const plan = createRunRequestExecutionPlan(request);
+
+  assert.deepEqual(plan, {
+    command: "run-request",
+    mode: "plan",
+    source: "eip.run-request",
+    status: "ready",
+    blockedReasons: [],
+    provenance: {
+      requestId: "req_01HV7Y8M8F2KQ5W3P9R6T4N2AB",
+      correlationId: "corr_01HV7Y8M8F2KQ5W3P9R6T4N2AC",
+      idempotencyKey: "github-issue-4",
+      schemaVersion: "eip.run-request.v1",
+      createdAt: "2026-04-29T01:45:45Z",
+      source: {
+        sourceId: "source_01HV7Y8M8F2KQ5W3P9R6T4N2AD",
+        sourceType: "github",
+        externalRef: "TommyKammy/Ensen-protocol",
+      },
+    },
+    workItem: {
+      id: "workitem_01HV7Y8M8F2KQ5W3P9R6T4N2AF",
+      title: "EIP-0001: Define RunRequest v1 schema",
+      source: "eip.run-request:github",
+      status: "ready",
+    },
+    requestIdentity: {
+      requestedBy: {
+        actorId: "actor_01HV7Y8M8F2KQ5W3P9R6T4N2AE",
+        actorType: "api_client",
+        displayName: "Ensen issue dispatcher",
+      },
+      workItemExternalId: "4",
+      workItemUrl: "https://github.com/TommyKammy/Ensen-protocol/issues/4",
+    },
+    boundedInputFacts: [
+      {
+        name: "source.externalRef",
+        value: "TommyKammy/Ensen-protocol",
+        trustedAuthority: false,
+      },
+      {
+        name: "workItem.externalId",
+        value: "4",
+        trustedAuthority: false,
+      },
+      {
+        name: "workItem.url",
+        value: "https://github.com/TommyKammy/Ensen-protocol/issues/4",
+        trustedAuthority: false,
+      },
+      {
+        name: "target.externalRef",
+        value: "TommyKammy/Ensen-protocol",
+        trustedAuthority: false,
+      },
+      {
+        name: "extensions.x-fixture-note",
+        value: "synthetic GitHub issue request",
+        trustedAuthority: false,
+      },
+    ],
+    laneWorkspace: {
+      intent: "normalize request scope without preparing a workspace",
+      mutatesFilesystem: false,
+      target: {
+        targetType: "repository",
+        targetId: "repo_01HV7Y8M8F2KQ5W3P9R6T4N2AG",
+        externalRef: "TommyKammy/Ensen-protocol",
+      },
+    },
+    agentProvider: {
+      intent: "normalize agent intent without invoking a provider",
+      invokesProvider: false,
+    },
+    scmProvider: {
+      intent: "normalize repository intent without creating branches, commits, or change requests",
+      createsBranch: false,
+      opensChangeRequest: false,
+    },
+    policy: {
+      intent: "record policy hints without granting execution authority",
+      trustedAuthority: false,
+      policySetId: "policy_01HV7Y8M8F2KQ5W3P9R6T4N2AH",
+      riskClasses: ["secrets"],
+      requiresApproval: true,
+    },
+    verification: {
+      intent: "normalize verification intent without running checks",
+      commands: [],
+    },
+    evidence: {
+      intent: "normalize evidence intent without writing durable evidence",
+      writesDurableEvidence: false,
+    },
+  });
+});
+
+test("maps incomplete manual RunRequest scope into a blocked plan", async () => {
+  const request = await readRunRequestFixture("manual-request.json");
+
+  const plan = createRunRequestExecutionPlan(request);
+
+  assert.equal(plan.status, "blocked");
+  assert.deepEqual(plan.blockedReasons, [
+    "target is required before execution can be planned",
+    "policyContext is required before execution can be planned",
+  ]);
+  assert.deepEqual(plan.workItem, {
+    id: "workitem_01HV7Y8M8F2KQ5W3P9R6T4N2BE",
+    title: "Review protocol fixture coverage",
+    source: "eip.run-request:manual",
+    status: "blocked",
+  });
+  assert.equal(plan.laneWorkspace.mutatesFilesystem, false);
+  assert.equal(plan.agentProvider.invokesProvider, false);
+  assert.equal(plan.scmProvider.createsBranch, false);
+  assert.equal(plan.evidence.writesDurableEvidence, false);
+});

--- a/test/run-request-execution-plan.test.ts
+++ b/test/run-request-execution-plan.test.ts
@@ -7,6 +7,13 @@ import {
   createRunRequestExecutionPlan,
   parseRunRequest,
 } from "../src/protocol/index.js";
+import type { RunRequest } from "../src/protocol/index.js";
+
+type Mutable<T> = T extends readonly (infer Item)[]
+  ? Mutable<Item>[]
+  : T extends object
+    ? { -readonly [Property in keyof T]: Mutable<T[Property]> }
+    : T;
 
 const runRequestFixtureRoot = path.join(
   "protocol-snapshots",
@@ -145,4 +152,49 @@ test("maps incomplete manual RunRequest scope into a blocked plan", async () => 
   assert.equal(plan.agentProvider.invokesProvider, false);
   assert.equal(plan.scmProvider.createsBranch, false);
   assert.equal(plan.evidence.writesDurableEvidence, false);
+});
+
+test("copies mutable request boundary fields into the execution plan", async () => {
+  const request = (await readRunRequestFixture("github-issue-request.json")) as Mutable<RunRequest>;
+
+  const plan = createRunRequestExecutionPlan(request);
+
+  assert.ok(request.target);
+  assert.ok(request.policyContext?.riskClasses);
+  assert.notStrictEqual(plan.provenance.source, request.source);
+  assert.notStrictEqual(plan.requestIdentity.requestedBy, request.requestedBy);
+  assert.notStrictEqual(plan.laneWorkspace.target, request.target);
+  assert.notStrictEqual(plan.policy.riskClasses, request.policyContext.riskClasses);
+
+  request.source.externalRef = "mutated/source";
+  request.requestedBy.displayName = "Mutated requester";
+  request.target.externalRef = "mutated/target";
+  request.policyContext.riskClasses.push("mutated-risk");
+
+  assert.equal(plan.provenance.source.externalRef, "TommyKammy/Ensen-protocol");
+  assert.equal(plan.requestIdentity.requestedBy.displayName, "Ensen issue dispatcher");
+  assert.equal(plan.laneWorkspace.target?.externalRef, "TommyKammy/Ensen-protocol");
+  assert.deepEqual(plan.policy.riskClasses, ["secrets"]);
+});
+
+test("orders extension facts with locale-independent code point comparison", async () => {
+  const fixtureRequest = await readRunRequestFixture("github-issue-request.json");
+  const request: RunRequest = {
+    ...fixtureRequest,
+    extensions: {
+      "x-z": 3,
+      "x-ä": 4,
+      "x-a": 2,
+      "x-Z": 1,
+    },
+  };
+
+  const plan = createRunRequestExecutionPlan(request);
+
+  assert.deepEqual(
+    plan.boundedInputFacts
+      .filter((fact) => fact.name.startsWith("extensions."))
+      .map((fact) => fact.name),
+    ["extensions.x-Z", "extensions.x-a", "extensions.x-z", "extensions.x-ä"],
+  );
 });


### PR DESCRIPTION
## Summary
- add a RunRequest execution-plan mapper with request provenance and bounded input facts
- normalize work item, policy, scope, verification, and evidence intents without invoking providers or mutating state
- block accepted but incomplete manual requests when target or policy context is missing

## Verification
- npm run typecheck
- npm run build && node --test dist/test/run-request-execution-plan.test.js
- npm test

Part of #20
Closes #23

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added execution plan generation for run requests with automatic status tracking and validation capabilities
  * Incomplete or invalid requests are now blocked with specific feedback identifying missing requirements

* **Tests**
  * New comprehensive test suite for execution plan generation and validation scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->