### PR TITLE
LOOP-014: Add RunResult output for dry-run cases

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -7,11 +7,14 @@ import {
   describeProduct,
 } from "../index.js";
 import {
+  createBlockedRunResultFromValidationIssues,
   createBlockedRunStatusSnapshotFromValidationIssues,
   createRunRequestExecutionPlan,
+  createRunResult,
   createRunStatusSnapshot,
   validateRunRequest,
 } from "../protocol/index.js";
+import type { CreateRunResultOptions } from "../protocol/index.js";
 import type { CreateRunStatusSnapshotOptions } from "../protocol/index.js";
 
 const [, , command, ...args] = process.argv;
@@ -38,7 +41,7 @@ async function main(): Promise<number> {
   if (command === "run-request") {
     if (args.length !== 1 && args.length !== 3) {
       console.error(
-        "Usage: ensen-loop run-request <run-request-json-file> [--status-snapshot accepted|queued|running|blocked]",
+        "Usage: ensen-loop run-request <run-request-json-file> [--status-snapshot accepted|queued|running|blocked|--run-result succeeded|failed|blocked]",
       );
       return 1;
     }
@@ -46,15 +49,20 @@ async function main(): Promise<number> {
     const filePath = args[0];
     if (filePath === undefined) {
       console.error(
-        "Usage: ensen-loop run-request <run-request-json-file> [--status-snapshot accepted|queued|running|blocked]",
+        "Usage: ensen-loop run-request <run-request-json-file> [--status-snapshot accepted|queued|running|blocked|--run-result succeeded|failed|blocked]",
       );
       return 1;
     }
 
     const statusSnapshotMode = parseStatusSnapshotMode(args);
-    if (statusSnapshotMode === false) {
+    const runResultMode = parseRunResultMode(args);
+    if (
+      statusSnapshotMode === false ||
+      runResultMode === false ||
+      (statusSnapshotMode !== undefined && runResultMode !== undefined)
+    ) {
       console.error(
-        "Usage: ensen-loop run-request <run-request-json-file> [--status-snapshot accepted|queued|running|blocked]",
+        "Usage: ensen-loop run-request <run-request-json-file> [--status-snapshot accepted|queued|running|blocked|--run-result succeeded|failed|blocked]",
       );
       return 1;
     }
@@ -82,6 +90,26 @@ async function main(): Promise<number> {
       return plan.status === "blocked" ? 1 : 0;
     }
 
+    if (runResultMode !== undefined) {
+      const completedAt = new Date().toISOString();
+
+      if (!result.ok) {
+        const runResult = createBlockedRunResultFromValidationIssues(
+          input,
+          result.issues,
+          completedAt,
+        );
+
+        printJson(runResult ?? result);
+        return 1;
+      }
+
+      const plan = createRunRequestExecutionPlan(result.request);
+      const status = plan.status === "blocked" ? "blocked" : runResultMode;
+      printJson(createRunResult(plan, { status, completedAt }));
+      return plan.status === "blocked" || status === "failed" ? 1 : 0;
+    }
+
     printJson(result);
     return result.ok ? 0 : 1;
   }
@@ -94,7 +122,7 @@ async function main(): Promise<number> {
   console.error(`Unknown command: ${command}`);
   console.error("Usage: ensen-loop dry-run [--sample]");
   console.error(
-    "Usage: ensen-loop run-request <run-request-json-file> [--status-snapshot accepted|queued|running|blocked]",
+    "Usage: ensen-loop run-request <run-request-json-file> [--status-snapshot accepted|queued|running|blocked|--run-result succeeded|failed|blocked]",
   );
   return 1;
 }
@@ -107,12 +135,38 @@ function parseStatusSnapshotMode(
   }
 
   const [, flag, status] = args;
+  if (flag === "--run-result") {
+    return undefined;
+  }
+
   if (
     flag === "--status-snapshot" &&
     (status === "accepted" ||
       status === "queued" ||
       status === "running" ||
       status === "blocked")
+  ) {
+    return status;
+  }
+
+  return false;
+}
+
+function parseRunResultMode(
+  args: readonly string[],
+): CreateRunResultOptions["status"] | undefined | false {
+  if (args.length === 1) {
+    return undefined;
+  }
+
+  const [, flag, status] = args;
+  if (flag === "--status-snapshot") {
+    return undefined;
+  }
+
+  if (
+    flag === "--run-result" &&
+    (status === "succeeded" || status === "failed" || status === "blocked")
   ) {
     return status;
   }

--- a/src/protocol/index.ts
+++ b/src/protocol/index.ts
@@ -1,2 +1,3 @@
 export * from "./run-request.js";
+export * from "./run-result.js";
 export * from "./run-status.js";

--- a/src/protocol/run-result.ts
+++ b/src/protocol/run-result.ts
@@ -1,0 +1,821 @@
+import type { RunRequestExecutionPlan, RunRequestValidationIssue } from "./run-request.js";
+
+export type RunResultStatus =
+  | "succeeded"
+  | "failed"
+  | "blocked"
+  | "needs_review"
+  | "cancelled";
+
+export type VerificationStatus = "passed" | "failed" | "blocked" | "not_run";
+
+export interface VerificationCommand {
+  readonly command: string;
+  readonly status: VerificationStatus;
+  readonly completedAt?: string;
+  readonly summary?: string;
+}
+
+export interface VerificationSummary {
+  readonly status: VerificationStatus;
+  readonly commands?: readonly VerificationCommand[];
+  readonly summary?: string;
+}
+
+export interface ChangeRequestRef {
+  readonly changeRequestId: string;
+  readonly status?: "draft" | "open" | "accepted" | "rejected" | "superseded";
+}
+
+export interface EvidenceBundleRef {
+  readonly evidenceBundleId: string;
+  readonly digest?: string;
+}
+
+export interface RunResultErrorInfo {
+  readonly code: string;
+  readonly message: string;
+  readonly retryable?: boolean;
+  readonly details?: Record<string, string | number | boolean | null>;
+}
+
+export interface RunResultWarningInfo {
+  readonly code: string;
+  readonly message: string;
+}
+
+export interface RunMetrics {
+  readonly durationMs?: number;
+  readonly attempts?: number;
+  readonly tokensInput?: number;
+  readonly tokensOutput?: number;
+}
+
+export interface RunResult {
+  readonly schemaVersion: "eip.run-result.v1";
+  readonly id: string;
+  readonly requestId: string;
+  readonly correlationId: string;
+  readonly status: RunResultStatus;
+  readonly completedAt: string;
+  readonly changeRequests?: readonly ChangeRequestRef[];
+  readonly evidenceBundles?: readonly EvidenceBundleRef[];
+  readonly verification?: VerificationSummary;
+  readonly errors?: readonly RunResultErrorInfo[];
+  readonly warnings?: readonly RunResultWarningInfo[];
+  readonly metrics?: RunMetrics;
+  readonly extensions?: Record<string, unknown>;
+}
+
+export interface CreateRunResultOptions {
+  readonly status: "succeeded" | "failed" | "blocked";
+  readonly completedAt: string;
+  readonly verification?: VerificationSummary;
+  readonly evidenceBundles?: readonly EvidenceBundleRef[];
+  readonly errors?: readonly RunResultErrorInfo[];
+  readonly warnings?: readonly RunResultWarningInfo[];
+  readonly durationMs?: number;
+}
+
+export interface RunResultValidationSuccess {
+  readonly ok: true;
+  readonly result: RunResult;
+}
+
+export interface RunResultValidationFailure {
+  readonly ok: false;
+  readonly issues: readonly RunRequestValidationIssue[];
+}
+
+export type RunResultValidationResult =
+  | RunResultValidationSuccess
+  | RunResultValidationFailure;
+
+const resultKeys = new Set([
+  "schemaVersion",
+  "id",
+  "requestId",
+  "correlationId",
+  "status",
+  "completedAt",
+  "changeRequests",
+  "evidenceBundles",
+  "verification",
+  "errors",
+  "warnings",
+  "metrics",
+  "extensions",
+]);
+const verificationKeys = new Set(["status", "commands", "summary"]);
+const verificationCommandKeys = new Set(["command", "status", "completedAt", "summary"]);
+const changeRequestKeys = new Set(["changeRequestId", "status"]);
+const evidenceBundleKeys = new Set(["evidenceBundleId", "digest"]);
+const errorKeys = new Set(["code", "message", "retryable", "details"]);
+const warningKeys = new Set(["code", "message"]);
+const metricsKeys = new Set([
+  "durationMs",
+  "attempts",
+  "tokensInput",
+  "tokensOutput",
+]);
+
+const prefixedIdPattern =
+  /^(?:actor|artifact|corr|cr|evb|evt|flowstep|policy|pr|repo|req|run|source|sts|workitem)_[A-Za-z0-9][A-Za-z0-9._~-]{5,127}$/;
+const requestIdPattern = /^req_[A-Za-z0-9][A-Za-z0-9._~-]{5,127}$/;
+const runIdPattern = /^run_[A-Za-z0-9][A-Za-z0-9._~-]{5,127}$/;
+const correlationIdPattern = /^corr_[A-Za-z0-9][A-Za-z0-9._~-]{11,127}$/;
+const isoDateTimeUtcPattern = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z$/;
+const digestPattern = /^sha256:[a-f0-9]{64}$/;
+const codePattern = /^[A-Z][A-Z0-9_]{2,63}$/;
+const extensionKeyPattern = /^x-.+$/;
+
+const terminalRunResultStatuses = new Set<unknown>([
+  "succeeded",
+  "failed",
+  "blocked",
+  "needs_review",
+  "cancelled",
+]);
+const verificationStatuses = new Set<unknown>(["passed", "failed", "blocked", "not_run"]);
+const changeRequestStatuses = new Set<unknown>([
+  "draft",
+  "open",
+  "accepted",
+  "rejected",
+  "superseded",
+]);
+
+export function createRunResult(
+  plan: RunRequestExecutionPlan,
+  options: CreateRunResultOptions,
+): RunResult {
+  if (plan.status === "blocked" && options.status !== "blocked") {
+    throw new Error("blocked dry-run plans can only emit blocked run results");
+  }
+
+  if (plan.status === "ready" && options.status === "blocked") {
+    throw new Error("ready dry-run plans cannot emit blocked run results");
+  }
+
+  const result: RunResult = {
+    schemaVersion: "eip.run-result.v1",
+    id: replaceProtocolIdPrefix(plan.provenance.requestId, "run"),
+    requestId: plan.provenance.requestId,
+    correlationId: plan.provenance.correlationId,
+    status: options.status,
+    completedAt: options.completedAt,
+    verification: options.verification ?? createDryRunVerification(plan, options.status),
+    metrics: {
+      attempts: 1,
+    },
+  };
+
+  return stripUndefinedCollections({
+    ...result,
+    evidenceBundles:
+      options.evidenceBundles !== undefined && options.evidenceBundles.length > 0
+        ? options.evidenceBundles.map((evidenceBundle) => ({ ...evidenceBundle }))
+        : undefined,
+    errors: createErrors(plan, options),
+    warnings: createWarnings(plan, options),
+    metrics: createMetrics(options),
+  });
+}
+
+export function createBlockedRunResultFromValidationIssues(
+  value: unknown,
+  issues: readonly RunRequestValidationIssue[],
+  completedAt: string,
+): RunResult | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+
+  if (
+    typeof value.id !== "string" ||
+    !requestIdPattern.test(value.id) ||
+    typeof value.correlationId !== "string" ||
+    !correlationIdPattern.test(value.correlationId)
+  ) {
+    return undefined;
+  }
+
+  const blockedReasons = issues.map((issue) => `${issue.path}: ${issue.message}`);
+
+  return {
+    schemaVersion: "eip.run-result.v1",
+    id: replaceProtocolIdPrefix(value.id, "run"),
+    requestId: value.id,
+    correlationId: value.correlationId,
+    status: "blocked",
+    completedAt,
+    verification: {
+      status: "blocked",
+      summary: trimToMaxLength(`Dry-run request blocked: ${blockedReasons.join("; ")}`, 1000),
+    },
+    warnings: [
+      {
+        code: "DRY_RUN_BLOCKED",
+        message: "The dry-run request stopped before execution because validation failed.",
+      },
+    ],
+    metrics: {
+      attempts: 1,
+    },
+    extensions: {
+      "x-ensen-loop-blocked-reasons": blockedReasons,
+    },
+  };
+}
+
+export function validateRunResult(value: unknown): RunResultValidationResult {
+  const issues = collectRunResultIssues(value);
+
+  if (issues.length > 0) {
+    return {
+      ok: false,
+      issues,
+    };
+  }
+
+  return {
+    ok: true,
+    result: value as RunResult,
+  };
+}
+
+function createDryRunVerification(
+  plan: RunRequestExecutionPlan,
+  status: CreateRunResultOptions["status"],
+): VerificationSummary {
+  if (status === "succeeded") {
+    return {
+      status: "not_run",
+      summary: "Dry-run completed without running verification commands.",
+    };
+  }
+
+  if (status === "failed") {
+    return {
+      status: "failed",
+      summary: "Dry-run failed before agent execution or verification commands ran.",
+    };
+  }
+
+  return {
+    status: "blocked",
+    summary: trimToMaxLength(
+      `Dry-run request blocked: ${plan.blockedReasons.join("; ")}`,
+      1000,
+    ),
+  };
+}
+
+function createErrors(
+  plan: RunRequestExecutionPlan,
+  options: CreateRunResultOptions,
+): readonly RunResultErrorInfo[] | undefined {
+  if (options.errors !== undefined && options.errors.length > 0) {
+    return options.errors.map((error) => ({ ...error }));
+  }
+
+  if (options.status !== "failed") {
+    return undefined;
+  }
+
+  return [
+    {
+      code: "DRY_RUN_FAILED",
+      message: "Dry-run result was marked failed before real agent execution.",
+      retryable: false,
+      details: {
+        requestId: plan.provenance.requestId,
+      },
+    },
+  ];
+}
+
+function createWarnings(
+  plan: RunRequestExecutionPlan,
+  options: CreateRunResultOptions,
+): readonly RunResultWarningInfo[] | undefined {
+  if (options.warnings !== undefined && options.warnings.length > 0) {
+    return options.warnings.map((warning) => ({ ...warning }));
+  }
+
+  if (options.status !== "blocked") {
+    return undefined;
+  }
+
+  return [
+    {
+      code: "DRY_RUN_BLOCKED",
+      message: trimToMaxLength(
+        plan.blockedReasons.length === 0
+          ? "The dry-run request stopped before execution because planning was blocked."
+          : "The dry-run request stopped before execution because required planning scope is missing.",
+        1000,
+      ),
+    },
+  ];
+}
+
+function createMetrics(options: CreateRunResultOptions): RunMetrics {
+  const metrics: RunMetrics = {
+    attempts: 1,
+  };
+
+  if (options.durationMs !== undefined) {
+    return {
+      ...metrics,
+      durationMs: options.durationMs,
+    };
+  }
+
+  return metrics;
+}
+
+function stripUndefinedCollections(result: RunResult): RunResult {
+  return Object.fromEntries(
+    Object.entries(result).filter(([, value]) => value !== undefined),
+  ) as unknown as RunResult;
+}
+
+function replaceProtocolIdPrefix(id: string, prefix: "run"): string {
+  return `${prefix}_${id.slice(id.indexOf("_") + 1)}`;
+}
+
+function collectRunResultIssues(value: unknown): readonly RunRequestValidationIssue[] {
+  if (!isRecord(value)) {
+    return [
+      {
+        path: "$",
+        message: "RunResult input must be a JSON object.",
+      },
+    ];
+  }
+
+  const issues: RunRequestValidationIssue[] = [];
+  collectUnknownKeyIssues(issues, value, resultKeys, "$");
+  collectConstIssue(issues, "schemaVersion", value.schemaVersion, "eip.run-result.v1");
+  collectPatternIssue(issues, "id", value.id, runIdPattern, "id must be a valid EIP run id.");
+  collectPatternIssue(
+    issues,
+    "requestId",
+    value.requestId,
+    requestIdPattern,
+    "requestId must be a valid EIP request id.",
+  );
+  collectPatternIssue(
+    issues,
+    "correlationId",
+    value.correlationId,
+    correlationIdPattern,
+    "correlationId must be a valid EIP correlation id.",
+  );
+  collectEnumIssue(
+    issues,
+    "status",
+    value.status,
+    terminalRunResultStatuses,
+    "status must be a terminal EIP run result status.",
+  );
+  collectUtcTimestampIssue(issues, "completedAt", value.completedAt);
+  collectChangeRequestIssues(issues, value.changeRequests);
+  collectEvidenceBundleIssues(issues, value.evidenceBundles);
+  collectVerificationIssues(issues, value.verification);
+  collectErrorIssues(issues, value.errors);
+  collectWarningIssues(issues, value.warnings);
+  collectMetricsIssues(issues, value.metrics);
+  collectExtensionsIssues(issues, value.extensions);
+
+  return issues;
+}
+
+function collectChangeRequestIssues(
+  issues: RunRequestValidationIssue[],
+  value: unknown,
+): void {
+  collectArrayIssues(
+    issues,
+    "changeRequests",
+    value,
+    50,
+    changeRequestKeys,
+    (entry, path) => {
+      collectPatternIssue(
+        issues,
+        `${path}.changeRequestId`,
+        entry.changeRequestId,
+        prefixedIdPattern,
+        "changeRequestId must be a valid EIP id.",
+      );
+      collectEnumIssue(
+        issues,
+        `${path}.status`,
+        entry.status,
+        changeRequestStatuses,
+        "status must be a valid change request status.",
+        true,
+      );
+    },
+  );
+}
+
+function collectEvidenceBundleIssues(
+  issues: RunRequestValidationIssue[],
+  value: unknown,
+): void {
+  collectArrayIssues(
+    issues,
+    "evidenceBundles",
+    value,
+    50,
+    evidenceBundleKeys,
+    (entry, path) => {
+      collectPatternIssue(
+        issues,
+        `${path}.evidenceBundleId`,
+        entry.evidenceBundleId,
+        prefixedIdPattern,
+        "evidenceBundleId must be a valid EIP id.",
+      );
+      collectPatternIssue(
+        issues,
+        `${path}.digest`,
+        entry.digest,
+        digestPattern,
+        "digest must be a sha256 digest.",
+        true,
+      );
+    },
+  );
+}
+
+function collectVerificationIssues(
+  issues: RunRequestValidationIssue[],
+  value: unknown,
+): void {
+  if (value === undefined) {
+    return;
+  }
+
+  if (!isRecord(value)) {
+    issues.push({
+      path: "verification",
+      message: "verification must be a JSON object.",
+    });
+    return;
+  }
+
+  collectUnknownKeyIssues(issues, value, verificationKeys, "verification");
+  collectEnumIssue(
+    issues,
+    "verification.status",
+    value.status,
+    verificationStatuses,
+    "verification.status must be a valid verification status.",
+  );
+  collectOptionalStringLengthIssue(issues, "verification.summary", value.summary, 1, 1000);
+  collectArrayIssues(
+    issues,
+    "verification.commands",
+    value.commands,
+    50,
+    verificationCommandKeys,
+    (entry, path) => {
+      collectStringLengthIssue(issues, `${path}.command`, entry.command, 1, 240);
+      collectEnumIssue(
+        issues,
+        `${path}.status`,
+        entry.status,
+        verificationStatuses,
+        "status must be a valid verification command status.",
+      );
+      collectUtcTimestampIssue(issues, `${path}.completedAt`, entry.completedAt, true);
+      collectOptionalStringLengthIssue(issues, `${path}.summary`, entry.summary, 1, 500);
+    },
+  );
+}
+
+function collectErrorIssues(issues: RunRequestValidationIssue[], value: unknown): void {
+  collectArrayIssues(issues, "errors", value, 50, errorKeys, (entry, path) => {
+    collectPatternIssue(issues, `${path}.code`, entry.code, codePattern, "code must be valid.");
+    collectStringLengthIssue(issues, `${path}.message`, entry.message, 1, 1000);
+    collectOptionalBooleanIssue(issues, `${path}.retryable`, entry.retryable);
+    collectDetailsIssues(issues, `${path}.details`, entry.details);
+  });
+}
+
+function collectWarningIssues(issues: RunRequestValidationIssue[], value: unknown): void {
+  collectArrayIssues(issues, "warnings", value, 50, warningKeys, (entry, path) => {
+    collectPatternIssue(issues, `${path}.code`, entry.code, codePattern, "code must be valid.");
+    collectStringLengthIssue(issues, `${path}.message`, entry.message, 1, 1000);
+  });
+}
+
+function collectMetricsIssues(issues: RunRequestValidationIssue[], value: unknown): void {
+  if (value === undefined) {
+    return;
+  }
+
+  if (!isRecord(value)) {
+    issues.push({
+      path: "metrics",
+      message: "metrics must be a JSON object.",
+    });
+    return;
+  }
+
+  collectUnknownKeyIssues(issues, value, metricsKeys, "metrics");
+  collectOptionalIntegerMinimumIssue(issues, "metrics.durationMs", value.durationMs, 0);
+  collectOptionalIntegerMinimumIssue(issues, "metrics.attempts", value.attempts, 1);
+  collectOptionalIntegerMinimumIssue(issues, "metrics.tokensInput", value.tokensInput, 0);
+  collectOptionalIntegerMinimumIssue(issues, "metrics.tokensOutput", value.tokensOutput, 0);
+}
+
+function collectArrayIssues(
+  issues: RunRequestValidationIssue[],
+  path: string,
+  value: unknown,
+  maxItems: number,
+  allowedKeys: ReadonlySet<string>,
+  collectEntryIssues: (entry: Record<string, unknown>, path: string) => void,
+): void {
+  if (value === undefined) {
+    return;
+  }
+
+  if (!Array.isArray(value)) {
+    issues.push({
+      path,
+      message: `${path} must be an array.`,
+    });
+    return;
+  }
+
+  if (value.length > maxItems) {
+    issues.push({
+      path,
+      message: `${path} must contain at most ${maxItems} items.`,
+    });
+  }
+
+  value.forEach((entry, index) => {
+    const entryPath = `${path}.${index}`;
+
+    if (!isRecord(entry)) {
+      issues.push({
+        path: entryPath,
+        message: `${entryPath} must be a JSON object.`,
+      });
+      return;
+    }
+
+    collectUnknownKeyIssues(issues, entry, allowedKeys, entryPath);
+    collectEntryIssues(entry, entryPath);
+  });
+}
+
+function collectDetailsIssues(
+  issues: RunRequestValidationIssue[],
+  path: string,
+  value: unknown,
+): void {
+  if (value === undefined) {
+    return;
+  }
+
+  if (!isRecord(value)) {
+    issues.push({
+      path,
+      message: `${path} must be a JSON object.`,
+    });
+    return;
+  }
+
+  for (const [key, detailValue] of Object.entries(value)) {
+    if (
+      typeof detailValue !== "string" &&
+      typeof detailValue !== "number" &&
+      typeof detailValue !== "boolean" &&
+      detailValue !== null
+    ) {
+      issues.push({
+        path: `${path}.${key}`,
+        message: "details values must be scalar JSON values.",
+      });
+    }
+  }
+}
+
+function collectExtensionsIssues(
+  issues: RunRequestValidationIssue[],
+  value: unknown,
+): void {
+  if (value === undefined) {
+    return;
+  }
+
+  if (!isRecord(value)) {
+    issues.push({
+      path: "extensions",
+      message: "extensions must be a JSON object.",
+    });
+    return;
+  }
+
+  for (const key of Object.keys(value)) {
+    if (!extensionKeyPattern.test(key)) {
+      issues.push({
+        path: `extensions.${key}`,
+        message: "extension keys must start with x-.",
+      });
+    }
+  }
+}
+
+function collectUnknownKeyIssues(
+  issues: RunRequestValidationIssue[],
+  value: Record<string, unknown>,
+  allowedKeys: ReadonlySet<string>,
+  path: string,
+): void {
+  for (const key of Object.keys(value)) {
+    if (!allowedKeys.has(key)) {
+      issues.push({
+        path: path === "$" ? key : `${path}.${key}`,
+        message: "field is not allowed.",
+      });
+    }
+  }
+}
+
+function collectConstIssue(
+  issues: RunRequestValidationIssue[],
+  path: string,
+  value: unknown,
+  expected: string,
+): void {
+  if (value !== expected) {
+    issues.push({
+      path,
+      message: `${path} must be ${expected}.`,
+    });
+  }
+}
+
+function collectPatternIssue(
+  issues: RunRequestValidationIssue[],
+  path: string,
+  value: unknown,
+  pattern: RegExp,
+  message: string,
+  optional = false,
+): void {
+  if (value === undefined && optional) {
+    return;
+  }
+
+  if (typeof value !== "string" || !pattern.test(value)) {
+    issues.push({
+      path,
+      message,
+    });
+  }
+}
+
+function collectEnumIssue(
+  issues: RunRequestValidationIssue[],
+  path: string,
+  value: unknown,
+  allowed: ReadonlySet<unknown>,
+  message: string,
+  optional = false,
+): void {
+  if (value === undefined && optional) {
+    return;
+  }
+
+  if (!allowed.has(value)) {
+    issues.push({
+      path,
+      message,
+    });
+  }
+}
+
+function collectStringLengthIssue(
+  issues: RunRequestValidationIssue[],
+  path: string,
+  value: unknown,
+  minLength: number,
+  maxLength: number,
+  optional = false,
+): void {
+  if (value === undefined && optional) {
+    return;
+  }
+
+  if (typeof value !== "string" || value.length < minLength || value.length > maxLength) {
+    issues.push({
+      path,
+      message: `${path} must be a string with length ${minLength}-${maxLength}.`,
+    });
+  }
+}
+
+function collectOptionalStringLengthIssue(
+  issues: RunRequestValidationIssue[],
+  path: string,
+  value: unknown,
+  minLength: number,
+  maxLength: number,
+): void {
+  collectStringLengthIssue(issues, path, value, minLength, maxLength, true);
+}
+
+function collectUtcTimestampIssue(
+  issues: RunRequestValidationIssue[],
+  path: string,
+  value: unknown,
+  optional = false,
+): void {
+  if (value === undefined && optional) {
+    return;
+  }
+
+  if (typeof value !== "string" || !isoDateTimeUtcPattern.test(value)) {
+    issues.push({
+      path,
+      message: `${path} must be a UTC ISO 8601 timestamp.`,
+    });
+    return;
+  }
+
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime()) || parsed.toISOString() !== normalizeUtcTimestamp(value)) {
+    issues.push({
+      path,
+      message: `${path} must be a real UTC timestamp.`,
+    });
+  }
+}
+
+function collectOptionalIntegerMinimumIssue(
+  issues: RunRequestValidationIssue[],
+  path: string,
+  value: unknown,
+  minimum: number,
+): void {
+  if (value === undefined) {
+    return;
+  }
+
+  if (typeof value !== "number" || !Number.isInteger(value) || value < minimum) {
+    issues.push({
+      path,
+      message: `${path} must be an integer greater than or equal to ${minimum}.`,
+    });
+  }
+}
+
+function collectOptionalBooleanIssue(
+  issues: RunRequestValidationIssue[],
+  path: string,
+  value: unknown,
+): void {
+  if (value === undefined) {
+    return;
+  }
+
+  if (typeof value !== "boolean") {
+    issues.push({
+      path,
+      message: `${path} must be a boolean.`,
+    });
+  }
+}
+
+function trimToMaxLength(value: string, maxLength: number): string {
+  if (value.length <= maxLength) {
+    return value;
+  }
+
+  return value.slice(0, maxLength);
+}
+
+function normalizeUtcTimestamp(value: string): string {
+  const [whole, fractional = ""] = value.slice(0, -1).split(".");
+  const normalizedFraction = fractional.replace(/0+$/, "");
+
+  if (normalizedFraction.length === 0) {
+    return `${whole}.000Z`;
+  }
+
+  return `${whole}.${normalizedFraction.padEnd(3, "0")}Z`;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}

--- a/src/protocol/run-result.ts
+++ b/src/protocol/run-result.ts
@@ -257,7 +257,7 @@ function createDryRunVerification(
 
   if (status === "failed") {
     return {
-      status: "failed",
+      status: "not_run",
       summary: "Dry-run failed before agent execution or verification commands ran.",
     };
   }

--- a/src/protocol/run-result.ts
+++ b/src/protocol/run-result.ts
@@ -124,7 +124,7 @@ const prefixedIdPattern =
 const requestIdPattern = /^req_[A-Za-z0-9][A-Za-z0-9._~-]{5,127}$/;
 const runIdPattern = /^run_[A-Za-z0-9][A-Za-z0-9._~-]{5,127}$/;
 const correlationIdPattern = /^corr_[A-Za-z0-9][A-Za-z0-9._~-]{11,127}$/;
-const isoDateTimeUtcPattern = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z$/;
+const isoDateTimeUtcPattern = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,3})?Z$/;
 const digestPattern = /^sha256:[a-f0-9]{64}$/;
 const codePattern = /^[A-Z][A-Z0-9_]{2,63}$/;
 const extensionKeyPattern = /^x-.+$/;
@@ -164,7 +164,10 @@ export function createRunResult(
     correlationId: plan.provenance.correlationId,
     status: options.status,
     completedAt: options.completedAt,
-    verification: options.verification ?? createDryRunVerification(plan, options.status),
+    verification:
+      options.verification === undefined
+        ? createDryRunVerification(plan, options.status)
+        : cloneVerification(options.verification),
     metrics: {
       attempts: 1,
     },
@@ -268,6 +271,17 @@ function createDryRunVerification(
       `Dry-run request blocked: ${plan.blockedReasons.join("; ")}`,
       1000,
     ),
+  };
+}
+
+function cloneVerification(verification: VerificationSummary): VerificationSummary {
+  return {
+    ...verification,
+    ...(verification.commands === undefined
+      ? {}
+      : {
+          commands: verification.commands.map((command) => ({ ...command })),
+        }),
   };
 }
 

--- a/test/run-result-output.test.ts
+++ b/test/run-result-output.test.ts
@@ -1,0 +1,131 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import test from "node:test";
+import { promisify } from "node:util";
+
+import {
+  createRunRequestExecutionPlan,
+  createRunResult,
+  parseRunRequest,
+  validateRunResult,
+} from "../src/protocol/index.js";
+
+const execFileAsync = promisify(execFile);
+const fixtureRoot = path.join(
+  "protocol-snapshots",
+  "ensen-protocol",
+  "v0.1.0",
+  "fixtures",
+);
+
+async function readJson(relativePath: string): Promise<unknown> {
+  return JSON.parse(await readFile(path.join(fixtureRoot, relativePath), "utf8")) as unknown;
+}
+
+test("emits RunResult-compatible dry-run succeeded and blocked outputs", async () => {
+  const readyRequest = parseRunRequest(
+    await readJson("run-request/v1/valid/github-issue-request.json"),
+  );
+  const readyPlan = createRunRequestExecutionPlan(readyRequest);
+
+  const succeeded = createRunResult(readyPlan, {
+    status: "succeeded",
+    completedAt: "2026-04-30T00:00:04Z",
+  });
+
+  assert.equal(validateRunResult(succeeded).ok, true);
+  assert.equal(succeeded.schemaVersion, "eip.run-result.v1");
+  assert.equal(succeeded.id, "run_01HV7Y8M8F2KQ5W3P9R6T4N2AB");
+  assert.equal(succeeded.requestId, readyRequest.id);
+  assert.equal(succeeded.correlationId, readyRequest.correlationId);
+  assert.equal(succeeded.status, "succeeded");
+  assert.deepEqual(succeeded.verification, {
+    status: "not_run",
+    summary: "Dry-run completed without running verification commands.",
+  });
+  assert.equal(Object.hasOwn(succeeded, "changeRequests"), false);
+  assert.equal(Object.hasOwn(succeeded, "evidenceBundles"), false);
+
+  const blockedRequest = parseRunRequest(
+    await readJson("run-request/v1/valid/manual-request.json"),
+  );
+  const blockedPlan = createRunRequestExecutionPlan(blockedRequest);
+  const blocked = createRunResult(blockedPlan, {
+    status: "blocked",
+    completedAt: "2026-04-30T00:00:05Z",
+  });
+
+  assert.equal(validateRunResult(blocked).ok, true);
+  assert.equal(blocked.requestId, blockedRequest.id);
+  assert.equal(blocked.status, "blocked");
+  assert.match(blocked.verification?.summary ?? "", /target is required/);
+  assert.deepEqual(blocked.warnings, [
+    {
+      code: "DRY_RUN_BLOCKED",
+      message: "The dry-run request stopped before execution because required planning scope is missing.",
+    },
+  ]);
+});
+
+test("rejects non-final RunResult statuses", async () => {
+  const invalid = await readJson("run-result/v1/invalid/running-status.json");
+
+  const result = validateRunResult(invalid);
+
+  assert.equal(result.ok, false);
+  assert.ok(
+    result.issues.some((issue) => issue.path === "status"),
+    "RunResult status must be terminal",
+  );
+});
+
+test("CLI emits terminal RunResult JSON for dry-run RunRequest mode", async () => {
+  const fixturePath = path.join(fixtureRoot, "run-request/v1/valid/github-issue-request.json");
+
+  const { stdout, stderr } = await execFileAsync(process.execPath, [
+    "dist/src/cli/index.js",
+    "run-request",
+    fixturePath,
+    "--run-result",
+    "succeeded",
+  ]);
+
+  assert.equal(stderr, "");
+
+  const runResult = JSON.parse(stdout) as unknown;
+  const result = validateRunResult(runResult);
+
+  assert.equal(result.ok, true);
+  assert.equal(result.ok && result.result.status, "succeeded");
+});
+
+test("CLI emits blocked RunResult JSON for blocked dry-run plans", async () => {
+  const fixturePath = path.join(fixtureRoot, "run-request/v1/valid/manual-request.json");
+
+  await assert.rejects(
+    execFileAsync(process.execPath, [
+      "dist/src/cli/index.js",
+      "run-request",
+      fixturePath,
+      "--run-result",
+      "succeeded",
+    ]),
+    (error: unknown) => {
+      assert.ok(error && typeof error === "object");
+      assert.ok("code" in error);
+      assert.equal(error.code, 1);
+      assert.ok("stdout" in error && typeof error.stdout === "string");
+
+      const runResult = JSON.parse(error.stdout) as unknown;
+      const result = validateRunResult(runResult);
+
+      assert.equal(result.ok, true);
+      assert.equal(result.ok && result.result.status, "blocked");
+      assert.match(result.ok ? (result.result.verification?.summary ?? "") : "", /target is required/);
+
+      return true;
+    },
+  );
+});

--- a/test/run-result-output.test.ts
+++ b/test/run-result-output.test.ts
@@ -128,10 +128,16 @@ test("rejects non-final RunResult statuses", async () => {
 });
 
 test("rejects RunResult timestamps beyond millisecond precision", async () => {
-  const invalid = await readJson("run-result/v1/invalid/running-status.json");
-  const timestampWithMicroseconds = {
-    ...(invalid as Record<string, unknown>),
+  const readyRequest = parseRunRequest(
+    await readJson("run-request/v1/valid/github-issue-request.json"),
+  );
+  const readyPlan = createRunRequestExecutionPlan(readyRequest);
+  const valid = createRunResult(readyPlan, {
     status: "succeeded",
+    completedAt: "2026-04-30T00:00:00Z",
+  });
+  const timestampWithMicroseconds = {
+    ...valid,
     completedAt: "2026-04-30T00:00:00.123456Z",
   };
 

--- a/test/run-result-output.test.ts
+++ b/test/run-result-output.test.ts
@@ -84,6 +84,37 @@ test("emits RunResult-compatible dry-run terminal outputs", async () => {
   ]);
 });
 
+test("clones caller-provided RunResult verification payloads", async () => {
+  const readyRequest = parseRunRequest(
+    await readJson("run-request/v1/valid/github-issue-request.json"),
+  );
+  const readyPlan = createRunRequestExecutionPlan(readyRequest);
+  const verification = {
+    status: "passed" as const,
+    summary: "initial verification summary",
+    commands: [
+      {
+        command: "npm test",
+        status: "passed" as const,
+        completedAt: "2026-04-30T00:00:04Z",
+        summary: "initial command summary",
+      },
+    ],
+  };
+
+  const result = createRunResult(readyPlan, {
+    status: "succeeded",
+    completedAt: "2026-04-30T00:00:05Z",
+    verification,
+  });
+
+  verification.summary = "mutated verification summary";
+  verification.commands[0].summary = "mutated command summary";
+
+  assert.equal(result.verification?.summary, "initial verification summary");
+  assert.equal(result.verification?.commands?.[0]?.summary, "initial command summary");
+});
+
 test("rejects non-final RunResult statuses", async () => {
   const invalid = await readJson("run-result/v1/invalid/running-status.json");
 
@@ -93,6 +124,27 @@ test("rejects non-final RunResult statuses", async () => {
   assert.ok(
     result.issues.some((issue) => issue.path === "status"),
     "RunResult status must be terminal",
+  );
+});
+
+test("rejects RunResult timestamps beyond millisecond precision", async () => {
+  const invalid = await readJson("run-result/v1/invalid/running-status.json");
+  const timestampWithMicroseconds = {
+    ...(invalid as Record<string, unknown>),
+    status: "succeeded",
+    completedAt: "2026-04-30T00:00:00.123456Z",
+  };
+
+  const result = validateRunResult(timestampWithMicroseconds);
+
+  assert.equal(result.ok, false);
+  assert.ok(
+    result.issues.some(
+      (issue) =>
+        issue.path === "completedAt" &&
+        issue.message === "completedAt must be a UTC ISO 8601 timestamp.",
+    ),
+    "RunResult timestamps must use millisecond precision or less",
   );
 });
 

--- a/test/run-result-output.test.ts
+++ b/test/run-result-output.test.ts
@@ -24,7 +24,7 @@ async function readJson(relativePath: string): Promise<unknown> {
   return JSON.parse(await readFile(path.join(fixtureRoot, relativePath), "utf8")) as unknown;
 }
 
-test("emits RunResult-compatible dry-run succeeded and blocked outputs", async () => {
+test("emits RunResult-compatible dry-run terminal outputs", async () => {
   const readyRequest = parseRunRequest(
     await readJson("run-request/v1/valid/github-issue-request.json"),
   );
@@ -48,13 +48,28 @@ test("emits RunResult-compatible dry-run succeeded and blocked outputs", async (
   assert.equal(Object.hasOwn(succeeded, "changeRequests"), false);
   assert.equal(Object.hasOwn(succeeded, "evidenceBundles"), false);
 
+  const failed = createRunResult(readyPlan, {
+    status: "failed",
+    completedAt: "2026-04-30T00:00:05Z",
+  });
+
+  assert.equal(validateRunResult(failed).ok, true);
+  assert.equal(failed.requestId, readyRequest.id);
+  assert.equal(failed.status, "failed");
+  assert.deepEqual(failed.verification, {
+    status: "not_run",
+    summary: "Dry-run failed before agent execution or verification commands ran.",
+  });
+  assert.equal(failed.errors?.[0]?.code, "DRY_RUN_FAILED");
+  assert.equal(failed.errors?.[0]?.retryable, false);
+
   const blockedRequest = parseRunRequest(
     await readJson("run-request/v1/valid/manual-request.json"),
   );
   const blockedPlan = createRunRequestExecutionPlan(blockedRequest);
   const blocked = createRunResult(blockedPlan, {
     status: "blocked",
-    completedAt: "2026-04-30T00:00:05Z",
+    completedAt: "2026-04-30T00:00:06Z",
   });
 
   assert.equal(validateRunResult(blocked).ok, true);
@@ -99,6 +114,36 @@ test("CLI emits terminal RunResult JSON for dry-run RunRequest mode", async () =
 
   assert.equal(result.ok, true);
   assert.equal(result.ok && result.result.status, "succeeded");
+});
+
+test("CLI emits failed RunResult JSON for failed dry-run RunRequest mode", async () => {
+  const fixturePath = path.join(fixtureRoot, "run-request/v1/valid/github-issue-request.json");
+
+  await assert.rejects(
+    execFileAsync(process.execPath, [
+      "dist/src/cli/index.js",
+      "run-request",
+      fixturePath,
+      "--run-result",
+      "failed",
+    ]),
+    (error: unknown) => {
+      assert.ok(error && typeof error === "object");
+      assert.ok("code" in error);
+      assert.equal(error.code, 1);
+      assert.ok("stdout" in error && typeof error.stdout === "string");
+
+      const runResult = JSON.parse(error.stdout) as unknown;
+      const result = validateRunResult(runResult);
+
+      assert.equal(result.ok, true);
+      assert.equal(result.ok && result.result.status, "failed");
+      assert.equal(result.ok && result.result.verification?.status, "not_run");
+      assert.equal(result.ok && result.result.errors?.[0]?.code, "DRY_RUN_FAILED");
+
+      return true;
+    },
+  );
 });
 
 test("CLI emits blocked RunResult JSON for blocked dry-run plans", async () => {


### PR DESCRIPTION
## Summary
- add RunResult creation and validation helpers for dry-run succeeded, failed, and blocked terminal outcomes
- expose run-request --run-result succeeded|failed|blocked from the CLI
- add focused RunResult tests for deterministic identity binding, blocked output, non-final rejection, and CLI JSON output

## Verification
- npm ci
- npm run typecheck
- npm run build
- npm test

Closes #25

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a --run-result <succeeded|failed|blocked> CLI option with updated usage/help and non-zero exit codes for blocked/failed outcomes; CLI now computes completion timestamps and can emit blocked results when validation fails.
  * Introduced a RunResult protocol: schema, statuses/verification enums, validation rules, and helpers to construct validated or blocked run results.

* **Tests**
  * Added unit and end-to-end tests covering RunResult creation, validation, cloning behavior, and CLI integration for succeeded/failed/blocked flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->