### PR TITLE
LOOP-015: Add EvidenceBundleRef output contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,11 +26,13 @@ node dist/src/cli/index.js run-request <run-request-json-file>
 node dist/src/cli/index.js run-request <run-request-json-file> --status-snapshot queued
 ```
 
-`dry-run --sample` emits a deterministic local execution plan as JSON. It describes the work item, lane workspace, agent provider, SCM provider, verification, and evidence intents without creating worktrees, branches, commits, change requests, durable evidence, or invoking external providers.
+`dry-run --sample` emits a deterministic local execution plan as JSON. It describes the work item, lane workspace, agent provider, SCM provider, verification, and evidence intents without creating worktrees, branches, commits, change requests, durable evidence, or invoking external providers. Its evidence section may include EvidenceBundleRef v1-compatible references as validation-ready metadata. These references identify where evidence could be found; they are not full evidence bundle artifacts and do not claim durable compliance packaging.
 
 `run-request <run-request-json-file>` reads an EIP RunRequest v1 JSON file, validates it at the protocol input boundary, and emits either `{ "ok": true, "request": ... }` or `{ "ok": false, "issues": [...] }`. The `source` field is protocol input data, not trusted internal authority.
 
 `run-request <run-request-json-file> --status-snapshot accepted|queued|running|blocked` emits a RunStatusSnapshot-compatible dry-run polling snapshot for the request. The mode maps only Ensen-loop dry-run lifecycle facts; it does not read Ensen-flow workflow state, approval state, or final RunResult fields. If validation or plan normalization blocks the dry run and valid request/correlation identifiers are available, the command emits a blocked status snapshot with actionable reasons under `extensions.x-ensen-loop-blocked-reasons`.
+
+EvidenceBundleRef validation is exposed as an Ensen-loop-native protocol helper for copied Ensen-protocol v0.1.0 fixtures and dry-run metadata. It accepts relative traversal-free local paths and absolute `file:///` URIs, rejects credential-shaped URIs, query or fragment-bearing file URIs, traversal, absolute local paths, and ambiguous local path shapes, and keeps validation independent from any Ensen-flow runtime.
 
 ## Scope
 

--- a/docs/architecture/core-model.md
+++ b/docs/architecture/core-model.md
@@ -44,7 +44,7 @@ The Lane Journal is embedded in the Lane Run State for Phase 1. It records short
 Audit and evidence surfaces are represented as explicit reference lists on the Lane Run State:
 
 - `audit.eventRefs` reserves the relationship to future audit events without emitting a full EIP AuditEvent.
-- `evidence.bundleRefs` reserves the relationship to future evidence bundles without emitting a full EvidenceBundleRef.
+- `evidence.bundleRefs` reserves the relationship to future evidence bundles. Dry-run output may expose EvidenceBundleRef v1-compatible reference metadata, but that metadata is not a full evidence bundle artifact and does not claim durable compliance packaging.
 
 Local storage helpers must resolve lane run state paths below a real configured state root, reject lane run identifiers containing path separators or traversal syntax, and fail closed when existing storage components are symbolic links. Derived summaries, detail projections, or operator-facing notes must be rebuilt from the Lane Run State instead of redefining the durable status.
 

--- a/docs/reference/quality-kit.md
+++ b/docs/reference/quality-kit.md
@@ -19,6 +19,7 @@ The Ensen-loop quality kit is the repo-owned vocabulary for keeping AI-assisted 
 | Lane journal | The short-horizon handoff record for active work. | Current hypothesis, changed files, focused commands, failures, rollback concerns, and next action are recorded. |
 | Verification gate | The repo-owned commands that prove the work locally. | For this baseline, `npm run typecheck`, `npm run build`, and `npm test` are the required checks after `npm ci` has installed dependencies. |
 | Evidence bundle | The collected facts that justify publication or repair. | Issue scope, branch/head state, changed files, test output, review facts, and PR state are linked without relying on chat memory. |
+| EvidenceBundleRef | Validation-ready metadata that points at an evidence bundle location. | The reference must be path-safe and secret-safe; it does not embed the bundle body and does not by itself make a compliance claim. |
 | Reviewability | The ability for humans and tools to inspect the change safely. | The PR or handoff names the behavior delta, verification performed, unresolved risks, and review signal state. |
 | Lane introspection | Operator-facing status and explanation surfaces. | Summaries must be derived from authoritative lane state rather than stale display text. |
 
@@ -35,7 +36,9 @@ Ensen-loop keeps the quality goals, not the old implementation shape:
 
 ## Phase 1 Boundary
 
-This document does not define EIP RunRequest or RunResult. It also does not make codex-supervisor a package dependency. Future phases may turn these concepts into schemas, commands, or runtime enforcement, but those contracts must be Ensen-loop-native and explicitly documented before implementation work depends on them.
+This document does not make codex-supervisor a package dependency. Protocol contract work must stay Ensen-loop-native and explicitly documented before runtime behavior depends on it.
+
+EvidenceBundleRef v1 handling is limited to the reference boundary. Ensen-loop can validate copied protocol fixtures and expose dry-run reference examples, but the sample does not write a durable bundle, package evidence, or assert compliance readiness. Safe references use repo-relative traversal-free local paths or absolute `file:///` URIs without query strings, fragments, credentials, or raw secret material.
 
 ## Baseline Verification
 

--- a/src/lane/index.ts
+++ b/src/lane/index.ts
@@ -7,6 +7,7 @@ import path from "node:path";
 import type { LaneAuditRefs } from "../audit/index.js";
 import type { WorkItem } from "../core/index.js";
 import type { LaneEvidenceRefs } from "../evidence/index.js";
+import type { EvidenceBundleRef } from "../protocol/index.js";
 import { sampleLocalWorkItem } from "../work-item/index.js";
 
 export type LaneRunStatus =
@@ -497,6 +498,7 @@ export interface DryRunExecutionPlan {
   readonly evidence: {
     readonly intent: string;
     readonly writesDurableEvidence: false;
+    readonly bundleRefs: readonly EvidenceBundleRef[];
   };
 }
 
@@ -523,8 +525,25 @@ export function createSampleDryRunExecutionPlan(): DryRunExecutionPlan {
       commands: ["npm run build", "npm test"],
     },
     evidence: {
-      intent: "describe evidence capture without writing durable evidence",
+      intent:
+        "describe validation-ready evidence metadata without writing a full evidence bundle artifact",
       writesDurableEvidence: false,
+      bundleRefs: [
+        {
+          schemaVersion: "eip.evidence-bundle-ref.v1",
+          id: "evb_sampleDryRunEvidenceRef01",
+          correlationId: "corr_sampleDryRunEvidenceRef01",
+          type: "local_path",
+          uri: "artifacts/evidence/dry-run/sample-bundle.json",
+          createdAt: "2026-04-29T00:00:00Z",
+          contentType: "application/json",
+          metadata: {
+            producer: "ensen-loop",
+            artifactKind: "validationReadyEvidenceMetadata",
+            writesDurableEvidence: false,
+          },
+        },
+      ],
     },
   };
 }

--- a/src/protocol/evidence-bundle-ref.ts
+++ b/src/protocol/evidence-bundle-ref.ts
@@ -1,0 +1,331 @@
+export type EvidenceBundleRefType = "local_path" | "file_uri";
+
+export interface EvidenceBundleChecksum {
+  readonly algorithm: "sha256";
+  readonly value: string;
+}
+
+export type EvidenceBundleMetadataValue = string | number | boolean | null;
+
+export interface EvidenceBundleRef {
+  readonly schemaVersion: "eip.evidence-bundle-ref.v1";
+  readonly id: string;
+  readonly correlationId: string;
+  readonly type: EvidenceBundleRefType;
+  readonly uri: string;
+  readonly createdAt: string;
+  readonly contentType?: string;
+  readonly checksum?: EvidenceBundleChecksum;
+  readonly metadata?: Record<string, EvidenceBundleMetadataValue>;
+}
+
+export interface EvidenceBundleRefValidationIssue {
+  readonly path: string;
+  readonly message: string;
+}
+
+export interface EvidenceBundleRefValidationSuccess {
+  readonly ok: true;
+  readonly ref: EvidenceBundleRef;
+}
+
+export interface EvidenceBundleRefValidationFailure {
+  readonly ok: false;
+  readonly issues: readonly EvidenceBundleRefValidationIssue[];
+}
+
+export type EvidenceBundleRefValidationResult =
+  | EvidenceBundleRefValidationSuccess
+  | EvidenceBundleRefValidationFailure;
+
+const evidenceBundleRefKeys = new Set([
+  "schemaVersion",
+  "id",
+  "correlationId",
+  "type",
+  "uri",
+  "createdAt",
+  "contentType",
+  "checksum",
+  "metadata",
+]);
+const checksumKeys = new Set(["algorithm", "value"]);
+
+const prefixedIdPattern =
+  /^(?:actor|artifact|corr|cr|evb|evt|flowstep|policy|pr|repo|req|run|source|sts|workitem)_[A-Za-z0-9][A-Za-z0-9._~-]{5,127}$/;
+const correlationIdPattern = /^corr_[A-Za-z0-9][A-Za-z0-9._~-]{11,127}$/;
+const isoDateTimeUtcPattern = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z$/;
+const contentTypePattern =
+  /^[A-Za-z0-9][A-Za-z0-9!#$&^_.+-]*\/[A-Za-z0-9][A-Za-z0-9!#$&^_.+-]*(?:; ?[A-Za-z0-9_.-]+=[A-Za-z0-9_.+-]+)*$/;
+const checksumPattern = /^[a-f0-9]{64}$/;
+const metadataKeyPattern = /^[a-z][a-z0-9]*(?:[A-Z][a-z0-9]*)*$/;
+const credentialUriAuthorityPattern =
+  /^[A-Za-z][A-Za-z0-9+.-]*:\/\/[^/?#\s]*[^/?#\s:@]+:[^/?#\s:@]+@/;
+const localPathPattern = /^(?![A-Za-z][A-Za-z0-9+.-]*:\/\/)(?!\/)(?!.*(?:^|\/)\.\.(?:\/|$))[A-Za-z0-9._~@/-]+$/;
+const fileUriPattern = /^file:\/\/\/(?!.*(?:^|\/)\.\.(?:\/|$))[^\s?#]+$/;
+const evidenceBundleRefTypes = new Set<unknown>(["local_path", "file_uri"]);
+
+export function validateEvidenceBundleRef(value: unknown): EvidenceBundleRefValidationResult {
+  const issues = collectEvidenceBundleRefIssues(value);
+
+  if (issues.length > 0) {
+    return {
+      ok: false,
+      issues,
+    };
+  }
+
+  return {
+    ok: true,
+    ref: value as EvidenceBundleRef,
+  };
+}
+
+function collectEvidenceBundleRefIssues(
+  value: unknown,
+): readonly EvidenceBundleRefValidationIssue[] {
+  if (!isRecord(value)) {
+    return [
+      {
+        path: "$",
+        message: "EvidenceBundleRef input must be a JSON object.",
+      },
+    ];
+  }
+
+  const issues: EvidenceBundleRefValidationIssue[] = [];
+
+  collectUnknownKeyIssues(issues, value, evidenceBundleRefKeys, "$");
+  collectConstIssue(issues, "schemaVersion", value.schemaVersion, "eip.evidence-bundle-ref.v1");
+  collectPatternIssue(issues, "id", value.id, prefixedIdPattern, "id must be a valid EIP id.");
+  collectPatternIssue(
+    issues,
+    "correlationId",
+    value.correlationId,
+    correlationIdPattern,
+    "correlationId must be a valid EIP correlation id.",
+  );
+  collectEnumIssue(
+    issues,
+    "type",
+    value.type,
+    evidenceBundleRefTypes,
+    "type must be local_path or file_uri.",
+  );
+  collectUriIssues(issues, value.type, value.uri);
+  collectUtcTimestampIssue(issues, "createdAt", value.createdAt);
+  collectPatternIssue(
+    issues,
+    "contentType",
+    value.contentType,
+    contentTypePattern,
+    "contentType must be a valid media type.",
+    true,
+  );
+  collectChecksumIssues(issues, value.checksum);
+  collectMetadataIssues(issues, value.metadata);
+
+  return issues;
+}
+
+function collectUriIssues(
+  issues: EvidenceBundleRefValidationIssue[],
+  type: unknown,
+  value: unknown,
+): void {
+  if (typeof value !== "string" || value.length < 1 || value.length > 1000) {
+    issues.push({
+      path: "uri",
+      message: "uri must be a string with length 1-1000.",
+    });
+    return;
+  }
+
+  if (credentialUriAuthorityPattern.test(value)) {
+    issues.push({
+      path: "uri",
+      message: "uri must not contain credential material.",
+    });
+  }
+
+  if (type === "local_path" && !localPathPattern.test(value)) {
+    issues.push({
+      path: "uri",
+      message: "local_path uri must be relative, traversal-free, and scheme-free.",
+    });
+  }
+
+  if (type === "file_uri" && !fileUriPattern.test(value)) {
+    issues.push({
+      path: "uri",
+      message: "file_uri uri must be an absolute file URI without traversal, query, or fragment.",
+    });
+  }
+}
+
+function collectChecksumIssues(
+  issues: EvidenceBundleRefValidationIssue[],
+  value: unknown,
+): void {
+  if (value === undefined) {
+    return;
+  }
+
+  if (!isRecord(value)) {
+    issues.push({
+      path: "checksum",
+      message: "checksum must be a JSON object.",
+    });
+    return;
+  }
+
+  collectUnknownKeyIssues(issues, value, checksumKeys, "checksum");
+  collectConstIssue(issues, "checksum.algorithm", value.algorithm, "sha256");
+  collectPatternIssue(
+    issues,
+    "checksum.value",
+    value.value,
+    checksumPattern,
+    "checksum.value must be a sha256 digest value.",
+  );
+}
+
+function collectMetadataIssues(
+  issues: EvidenceBundleRefValidationIssue[],
+  value: unknown,
+): void {
+  if (value === undefined) {
+    return;
+  }
+
+  if (!isRecord(value)) {
+    issues.push({
+      path: "metadata",
+      message: "metadata must be a JSON object.",
+    });
+    return;
+  }
+
+  const entries = Object.entries(value);
+  if (entries.length > 20) {
+    issues.push({
+      path: "metadata",
+      message: "metadata must contain at most 20 properties.",
+    });
+  }
+
+  for (const [key, metadataValue] of entries) {
+    if (!metadataKeyPattern.test(key)) {
+      issues.push({
+        path: `metadata.${key}`,
+        message: "metadata keys must be lower camel case.",
+      });
+    }
+
+    if (
+      metadataValue !== null &&
+      typeof metadataValue !== "number" &&
+      typeof metadataValue !== "boolean" &&
+      !(
+        typeof metadataValue === "string" &&
+        metadataValue.length >= 1 &&
+        metadataValue.length <= 500
+      )
+    ) {
+      issues.push({
+        path: `metadata.${key}`,
+        message: "metadata values must be scalar JSON values.",
+      });
+    }
+  }
+}
+
+function collectUnknownKeyIssues(
+  issues: EvidenceBundleRefValidationIssue[],
+  value: Record<string, unknown>,
+  allowedKeys: ReadonlySet<string>,
+  path: string,
+): void {
+  for (const key of Object.keys(value)) {
+    if (!allowedKeys.has(key)) {
+      issues.push({
+        path: path === "$" ? key : `${path}.${key}`,
+        message: "field is not allowed.",
+      });
+    }
+  }
+}
+
+function collectConstIssue(
+  issues: EvidenceBundleRefValidationIssue[],
+  path: string,
+  value: unknown,
+  expected: string,
+): void {
+  if (value !== expected) {
+    issues.push({
+      path,
+      message: `${path} must be ${expected}.`,
+    });
+  }
+}
+
+function collectPatternIssue(
+  issues: EvidenceBundleRefValidationIssue[],
+  path: string,
+  value: unknown,
+  pattern: RegExp,
+  message: string,
+  optional = false,
+): void {
+  if (value === undefined && optional) {
+    return;
+  }
+
+  if (typeof value !== "string" || !pattern.test(value)) {
+    issues.push({
+      path,
+      message,
+    });
+  }
+}
+
+function collectEnumIssue(
+  issues: EvidenceBundleRefValidationIssue[],
+  path: string,
+  value: unknown,
+  allowed: ReadonlySet<unknown>,
+  message: string,
+): void {
+  if (!allowed.has(value)) {
+    issues.push({
+      path,
+      message,
+    });
+  }
+}
+
+function collectUtcTimestampIssue(
+  issues: EvidenceBundleRefValidationIssue[],
+  path: string,
+  value: unknown,
+): void {
+  if (typeof value !== "string" || !isoDateTimeUtcPattern.test(value)) {
+    issues.push({
+      path,
+      message: `${path} must be a UTC ISO 8601 timestamp.`,
+    });
+    return;
+  }
+
+  if (Number.isNaN(Date.parse(value))) {
+    issues.push({
+      path,
+      message: `${path} must be a real UTC timestamp.`,
+    });
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}

--- a/src/protocol/evidence-bundle-ref.ts
+++ b/src/protocol/evidence-bundle-ref.ts
@@ -63,6 +63,8 @@ const credentialUriAuthorityPattern =
   /^[A-Za-z][A-Za-z0-9+.-]*:\/\/[^/?#\s]*[^/?#\s:@]+:[^/?#\s:@]+@/;
 const localPathPattern = /^(?![A-Za-z][A-Za-z0-9+.-]*:\/\/)(?!\/)(?!.*(?:^|\/)\.\.(?:\/|$))[A-Za-z0-9._~@/-]+$/;
 const fileUriPattern = /^file:\/\/\/(?!.*(?:^|\/)\.\.(?:\/|$))[^\s?#]+$/;
+const fileUriIssueMessage =
+  "file_uri uri must be an absolute file URI without traversal, query, or fragment.";
 const evidenceBundleRefTypes = new Set<unknown>(["local_path", "file_uri"]);
 
 export function validateEvidenceBundleRef(value: unknown): EvidenceBundleRefValidationResult {
@@ -155,10 +157,77 @@ function collectUriIssues(
     });
   }
 
-  if (type === "file_uri" && !fileUriPattern.test(value)) {
+  if (type === "file_uri") {
+    collectFileUriIssues(issues, value);
+  }
+}
+
+function collectFileUriIssues(
+  issues: EvidenceBundleRefValidationIssue[],
+  value: string,
+): void {
+  if (!fileUriPattern.test(value)) {
     issues.push({
       path: "uri",
-      message: "file_uri uri must be an absolute file URI without traversal, query, or fragment.",
+      message: fileUriIssueMessage,
+    });
+    return;
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(value);
+  } catch {
+    issues.push({
+      path: "uri",
+      message: "file_uri uri must be a valid absolute file URI.",
+    });
+    return;
+  }
+
+  const rawPath = value.slice("file://".length);
+  if (
+    parsed.protocol !== "file:" ||
+    parsed.username !== "" ||
+    parsed.password !== "" ||
+    parsed.search !== "" ||
+    parsed.hash !== "" ||
+    rawPath.startsWith("//")
+  ) {
+    issues.push({
+      path: "uri",
+      message: fileUriIssueMessage,
+    });
+    return;
+  }
+
+  let decodedSegments: string[];
+  try {
+    decodedSegments = rawPath
+      .split("/")
+      .filter((segment) => segment.length > 0)
+      .map((segment) => decodeURIComponent(segment));
+  } catch {
+    issues.push({
+      path: "uri",
+      message: fileUriIssueMessage,
+    });
+    return;
+  }
+
+  if (
+    decodedSegments.some(
+      (segment) =>
+        segment === "." ||
+        segment === ".." ||
+        segment.includes("/") ||
+        segment.includes("\\") ||
+        /[\s\u0000-\u001f\u007f]/.test(segment),
+    )
+  ) {
+    issues.push({
+      path: "uri",
+      message: fileUriIssueMessage,
     });
   }
 }
@@ -224,8 +293,8 @@ function collectMetadataIssues(
 
     if (
       metadataValue !== null &&
-      typeof metadataValue !== "number" &&
       typeof metadataValue !== "boolean" &&
+      !(typeof metadataValue === "number" && Number.isFinite(metadataValue)) &&
       !(
         typeof metadataValue === "string" &&
         metadataValue.length >= 1 &&

--- a/src/protocol/index.ts
+++ b/src/protocol/index.ts
@@ -1,3 +1,4 @@
+export * from "./evidence-bundle-ref.js";
 export * from "./run-request.js";
 export * from "./run-result.js";
 export * from "./run-status.js";

--- a/src/protocol/run-request.ts
+++ b/src/protocol/run-request.ts
@@ -117,6 +117,7 @@ export interface RunRequestExecutionPlan {
   readonly evidence: {
     readonly intent: string;
     readonly writesDurableEvidence: false;
+    readonly bundleRefs: readonly [];
   };
 }
 
@@ -277,6 +278,7 @@ export function createRunRequestExecutionPlan(request: RunRequest): RunRequestEx
     evidence: {
       intent: "normalize evidence intent without writing durable evidence",
       writesDurableEvidence: false,
+      bundleRefs: [],
     },
   };
 }

--- a/src/protocol/run-result.ts
+++ b/src/protocol/run-result.ts
@@ -27,7 +27,7 @@ export interface ChangeRequestRef {
   readonly status?: "draft" | "open" | "accepted" | "rejected" | "superseded";
 }
 
-export interface EvidenceBundleRef {
+export interface RunResultEvidenceBundleRef {
   readonly evidenceBundleId: string;
   readonly digest?: string;
 }
@@ -59,7 +59,7 @@ export interface RunResult {
   readonly status: RunResultStatus;
   readonly completedAt: string;
   readonly changeRequests?: readonly ChangeRequestRef[];
-  readonly evidenceBundles?: readonly EvidenceBundleRef[];
+  readonly evidenceBundles?: readonly RunResultEvidenceBundleRef[];
   readonly verification?: VerificationSummary;
   readonly errors?: readonly RunResultErrorInfo[];
   readonly warnings?: readonly RunResultWarningInfo[];
@@ -71,7 +71,7 @@ export interface CreateRunResultOptions {
   readonly status: "succeeded" | "failed" | "blocked";
   readonly completedAt: string;
   readonly verification?: VerificationSummary;
-  readonly evidenceBundles?: readonly EvidenceBundleRef[];
+  readonly evidenceBundles?: readonly RunResultEvidenceBundleRef[];
   readonly errors?: readonly RunResultErrorInfo[];
   readonly warnings?: readonly RunResultWarningInfo[];
   readonly durationMs?: number;

--- a/test/dry-run-cli.test.ts
+++ b/test/dry-run-cli.test.ts
@@ -43,6 +43,7 @@ test("dry-run sample emits a normalized execution plan", async () => {
     evidence: {
       intent: string;
       writesDurableEvidence: boolean;
+      bundleRefs: readonly unknown[];
     };
   };
 
@@ -72,7 +73,24 @@ test("dry-run sample emits a normalized execution plan", async () => {
     commands: ["npm run build", "npm test"],
   });
   assert.deepEqual(plan.evidence, {
-    intent: "describe evidence capture without writing durable evidence",
+    intent:
+      "describe validation-ready evidence metadata without writing a full evidence bundle artifact",
     writesDurableEvidence: false,
+    bundleRefs: [
+      {
+        schemaVersion: "eip.evidence-bundle-ref.v1",
+        id: "evb_sampleDryRunEvidenceRef01",
+        correlationId: "corr_sampleDryRunEvidenceRef01",
+        type: "local_path",
+        uri: "artifacts/evidence/dry-run/sample-bundle.json",
+        createdAt: "2026-04-29T00:00:00Z",
+        contentType: "application/json",
+        metadata: {
+          producer: "ensen-loop",
+          artifactKind: "validationReadyEvidenceMetadata",
+          writesDurableEvidence: false,
+        },
+      },
+    ],
   });
 });

--- a/test/evidence-bundle-ref.test.ts
+++ b/test/evidence-bundle-ref.test.ts
@@ -1,0 +1,82 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import test from "node:test";
+
+import {
+  createSampleDryRunExecutionPlan,
+  validateEvidenceBundleRef,
+} from "../src/index.js";
+
+const fixtureRoot = path.join(
+  "protocol-snapshots",
+  "ensen-protocol",
+  "v0.1.0",
+  "fixtures",
+  "evidence-bundle-ref",
+  "v1",
+);
+
+async function readJson(relativePath: string): Promise<unknown> {
+  return JSON.parse(await readFile(path.join(fixtureRoot, relativePath), "utf8")) as unknown;
+}
+
+test("accepts copied EvidenceBundleRef fixtures at the Ensen-loop boundary", async () => {
+  for (const fixturePath of ["valid/local-path.json", "valid/file-uri.json"]) {
+    const result = validateEvidenceBundleRef(await readJson(fixturePath));
+
+    assert.equal(result.ok, true, `${fixturePath} must pass validation`);
+  }
+});
+
+test("rejects unsafe EvidenceBundleRef paths and secret-bearing URI shapes", async () => {
+  const unsafeExamples = [
+    {
+      schemaVersion: "eip.evidence-bundle-ref.v1",
+      id: "evb_01HV9ZX8J2K6T3QW4R5Y7M8N9U",
+      correlationId: "corr_01HV9ZX8J2K6T3QW4R5Y7M8N9R",
+      type: "local_path",
+      uri: "../evidence/bundle.json",
+      createdAt: "2026-04-29T00:10:00Z",
+    },
+    {
+      schemaVersion: "eip.evidence-bundle-ref.v1",
+      id: "evb_01HV9ZX8J2K6T3QW4R5Y7M8N9U",
+      correlationId: "corr_01HV9ZX8J2K6T3QW4R5Y7M8N9R",
+      type: "local_path",
+      uri: "/var/lib/ensen/evidence/bundle.json",
+      createdAt: "2026-04-29T00:10:00Z",
+    },
+    {
+      schemaVersion: "eip.evidence-bundle-ref.v1",
+      id: "evb_01HV9ZX8J2K6T3QW4R5Y7M8N9U",
+      correlationId: "corr_01HV9ZX8J2K6T3QW4R5Y7M8N9R",
+      type: "file_uri",
+      uri: "file:///evidence.example.test/bundle.json?token=REDACTED_FIXTURE_SECRET_PLACEHOLDER",
+      createdAt: "2026-04-29T00:10:00Z",
+    },
+  ];
+
+  for (const example of unsafeExamples) {
+    const result = validateEvidenceBundleRef(example);
+
+    assert.equal(result.ok, false, `${example.uri} must fail closed`);
+  }
+
+  const invalidFixture = validateEvidenceBundleRef(await readJson("invalid/raw-secret-uri.json"));
+
+  assert.equal(invalidFixture.ok, false, "invalid copied fixture must fail validation");
+});
+
+test("dry-run sample exposes validation-ready EvidenceBundleRef references", () => {
+  const plan = createSampleDryRunExecutionPlan();
+
+  assert.equal(plan.evidence.writesDurableEvidence, false);
+  assert.ok(plan.evidence.bundleRefs.length > 0);
+
+  for (const bundleRef of plan.evidence.bundleRefs) {
+    const result = validateEvidenceBundleRef(bundleRef);
+
+    assert.equal(result.ok, true, `${bundleRef.uri} must be EvidenceBundleRef-compatible`);
+  }
+});

--- a/test/evidence-bundle-ref.test.ts
+++ b/test/evidence-bundle-ref.test.ts
@@ -51,8 +51,40 @@ test("rejects unsafe EvidenceBundleRef paths and secret-bearing URI shapes", asy
       schemaVersion: "eip.evidence-bundle-ref.v1",
       id: "evb_01HV9ZX8J2K6T3QW4R5Y7M8N9U",
       correlationId: "corr_01HV9ZX8J2K6T3QW4R5Y7M8N9R",
+      type: "local_path",
+      uri: "evidence\\bundle.json",
+      createdAt: "2026-04-29T00:10:00Z",
+    },
+    {
+      schemaVersion: "eip.evidence-bundle-ref.v1",
+      id: "evb_01HV9ZX8J2K6T3QW4R5Y7M8N9U",
+      correlationId: "corr_01HV9ZX8J2K6T3QW4R5Y7M8N9R",
       type: "file_uri",
       uri: "file:///evidence.example.test/bundle.json?token=REDACTED_FIXTURE_SECRET_PLACEHOLDER",
+      createdAt: "2026-04-29T00:10:00Z",
+    },
+    {
+      schemaVersion: "eip.evidence-bundle-ref.v1",
+      id: "evb_01HV9ZX8J2K6T3QW4R5Y7M8N9U",
+      correlationId: "corr_01HV9ZX8J2K6T3QW4R5Y7M8N9R",
+      type: "file_uri",
+      uri: "file://user:REDACTED_FIXTURE_SECRET_PLACEHOLDER@localhost/evidence/bundle.json",
+      createdAt: "2026-04-29T00:10:00Z",
+    },
+    {
+      schemaVersion: "eip.evidence-bundle-ref.v1",
+      id: "evb_01HV9ZX8J2K6T3QW4R5Y7M8N9U",
+      correlationId: "corr_01HV9ZX8J2K6T3QW4R5Y7M8N9R",
+      type: "file_uri",
+      uri: "file:///evidence/%2e%2e/bundle.json",
+      createdAt: "2026-04-29T00:10:00Z",
+    },
+    {
+      schemaVersion: "eip.evidence-bundle-ref.v1",
+      id: "evb_01HV9ZX8J2K6T3QW4R5Y7M8N9U",
+      correlationId: "corr_01HV9ZX8J2K6T3QW4R5Y7M8N9R",
+      type: "file_uri",
+      uri: "file:///evidence%5Cbundle.json",
       createdAt: "2026-04-29T00:10:00Z",
     },
   ];
@@ -66,6 +98,24 @@ test("rejects unsafe EvidenceBundleRef paths and secret-bearing URI shapes", asy
   const invalidFixture = validateEvidenceBundleRef(await readJson("invalid/raw-secret-uri.json"));
 
   assert.equal(invalidFixture.ok, false, "invalid copied fixture must fail validation");
+});
+
+test("rejects non-finite EvidenceBundleRef metadata numbers", () => {
+  for (const metadataValue of [Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY]) {
+    const result = validateEvidenceBundleRef({
+      schemaVersion: "eip.evidence-bundle-ref.v1",
+      id: "evb_01HV9ZX8J2K6T3QW4R5Y7M8N9U",
+      correlationId: "corr_01HV9ZX8J2K6T3QW4R5Y7M8N9R",
+      type: "local_path",
+      uri: "evidence/bundle.json",
+      createdAt: "2026-04-29T00:10:00Z",
+      metadata: {
+        attemptCount: metadataValue,
+      },
+    });
+
+    assert.equal(result.ok, false, `${metadataValue} must fail validation`);
+  }
 });
 
 test("dry-run sample exposes validation-ready EvidenceBundleRef references", () => {

--- a/test/run-request-execution-plan.test.ts
+++ b/test/run-request-execution-plan.test.ts
@@ -128,6 +128,7 @@ test("maps an issue-like RunRequest into a bounded execution plan", async () => 
     evidence: {
       intent: "normalize evidence intent without writing durable evidence",
       writesDurableEvidence: false,
+      bundleRefs: [],
     },
   });
 });


### PR DESCRIPTION
## Summary
- add an Ensen-loop-native EvidenceBundleRef v1 validator for copied protocol fixtures and dry-run metadata
- expose validation-ready dry-run evidence reference metadata without writing a durable evidence bundle
- document reference-only scope and path/secret safety rules

## Verification
- npm test -- --test-name-pattern EvidenceBundleRef
- npm run typecheck
- npm run build
- npm test

Closes #26

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dry-run execution plans can include EvidenceBundleRef v1-compatible reference metadata for validation-ready evidence pointers.

* **Documentation**
  * Clarified EvidenceBundleRef is location/validation metadata, not a full evidence bundle.
  * Added protocol-helper guidance on allowed formats and validation behavior.

* **Tests**
  * Added validation tests and updated dry-run tests to assert EvidenceBundleRef handling and fail-closed behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->