### PR TITLE
LOOP-013: Add RunStatusSnapshot dry-run output

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,12 +23,15 @@ npm run build
 npm test
 node dist/src/cli/index.js dry-run --sample
 node dist/src/cli/index.js run-request <run-request-json-file>
+node dist/src/cli/index.js run-request <run-request-json-file> --status-snapshot queued
 ```
 
 `dry-run --sample` emits a deterministic local execution plan as JSON. It describes the work item, lane workspace, agent provider, SCM provider, verification, and evidence intents without creating worktrees, branches, commits, change requests, durable evidence, or invoking external providers.
 
 `run-request <run-request-json-file>` reads an EIP RunRequest v1 JSON file, validates it at the protocol input boundary, and emits either `{ "ok": true, "request": ... }` or `{ "ok": false, "issues": [...] }`. The `source` field is protocol input data, not trusted internal authority.
 
+`run-request <run-request-json-file> --status-snapshot accepted|queued|running|blocked` emits a RunStatusSnapshot-compatible dry-run polling snapshot for the request. The mode maps only Ensen-loop dry-run lifecycle facts; it does not read Ensen-flow workflow state, approval state, or final RunResult fields. If validation or plan normalization blocks the dry run and valid request/correlation identifiers are available, the command emits a blocked status snapshot with actionable reasons under `extensions.x-ensen-loop-blocked-reasons`.
+
 ## Scope
 
-Ensen-loop must remain independently buildable and testable. EIP RunRequest input support is limited to the explicit file validation boundary. RunResult support belongs to a later phase.
+Ensen-loop must remain independently buildable and testable. EIP RunRequest input support is limited to the explicit file validation and dry-run status boundary. RunResult support belongs to a later phase.

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -2,8 +2,17 @@
 
 import { readFile } from "node:fs/promises";
 
-import { createSampleDryRunExecutionPlan, describeProduct } from "../index.js";
-import { validateRunRequest } from "../protocol/index.js";
+import {
+  createSampleDryRunExecutionPlan,
+  describeProduct,
+} from "../index.js";
+import {
+  createBlockedRunStatusSnapshotFromValidationIssues,
+  createRunRequestExecutionPlan,
+  createRunStatusSnapshot,
+  validateRunRequest,
+} from "../protocol/index.js";
+import type { CreateRunStatusSnapshotOptions } from "../protocol/index.js";
 
 const [, , command, ...args] = process.argv;
 
@@ -27,18 +36,52 @@ async function main(): Promise<number> {
   }
 
   if (command === "run-request") {
-    if (args.length !== 1) {
-      console.error("Usage: ensen-loop run-request <run-request-json-file>");
+    if (args.length !== 1 && args.length !== 3) {
+      console.error(
+        "Usage: ensen-loop run-request <run-request-json-file> [--status-snapshot accepted|queued|running|blocked]",
+      );
       return 1;
     }
 
     const filePath = args[0];
     if (filePath === undefined) {
-      console.error("Usage: ensen-loop run-request <run-request-json-file>");
+      console.error(
+        "Usage: ensen-loop run-request <run-request-json-file> [--status-snapshot accepted|queued|running|blocked]",
+      );
       return 1;
     }
 
-    const result = validateRunRequest(await readJsonFile(filePath));
+    const statusSnapshotMode = parseStatusSnapshotMode(args);
+    if (statusSnapshotMode === false) {
+      console.error(
+        "Usage: ensen-loop run-request <run-request-json-file> [--status-snapshot accepted|queued|running|blocked]",
+      );
+      return 1;
+    }
+
+    const input = await readJsonFile(filePath);
+    const result = validateRunRequest(input);
+
+    if (statusSnapshotMode !== undefined) {
+      const observedAt = new Date().toISOString();
+
+      if (!result.ok) {
+        const snapshot = createBlockedRunStatusSnapshotFromValidationIssues(
+          input,
+          result.issues,
+          observedAt,
+        );
+
+        printJson(snapshot ?? result);
+        return 1;
+      }
+
+      const plan = createRunRequestExecutionPlan(result.request);
+      const status = plan.status === "blocked" ? "blocked" : statusSnapshotMode;
+      printJson(createRunStatusSnapshot(plan, { status, observedAt }));
+      return plan.status === "blocked" ? 1 : 0;
+    }
+
     printJson(result);
     return result.ok ? 0 : 1;
   }
@@ -50,8 +93,31 @@ async function main(): Promise<number> {
 
   console.error(`Unknown command: ${command}`);
   console.error("Usage: ensen-loop dry-run [--sample]");
-  console.error("Usage: ensen-loop run-request <run-request-json-file>");
+  console.error(
+    "Usage: ensen-loop run-request <run-request-json-file> [--status-snapshot accepted|queued|running|blocked]",
+  );
   return 1;
+}
+
+function parseStatusSnapshotMode(
+  args: readonly string[],
+): CreateRunStatusSnapshotOptions["status"] | undefined | false {
+  if (args.length === 1) {
+    return undefined;
+  }
+
+  const [, flag, status] = args;
+  if (
+    flag === "--status-snapshot" &&
+    (status === "accepted" ||
+      status === "queued" ||
+      status === "running" ||
+      status === "blocked")
+  ) {
+    return status;
+  }
+
+  return false;
 }
 
 main()

--- a/src/protocol/index.ts
+++ b/src/protocol/index.ts
@@ -1,1 +1,2 @@
 export * from "./run-request.js";
+export * from "./run-status.js";

--- a/src/protocol/run-status.ts
+++ b/src/protocol/run-status.ts
@@ -63,8 +63,9 @@ const snapshotKeys = new Set([
   "extensions",
 ]);
 const progressKeys = new Set(["current", "total", "percent", "unit"]);
-const prefixedIdPattern =
-  /^(?:actor|artifact|corr|cr|evb|evt|flowstep|policy|pr|repo|req|run|source|sts|workitem)_[A-Za-z0-9][A-Za-z0-9._~-]{5,127}$/;
+const statusIdPattern = /^sts_[A-Za-z0-9][A-Za-z0-9._~-]{5,127}$/;
+const requestIdPattern = /^req_[A-Za-z0-9][A-Za-z0-9._~-]{5,127}$/;
+const runIdPattern = /^run_[A-Za-z0-9][A-Za-z0-9._~-]{5,127}$/;
 const correlationIdPattern = /^corr_[A-Za-z0-9][A-Za-z0-9._~-]{11,127}$/;
 const isoDateTimeUtcPattern = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z$/;
 const extensionKeyPattern = /^x-.+$/;
@@ -145,7 +146,7 @@ export function createBlockedRunStatusSnapshotFromValidationIssues(
 
   if (
     typeof value.id !== "string" ||
-    !/^req_[A-Za-z0-9][A-Za-z0-9._~-]{5,127}$/.test(value.id) ||
+    !requestIdPattern.test(value.id) ||
     typeof value.correlationId !== "string" ||
     !correlationIdPattern.test(value.correlationId)
   ) {
@@ -234,12 +235,12 @@ function collectRunStatusSnapshotIssues(
   const issues: RunRequestValidationIssue[] = [];
   collectUnknownKeyIssues(issues, value, snapshotKeys, "$");
   collectConstIssue(issues, "schemaVersion", value.schemaVersion, "eip.run-status.v1");
-  collectPatternIssue(issues, "id", value.id, prefixedIdPattern, "id must be a valid EIP status id.");
+  collectPatternIssue(issues, "id", value.id, statusIdPattern, "id must be a valid EIP status id.");
   collectPatternIssue(
     issues,
     "requestId",
     value.requestId,
-    prefixedIdPattern,
+    requestIdPattern,
     "requestId must be a valid EIP request id.",
   );
   collectPatternIssue(
@@ -253,7 +254,7 @@ function collectRunStatusSnapshotIssues(
     issues,
     "runId",
     value.runId,
-    prefixedIdPattern,
+    runIdPattern,
     "runId must be a valid EIP run id.",
     true,
   );

--- a/src/protocol/run-status.ts
+++ b/src/protocol/run-status.ts
@@ -1,0 +1,488 @@
+import type { RunRequestExecutionPlan, RunRequestValidationIssue } from "./run-request.js";
+
+export type RunStatusSnapshotStatus =
+  | "accepted"
+  | "queued"
+  | "running"
+  | "cancelling"
+  | "cancelled"
+  | "completed"
+  | "failed"
+  | "blocked"
+  | "unknown";
+
+export interface RunStatusProgress {
+  readonly current?: number;
+  readonly total?: number;
+  readonly percent?: number;
+  readonly unit?: string;
+}
+
+export interface RunStatusSnapshot {
+  readonly schemaVersion: "eip.run-status.v1";
+  readonly id: string;
+  readonly requestId: string;
+  readonly correlationId: string;
+  readonly runId?: string;
+  readonly status: RunStatusSnapshotStatus;
+  readonly observedAt: string;
+  readonly message?: string;
+  readonly progress?: RunStatusProgress;
+  readonly extensions?: Record<string, unknown>;
+}
+
+export interface CreateRunStatusSnapshotOptions {
+  readonly status: "accepted" | "queued" | "running" | "blocked";
+  readonly observedAt: string;
+}
+
+export interface RunStatusSnapshotValidationSuccess {
+  readonly ok: true;
+  readonly snapshot: RunStatusSnapshot;
+}
+
+export interface RunStatusSnapshotValidationFailure {
+  readonly ok: false;
+  readonly issues: readonly RunRequestValidationIssue[];
+}
+
+export type RunStatusSnapshotValidationResult =
+  | RunStatusSnapshotValidationSuccess
+  | RunStatusSnapshotValidationFailure;
+
+const snapshotKeys = new Set([
+  "schemaVersion",
+  "id",
+  "requestId",
+  "correlationId",
+  "runId",
+  "status",
+  "observedAt",
+  "message",
+  "progress",
+  "extensions",
+]);
+const progressKeys = new Set(["current", "total", "percent", "unit"]);
+const prefixedIdPattern =
+  /^(?:actor|artifact|corr|cr|evb|evt|flowstep|policy|pr|repo|req|run|source|sts|workitem)_[A-Za-z0-9][A-Za-z0-9._~-]{5,127}$/;
+const correlationIdPattern = /^corr_[A-Za-z0-9][A-Za-z0-9._~-]{11,127}$/;
+const isoDateTimeUtcPattern = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z$/;
+const extensionKeyPattern = /^x-.+$/;
+const runStatuses = new Set<unknown>([
+  "accepted",
+  "queued",
+  "running",
+  "cancelling",
+  "cancelled",
+  "completed",
+  "failed",
+  "blocked",
+  "unknown",
+]);
+
+export function createRunStatusSnapshot(
+  plan: RunRequestExecutionPlan,
+  options: CreateRunStatusSnapshotOptions,
+): RunStatusSnapshot {
+  if (plan.status === "blocked" && options.status !== "blocked") {
+    throw new Error("blocked dry-run plans can only emit blocked status snapshots");
+  }
+
+  if (plan.status === "ready" && options.status === "blocked") {
+    throw new Error("ready dry-run plans cannot emit blocked status snapshots");
+  }
+
+  const base: RunStatusSnapshot = {
+    schemaVersion: "eip.run-status.v1",
+    id: replaceProtocolIdPrefix(plan.provenance.requestId, "sts"),
+    requestId: plan.provenance.requestId,
+    correlationId: plan.provenance.correlationId,
+    status: options.status,
+    observedAt: options.observedAt,
+    message: createSnapshotMessage(plan, options.status),
+  };
+
+  if (options.status === "queued") {
+    return {
+      ...base,
+      runId: replaceProtocolIdPrefix(plan.provenance.requestId, "run"),
+    };
+  }
+
+  if (options.status === "running") {
+    return {
+      ...base,
+      runId: replaceProtocolIdPrefix(plan.provenance.requestId, "run"),
+      progress: {
+        current: 0,
+        total: 1,
+        percent: 0,
+        unit: "dry-run",
+      },
+    };
+  }
+
+  if (options.status === "blocked") {
+    return {
+      ...base,
+      extensions: {
+        "x-ensen-loop-blocked-reasons": [...plan.blockedReasons],
+      },
+    };
+  }
+
+  return base;
+}
+
+export function createBlockedRunStatusSnapshotFromValidationIssues(
+  value: unknown,
+  issues: readonly RunRequestValidationIssue[],
+  observedAt: string,
+): RunStatusSnapshot | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+
+  if (
+    typeof value.id !== "string" ||
+    !/^req_[A-Za-z0-9][A-Za-z0-9._~-]{5,127}$/.test(value.id) ||
+    typeof value.correlationId !== "string" ||
+    !correlationIdPattern.test(value.correlationId)
+  ) {
+    return undefined;
+  }
+
+  const blockedReasons = issues.map((issue) => `${issue.path}: ${issue.message}`);
+  const message = `Dry-run request blocked: ${blockedReasons.join("; ")}`;
+
+  return {
+    schemaVersion: "eip.run-status.v1",
+    id: replaceProtocolIdPrefix(value.id, "sts"),
+    requestId: value.id,
+    correlationId: value.correlationId,
+    status: "blocked",
+    observedAt,
+    message: trimToMaxLength(message, 1000),
+    extensions: {
+      "x-ensen-loop-blocked-reasons": blockedReasons,
+    },
+  };
+}
+
+export function validateRunStatusSnapshot(value: unknown): RunStatusSnapshotValidationResult {
+  const issues = collectRunStatusSnapshotIssues(value);
+
+  if (issues.length > 0) {
+    return {
+      ok: false,
+      issues,
+    };
+  }
+
+  return {
+    ok: true,
+    snapshot: value as RunStatusSnapshot,
+  };
+}
+
+function createSnapshotMessage(
+  plan: RunRequestExecutionPlan,
+  status: CreateRunStatusSnapshotOptions["status"],
+): string {
+  if (status === "accepted") {
+    return "Dry-run request accepted by the Ensen-loop boundary.";
+  }
+
+  if (status === "queued") {
+    return "Dry-run lane state queued; no workspace or provider action has started.";
+  }
+
+  if (status === "running") {
+    return "Dry-run lane state running normalization only; no external provider is invoked.";
+  }
+
+  return trimToMaxLength(
+    `Dry-run request blocked: ${plan.blockedReasons.join("; ")}`,
+    1000,
+  );
+}
+
+function replaceProtocolIdPrefix(id: string, prefix: "run" | "sts"): string {
+  return `${prefix}_${id.slice(id.indexOf("_") + 1)}`;
+}
+
+function trimToMaxLength(value: string, maxLength: number): string {
+  if (value.length <= maxLength) {
+    return value;
+  }
+
+  return value.slice(0, maxLength);
+}
+
+function collectRunStatusSnapshotIssues(
+  value: unknown,
+): readonly RunRequestValidationIssue[] {
+  if (!isRecord(value)) {
+    return [
+      {
+        path: "$",
+        message: "RunStatusSnapshot input must be a JSON object.",
+      },
+    ];
+  }
+
+  const issues: RunRequestValidationIssue[] = [];
+  collectUnknownKeyIssues(issues, value, snapshotKeys, "$");
+  collectConstIssue(issues, "schemaVersion", value.schemaVersion, "eip.run-status.v1");
+  collectPatternIssue(issues, "id", value.id, prefixedIdPattern, "id must be a valid EIP status id.");
+  collectPatternIssue(
+    issues,
+    "requestId",
+    value.requestId,
+    prefixedIdPattern,
+    "requestId must be a valid EIP request id.",
+  );
+  collectPatternIssue(
+    issues,
+    "correlationId",
+    value.correlationId,
+    correlationIdPattern,
+    "correlationId must be a valid EIP correlation id.",
+  );
+  collectPatternIssue(
+    issues,
+    "runId",
+    value.runId,
+    prefixedIdPattern,
+    "runId must be a valid EIP run id.",
+    true,
+  );
+  collectEnumIssue(
+    issues,
+    "status",
+    value.status,
+    runStatuses,
+    "status must be a valid EIP run status.",
+  );
+  collectUtcTimestampIssue(issues, "observedAt", value.observedAt);
+  collectOptionalStringLengthIssue(issues, "message", value.message, 1, 1000);
+  collectProgressIssues(issues, value.progress);
+  collectExtensionsIssues(issues, value.extensions);
+
+  return issues;
+}
+
+function collectProgressIssues(
+  issues: RunRequestValidationIssue[],
+  value: unknown,
+): void {
+  if (value === undefined) {
+    return;
+  }
+
+  if (!isRecord(value)) {
+    issues.push({
+      path: "progress",
+      message: "progress must be a JSON object.",
+    });
+    return;
+  }
+
+  collectUnknownKeyIssues(issues, value, progressKeys, "progress");
+
+  if (Object.keys(value).length === 0) {
+    issues.push({
+      path: "progress",
+      message: "progress must contain at least one field.",
+    });
+  }
+
+  collectOptionalIntegerMinimumIssue(issues, "progress.current", value.current, 0);
+  collectOptionalIntegerMinimumIssue(issues, "progress.total", value.total, 1);
+  collectOptionalNumberRangeIssue(issues, "progress.percent", value.percent, 0, 100);
+  collectOptionalStringLengthIssue(issues, "progress.unit", value.unit, 1, 80);
+}
+
+function collectExtensionsIssues(
+  issues: RunRequestValidationIssue[],
+  value: unknown,
+): void {
+  if (value === undefined) {
+    return;
+  }
+
+  if (!isRecord(value)) {
+    issues.push({
+      path: "extensions",
+      message: "extensions must be a JSON object.",
+    });
+    return;
+  }
+
+  for (const key of Object.keys(value)) {
+    if (!extensionKeyPattern.test(key)) {
+      issues.push({
+        path: `extensions.${key}`,
+        message: "extension keys must start with x-.",
+      });
+    }
+  }
+}
+
+function collectUnknownKeyIssues(
+  issues: RunRequestValidationIssue[],
+  value: Record<string, unknown>,
+  allowedKeys: ReadonlySet<string>,
+  path: string,
+): void {
+  for (const key of Object.keys(value)) {
+    if (!allowedKeys.has(key)) {
+      issues.push({
+        path: path === "$" ? key : `${path}.${key}`,
+        message: "field is not allowed.",
+      });
+    }
+  }
+}
+
+function collectConstIssue(
+  issues: RunRequestValidationIssue[],
+  path: string,
+  value: unknown,
+  expected: string,
+): void {
+  if (value !== expected) {
+    issues.push({
+      path,
+      message: `${path} must be ${expected}.`,
+    });
+  }
+}
+
+function collectPatternIssue(
+  issues: RunRequestValidationIssue[],
+  path: string,
+  value: unknown,
+  pattern: RegExp,
+  message: string,
+  optional = false,
+): void {
+  if (value === undefined && optional) {
+    return;
+  }
+
+  if (typeof value !== "string" || !pattern.test(value)) {
+    issues.push({
+      path,
+      message,
+    });
+  }
+}
+
+function collectEnumIssue(
+  issues: RunRequestValidationIssue[],
+  path: string,
+  value: unknown,
+  allowed: ReadonlySet<unknown>,
+  message: string,
+): void {
+  if (!allowed.has(value)) {
+    issues.push({
+      path,
+      message,
+    });
+  }
+}
+
+function collectUtcTimestampIssue(
+  issues: RunRequestValidationIssue[],
+  path: string,
+  value: unknown,
+): void {
+  if (typeof value !== "string" || !isoDateTimeUtcPattern.test(value)) {
+    issues.push({
+      path,
+      message: `${path} must be a UTC ISO 8601 timestamp.`,
+    });
+    return;
+  }
+
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime()) || parsed.toISOString() !== normalizeUtcTimestamp(value)) {
+    issues.push({
+      path,
+      message: `${path} must be a real UTC timestamp.`,
+    });
+  }
+}
+
+function collectOptionalStringLengthIssue(
+  issues: RunRequestValidationIssue[],
+  path: string,
+  value: unknown,
+  minLength: number,
+  maxLength: number,
+): void {
+  if (value === undefined) {
+    return;
+  }
+
+  if (typeof value !== "string" || value.length < minLength || value.length > maxLength) {
+    issues.push({
+      path,
+      message: `${path} must be a string with length ${minLength}-${maxLength}.`,
+    });
+  }
+}
+
+function collectOptionalIntegerMinimumIssue(
+  issues: RunRequestValidationIssue[],
+  path: string,
+  value: unknown,
+  minimum: number,
+): void {
+  if (value === undefined) {
+    return;
+  }
+
+  if (typeof value !== "number" || !Number.isInteger(value) || value < minimum) {
+    issues.push({
+      path,
+      message: `${path} must be an integer greater than or equal to ${minimum}.`,
+    });
+  }
+}
+
+function collectOptionalNumberRangeIssue(
+  issues: RunRequestValidationIssue[],
+  path: string,
+  value: unknown,
+  minimum: number,
+  maximum: number,
+): void {
+  if (value === undefined) {
+    return;
+  }
+
+  if (typeof value !== "number" || Number.isNaN(value) || value < minimum || value > maximum) {
+    issues.push({
+      path,
+      message: `${path} must be a number between ${minimum} and ${maximum}.`,
+    });
+  }
+}
+
+function normalizeUtcTimestamp(value: string): string {
+  const [whole, fractional = ""] = value.slice(0, -1).split(".");
+  const normalizedFraction = fractional.replace(/0+$/, "");
+
+  if (normalizedFraction.length === 0) {
+    return `${whole}.000Z`;
+  }
+
+  return `${whole}.${normalizedFraction.padEnd(3, "0")}Z`;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}

--- a/test/run-status-snapshot.test.ts
+++ b/test/run-status-snapshot.test.ts
@@ -1,0 +1,152 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import test from "node:test";
+import { promisify } from "node:util";
+
+import {
+  createRunRequestExecutionPlan,
+  createRunStatusSnapshot,
+  parseRunRequest,
+  validateRunStatusSnapshot,
+} from "../src/protocol/index.js";
+
+const execFileAsync = promisify(execFile);
+const fixtureRoot = path.join(
+  "protocol-snapshots",
+  "ensen-protocol",
+  "v0.1.0",
+  "fixtures",
+);
+
+async function readJson(relativePath: string): Promise<unknown> {
+  return JSON.parse(await readFile(path.join(fixtureRoot, relativePath), "utf8")) as unknown;
+}
+
+test("emits RunStatusSnapshot-compatible dry-run lifecycle states", async () => {
+  const request = parseRunRequest(await readJson("run-request/v1/valid/github-issue-request.json"));
+  const plan = createRunRequestExecutionPlan(request);
+
+  const accepted = createRunStatusSnapshot(plan, {
+    status: "accepted",
+    observedAt: "2026-04-30T00:00:00Z",
+  });
+  const queued = createRunStatusSnapshot(plan, {
+    status: "queued",
+    observedAt: "2026-04-30T00:00:01Z",
+  });
+  const running = createRunStatusSnapshot(plan, {
+    status: "running",
+    observedAt: "2026-04-30T00:00:02Z",
+  });
+
+  assert.deepEqual(
+    [accepted, queued, running].map((snapshot) => validateRunStatusSnapshot(snapshot).ok),
+    [true, true, true],
+  );
+  assert.equal(accepted.schemaVersion, "eip.run-status.v1");
+  assert.equal(accepted.id, "sts_01HV7Y8M8F2KQ5W3P9R6T4N2AB");
+  assert.equal(accepted.requestId, request.id);
+  assert.equal(accepted.correlationId, request.correlationId);
+  assert.equal(accepted.runId, undefined);
+  assert.equal(queued.runId, "run_01HV7Y8M8F2KQ5W3P9R6T4N2AB");
+  assert.equal(running.runId, "run_01HV7Y8M8F2KQ5W3P9R6T4N2AB");
+  assert.deepEqual(running.progress, {
+    current: 0,
+    total: 1,
+    percent: 0,
+    unit: "dry-run",
+  });
+});
+
+test("includes blocked dry-run reasons without final-result-only fields", async () => {
+  const request = parseRunRequest(await readJson("run-request/v1/valid/manual-request.json"));
+  const plan = createRunRequestExecutionPlan(request);
+
+  const snapshot = createRunStatusSnapshot(plan, {
+    status: "blocked",
+    observedAt: "2026-04-30T00:00:03Z",
+  });
+
+  assert.equal(validateRunStatusSnapshot(snapshot).ok, true);
+  assert.equal(snapshot.status, "blocked");
+  assert.equal(snapshot.runId, undefined);
+  assert.match(snapshot.message ?? "", /target is required/);
+  assert.deepEqual(snapshot.extensions, {
+    "x-ensen-loop-blocked-reasons": [
+      "target is required before execution can be planned",
+      "policyContext is required before execution can be planned",
+    ],
+  });
+  assert.equal(Object.hasOwn(snapshot, "completedAt"), false);
+  assert.equal(Object.hasOwn(snapshot, "changeRequests"), false);
+});
+
+test("rejects final-result-only fields in RunStatusSnapshot payloads", async () => {
+  const invalid = await readJson("run-status/v1/invalid/final-result-only-fields.json");
+
+  const result = validateRunStatusSnapshot(invalid);
+
+  assert.equal(result.ok, false);
+  assert.ok(
+    result.issues.some((issue) => issue.path === "completedAt"),
+    "completedAt must be rejected as a status snapshot field",
+  );
+  assert.ok(
+    result.issues.some((issue) => issue.path === "changeRequests"),
+    "changeRequests must be rejected as a status snapshot field",
+  );
+});
+
+test("CLI emits RunStatusSnapshot JSON for dry-run RunRequest mode", async () => {
+  const fixturePath = path.join(fixtureRoot, "run-request/v1/valid/github-issue-request.json");
+
+  const { stdout, stderr } = await execFileAsync(process.execPath, [
+    "dist/src/cli/index.js",
+    "run-request",
+    fixturePath,
+    "--status-snapshot",
+    "queued",
+  ]);
+
+  assert.equal(stderr, "");
+
+  const snapshot = JSON.parse(stdout) as unknown;
+  const result = validateRunStatusSnapshot(snapshot);
+
+  assert.equal(result.ok, true);
+  assert.equal(result.ok && result.snapshot.status, "queued");
+});
+
+test("CLI emits blocked RunStatusSnapshot JSON when validation fails after stable ids", async () => {
+  const fixturePath = path.join(
+    fixtureRoot,
+    "run-request/v1/invalid/bad-schema-version.json",
+  );
+
+  await assert.rejects(
+    execFileAsync(process.execPath, [
+      "dist/src/cli/index.js",
+      "run-request",
+      fixturePath,
+      "--status-snapshot",
+      "queued",
+    ]),
+    (error: unknown) => {
+      assert.ok(error && typeof error === "object");
+      assert.ok("code" in error);
+      assert.equal(error.code, 1);
+      assert.ok("stdout" in error && typeof error.stdout === "string");
+
+      const snapshot = JSON.parse(error.stdout) as unknown;
+      const result = validateRunStatusSnapshot(snapshot);
+
+      assert.equal(result.ok, true);
+      assert.equal(result.ok && result.snapshot.status, "blocked");
+      assert.match(result.ok ? (result.snapshot.message ?? "") : "", /schemaVersion/);
+
+      return true;
+    },
+  );
+});

--- a/test/run-status-snapshot.test.ts
+++ b/test/run-status-snapshot.test.ts
@@ -60,6 +60,36 @@ test("emits RunStatusSnapshot-compatible dry-run lifecycle states", async () => 
   });
 });
 
+test("rejects crossed ID prefixes in RunStatusSnapshot payloads", async () => {
+  const request = parseRunRequest(await readJson("run-request/v1/valid/github-issue-request.json"));
+  const plan = createRunRequestExecutionPlan(request);
+  const snapshot = createRunStatusSnapshot(plan, {
+    status: "queued",
+    observedAt: "2026-04-30T00:00:01Z",
+  });
+
+  const result = validateRunStatusSnapshot({
+    ...snapshot,
+    id: snapshot.runId,
+    requestId: snapshot.runId,
+    runId: snapshot.id,
+  });
+
+  assert.equal(result.ok, false);
+  assert.ok(
+    result.issues.some((issue) => issue.path === "id"),
+    "status id must require an sts_ prefix",
+  );
+  assert.ok(
+    result.issues.some((issue) => issue.path === "requestId"),
+    "request id must require a req_ prefix",
+  );
+  assert.ok(
+    result.issues.some((issue) => issue.path === "runId"),
+    "run id must require a run_ prefix",
+  );
+});
+
 test("includes blocked dry-run reasons without final-result-only fields", async () => {
   const request = parseRunRequest(await readJson("run-request/v1/valid/manual-request.json"));
   const plan = createRunRequestExecutionPlan(request);


### PR DESCRIPTION
## Summary
- add RunStatusSnapshot helpers and validation for dry-run lifecycle snapshots
- map accepted, queued, running, and blocked RunRequest dry-run states without Ensen-flow state or RunResult fields
- expose `run-request <file> --status-snapshot accepted|queued|running|blocked` and document it

## Verification
- npm run typecheck
- npm run build
- npm test

Closes #24

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--status-snapshot` option to the `run-request` CLI command for generating dry-run status snapshots in accepted, queued, running, or blocked modes.
  * Blocked snapshots now include actionable reasons when validation or planning failures occur.

* **Documentation**
  * Updated README with specifications and sample commands for the new `--status-snapshot` option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->