### PR TITLE
LOOP-016: Add EIP conformance fixture tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,10 +21,13 @@ npm ci
 npm run typecheck
 npm run build
 npm test
+node --test dist/test/eip-conformance-fixtures.test.js
 node dist/src/cli/index.js dry-run --sample
 node dist/src/cli/index.js run-request <run-request-json-file>
 node dist/src/cli/index.js run-request <run-request-json-file> --status-snapshot queued
 ```
+
+`npm test` includes the EIP conformance fixture suite. After `npm run build`, `node --test dist/test/eip-conformance-fixtures.test.js` runs only the focused suite for the vendored Ensen-protocol v0.1.0 RunRequest, RunStatusSnapshot, RunResult, and EvidenceBundleRef fixtures.
 
 `dry-run --sample` emits a deterministic local execution plan as JSON. It describes the work item, lane workspace, agent provider, SCM provider, verification, and evidence intents without creating worktrees, branches, commits, change requests, durable evidence, or invoking external providers. Its evidence section may include EvidenceBundleRef v1-compatible references as validation-ready metadata. These references identify where evidence could be found; they are not full evidence bundle artifacts and do not claim durable compliance packaging.
 

--- a/test/eip-conformance-fixtures.test.ts
+++ b/test/eip-conformance-fixtures.test.ts
@@ -1,0 +1,232 @@
+import assert from "node:assert/strict";
+import { readdir, readFile } from "node:fs/promises";
+import path from "node:path";
+import test from "node:test";
+
+import {
+  createRunRequestExecutionPlan,
+  createRunResult,
+  createRunStatusSnapshot,
+  createSampleDryRunExecutionPlan,
+  validateEvidenceBundleRef,
+  validateRunRequest,
+  validateRunResult,
+  validateRunStatusSnapshot,
+} from "../src/index.js";
+
+const snapshotRoot = path.join(
+  "protocol-snapshots",
+  "ensen-protocol",
+  "v0.1.0",
+);
+const fixtureRoot = path.join(snapshotRoot, "fixtures");
+const protocolLabel = "Ensen-protocol v0.1.0 / EIP 0.1.0";
+
+const fixtureSurfaces = [
+  {
+    name: "RunRequest",
+    path: "run-request/v1",
+    validate: validateRunRequest,
+  },
+  {
+    name: "RunStatusSnapshot",
+    path: "run-status/v1",
+    validate: validateRunStatusSnapshot,
+  },
+  {
+    name: "RunResult",
+    path: "run-result/v1",
+    validate: validateRunResult,
+  },
+  {
+    name: "EvidenceBundleRef",
+    path: "evidence-bundle-ref/v1",
+    validate: validateEvidenceBundleRef,
+  },
+] as const;
+
+async function readJson(filePath: string): Promise<unknown> {
+  return JSON.parse(await readFile(filePath, "utf8")) as unknown;
+}
+
+async function listJsonFixtures(relativePath: string): Promise<string[]> {
+  const entries = await readdir(path.join(fixtureRoot, relativePath), {
+    withFileTypes: true,
+  });
+
+  return entries
+    .filter((entry) => entry.isFile() && entry.name.endsWith(".json"))
+    .map((entry) => path.join(fixtureRoot, relativePath, entry.name))
+    .sort();
+}
+
+function assertRecord(value: unknown, label: string): asserts value is Record<string, unknown> {
+  assert.equal(typeof value, "object", `${label} must be an object`);
+  assert.notEqual(value, null, `${label} must not be null`);
+  assert.equal(Array.isArray(value), false, `${label} must not be an array`);
+}
+
+test(`${protocolLabel} valid fixtures are consumed at every supported boundary`, async () => {
+  for (const surface of fixtureSurfaces) {
+    const fixturePaths = await listJsonFixtures(path.join(surface.path, "valid"));
+
+    assert.ok(fixturePaths.length > 0, `${surface.name} must include valid fixtures`);
+
+    for (const fixturePath of fixturePaths) {
+      const result = surface.validate(await readJson(fixturePath));
+
+      assert.equal(result.ok, true, `${surface.name} fixture ${fixturePath} must pass`);
+    }
+  }
+});
+
+test(`${protocolLabel} invalid fixtures fail closed at every supported boundary`, async () => {
+  for (const surface of fixtureSurfaces) {
+    const fixturePaths = await listJsonFixtures(path.join(surface.path, "invalid"));
+
+    assert.ok(fixturePaths.length > 0, `${surface.name} must include invalid fixtures`);
+
+    for (const fixturePath of fixturePaths) {
+      const result = surface.validate(await readJson(fixturePath));
+
+      assert.equal(result.ok, false, `${surface.name} fixture ${fixturePath} must be rejected`);
+      assert.ok(result.issues.length > 0, `${surface.name} rejection must include diagnostics`);
+    }
+  }
+});
+
+test(`${protocolLabel} dry-run consumer and producer outputs stay fixture-compatible`, async () => {
+  const requestResult = validateRunRequest(
+    await readJson(path.join(fixtureRoot, "run-request/v1/valid/github-issue-request.json")),
+  );
+
+  assert.equal(requestResult.ok, true, "valid RunRequest fixture must pass input validation");
+
+  const plan = createRunRequestExecutionPlan(requestResult.request);
+
+  assert.deepEqual(plan, {
+    command: "run-request",
+    mode: "plan",
+    source: "eip.run-request",
+    status: "ready",
+    blockedReasons: [],
+    provenance: {
+      requestId: "req_01HV7Y8M8F2KQ5W3P9R6T4N2AB",
+      correlationId: "corr_01HV7Y8M8F2KQ5W3P9R6T4N2AC",
+      idempotencyKey: "github-issue-4",
+      schemaVersion: "eip.run-request.v1",
+      createdAt: "2026-04-29T01:45:45Z",
+      source: {
+        sourceType: "github",
+        sourceId: "source_01HV7Y8M8F2KQ5W3P9R6T4N2AD",
+        externalRef: "TommyKammy/Ensen-protocol",
+      },
+    },
+    workItem: {
+      id: "workitem_01HV7Y8M8F2KQ5W3P9R6T4N2AF",
+      title: "EIP-0001: Define RunRequest v1 schema",
+      source: "eip.run-request:github",
+      status: "ready",
+    },
+    requestIdentity: {
+      requestedBy: {
+        actorType: "api_client",
+        actorId: "actor_01HV7Y8M8F2KQ5W3P9R6T4N2AE",
+        displayName: "Ensen issue dispatcher",
+      },
+      workItemExternalId: "4",
+      workItemUrl: "https://github.com/TommyKammy/Ensen-protocol/issues/4",
+    },
+    boundedInputFacts: [
+      {
+        name: "source.externalRef",
+        value: "TommyKammy/Ensen-protocol",
+        trustedAuthority: false,
+      },
+      {
+        name: "workItem.externalId",
+        value: "4",
+        trustedAuthority: false,
+      },
+      {
+        name: "workItem.url",
+        value: "https://github.com/TommyKammy/Ensen-protocol/issues/4",
+        trustedAuthority: false,
+      },
+      {
+        name: "target.externalRef",
+        value: "TommyKammy/Ensen-protocol",
+        trustedAuthority: false,
+      },
+      {
+        name: "extensions.x-fixture-note",
+        value: "synthetic GitHub issue request",
+        trustedAuthority: false,
+      },
+    ],
+    laneWorkspace: {
+      intent: "normalize request scope without preparing a workspace",
+      mutatesFilesystem: false,
+      target: {
+        targetType: "repository",
+        targetId: "repo_01HV7Y8M8F2KQ5W3P9R6T4N2AG",
+        externalRef: "TommyKammy/Ensen-protocol",
+      },
+    },
+    agentProvider: {
+      intent: "normalize agent intent without invoking a provider",
+      invokesProvider: false,
+    },
+    scmProvider: {
+      intent: "normalize repository intent without creating branches, commits, or change requests",
+      createsBranch: false,
+      opensChangeRequest: false,
+    },
+    policy: {
+      intent: "record policy hints without granting execution authority",
+      trustedAuthority: false,
+      policySetId: "policy_01HV7Y8M8F2KQ5W3P9R6T4N2AH",
+      riskClasses: ["secrets"],
+      requiresApproval: true,
+    },
+    verification: {
+      intent: "normalize verification intent without running checks",
+      commands: [],
+    },
+    evidence: {
+      intent: "normalize evidence intent without writing durable evidence",
+      writesDurableEvidence: false,
+      bundleRefs: [],
+    },
+  });
+
+  const status = createRunStatusSnapshot(plan, {
+    status: "running",
+    observedAt: "2026-04-30T00:00:02Z",
+  });
+  const result = createRunResult(plan, {
+    status: "succeeded",
+    completedAt: "2026-04-30T00:00:04Z",
+    evidenceBundles: [
+      {
+        evidenceBundleId: "evb_01HV9ZX8J2K6T3QW4R5Y7M8N9U",
+        digest: "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      },
+    ],
+  });
+  const dryRun = createSampleDryRunExecutionPlan();
+
+  assert.equal(validateRunStatusSnapshot(status).ok, true);
+  assert.equal(validateRunResult(result).ok, true);
+  assert.equal(dryRun.evidence.writesDurableEvidence, false);
+  assert.ok(dryRun.evidence.bundleRefs.length > 0);
+
+  for (const bundleRef of dryRun.evidence.bundleRefs) {
+    const refResult = validateEvidenceBundleRef(bundleRef);
+
+    assert.equal(refResult.ok, true, `${bundleRef.uri} must be EvidenceBundleRef-compatible`);
+  }
+
+  assertRecord(result.evidenceBundles?.[0], "RunResult evidence bundle reference");
+  assert.equal(result.evidenceBundles[0].evidenceBundleId, "evb_01HV9ZX8J2K6T3QW4R5Y7M8N9U");
+});


### PR DESCRIPTION
## Summary
- add a focused EIP conformance fixture suite for the vendored Ensen-protocol v0.1.0 snapshot
- verify valid and invalid RunRequest, RunStatusSnapshot, RunResult, and EvidenceBundleRef fixtures at the Ensen-loop boundary
- document the focused conformance test command in README.md

## Verification
- npm run typecheck && npm run build && node --test dist/test/eip-conformance-fixtures.test.js
- npm test

Closes #27

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README with explicit test command documentation for running conformance fixture checks, clarifying the relationship between the complete test suite and focused conformance fixture validation steps.

* **Tests**
  * Added comprehensive conformance test suite validating protocol fixtures across multiple public surfaces, including valid and invalid fixture validation checks, plus producer/consumer compatibility verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->