### PR TITLE
LOOP-X2-001: emit X-Gate 2 dry-run smoke output

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ node --test dist/test/eip-conformance-fixtures.test.js
 node dist/src/cli/index.js dry-run --sample
 node dist/src/cli/index.js run-request <run-request-json-file>
 node dist/src/cli/index.js run-request <run-request-json-file> --status-snapshot queued
+node dist/src/cli/index.js x-gate2-smoke <run-request-json-file>
 ```
 
 `npm test` includes the EIP conformance fixture suite. After `npm run build`, `node --test dist/test/eip-conformance-fixtures.test.js` runs only the focused suite for the vendored Ensen-protocol v0.1.0 RunRequest, RunStatusSnapshot, RunResult, and EvidenceBundleRef fixtures.
@@ -34,6 +35,8 @@ node dist/src/cli/index.js run-request <run-request-json-file> --status-snapshot
 `run-request <run-request-json-file>` reads an EIP RunRequest v1 JSON file, validates it at the protocol input boundary, and emits either `{ "ok": true, "request": ... }` or `{ "ok": false, "issues": [...] }`. The `source` field is protocol input data, not trusted internal authority.
 
 `run-request <run-request-json-file> --status-snapshot accepted|queued|running|blocked` emits a RunStatusSnapshot-compatible dry-run polling snapshot for the request. The mode maps only Ensen-loop dry-run lifecycle facts; it does not read Ensen-flow workflow state, approval state, or final RunResult fields. If validation or plan normalization blocks the dry run and valid request/correlation identifiers are available, the command emits a blocked status snapshot with actionable reasons under `extensions.x-ensen-loop-blocked-reasons`.
+
+`x-gate2-smoke <run-request-json-file>` emits the X-Gate 2 narrow loop-flow dry-run smoke payload to stdout. The JSON payload contains deterministic `statusSnapshot`, `runResult`, and `evidenceBundleRef` fields for a valid EIP RunRequest v1 fixture. The EvidenceBundleRef uses a relative local artifact URI under `artifacts/evidence/x-gate2/<request-id>.json`; the command describes that artifact location but does not create or write the artifact. The smoke path does not create a repository, branch, worktree, GitHub issue, pull request, Codex session, durable evidence bundle, or provider call. Invalid RunRequest input and unsupported EIP major versions fail closed with blocked status/result output when stable request and correlation identifiers are available.
 
 EvidenceBundleRef validation is exposed as an Ensen-loop-native protocol helper for copied Ensen-protocol v0.1.0 fixtures and dry-run metadata. It accepts relative traversal-free local paths and absolute `file:///` URIs, rejects credential-shaped URIs, query or fragment-bearing file URIs, traversal, absolute local paths, and ambiguous local path shapes, and keeps validation independent from any Ensen-flow runtime.
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -9,9 +9,11 @@ import {
 import {
   createBlockedRunResultFromValidationIssues,
   createBlockedRunStatusSnapshotFromValidationIssues,
+  createBlockedXGate2SmokeOutput,
   createRunRequestExecutionPlan,
   createRunResult,
   createRunStatusSnapshot,
+  createXGate2SmokeOutput,
   validateRunRequest,
 } from "../protocol/index.js";
 import type { CreateRunResultOptions } from "../protocol/index.js";
@@ -114,6 +116,34 @@ async function main(): Promise<number> {
     return result.ok ? 0 : 1;
   }
 
+  if (command === "x-gate2-smoke") {
+    if (args.length !== 1) {
+      console.error("Usage: ensen-loop x-gate2-smoke <run-request-json-file>");
+      return 1;
+    }
+
+    const filePath = args[0];
+    if (filePath === undefined) {
+      console.error("Usage: ensen-loop x-gate2-smoke <run-request-json-file>");
+      return 1;
+    }
+
+    const input = await readJsonFile(filePath);
+    const result = validateRunRequest(input);
+
+    if (!result.ok) {
+      const output = createBlockedXGate2SmokeOutput(input, result.issues);
+
+      printJson(output ?? result);
+      return 1;
+    }
+
+    const output = createXGate2SmokeOutput(result.request);
+
+    printJson(output);
+    return output.runResult.status === "succeeded" ? 0 : 1;
+  }
+
   if (command === undefined) {
     console.log(describeProduct());
     return 0;
@@ -124,6 +154,7 @@ async function main(): Promise<number> {
   console.error(
     "Usage: ensen-loop run-request <run-request-json-file> [--status-snapshot accepted|queued|running|blocked|--run-result succeeded|failed|blocked]",
   );
+  console.error("Usage: ensen-loop x-gate2-smoke <run-request-json-file>");
   return 1;
 }
 

--- a/src/protocol/index.ts
+++ b/src/protocol/index.ts
@@ -2,3 +2,4 @@ export * from "./evidence-bundle-ref.js";
 export * from "./run-request.js";
 export * from "./run-result.js";
 export * from "./run-status.js";
+export * from "./x-gate2-smoke.js";

--- a/src/protocol/x-gate2-smoke.ts
+++ b/src/protocol/x-gate2-smoke.ts
@@ -1,0 +1,140 @@
+import type { EvidenceBundleRef } from "./evidence-bundle-ref.js";
+import type { RunRequest } from "./run-request.js";
+import {
+  createRunRequestExecutionPlan,
+  type RunRequestValidationIssue,
+} from "./run-request.js";
+import {
+  createBlockedRunResultFromValidationIssues,
+  createRunResult,
+  type RunResult,
+} from "./run-result.js";
+import {
+  createBlockedRunStatusSnapshotFromValidationIssues,
+  createRunStatusSnapshot,
+  type RunStatusSnapshot,
+} from "./run-status.js";
+
+export interface XGate2SmokeOutput {
+  readonly schemaVersion: "ensen-loop.x-gate2-smoke.v1";
+  readonly boundary: "local-cli-stdout";
+  readonly requestId?: string;
+  readonly correlationId?: string;
+  readonly mutatesRepository: false;
+  readonly invokesProvider: false;
+  readonly writesDurableEvidence: false;
+  readonly statusSnapshot: RunStatusSnapshot;
+  readonly runResult: RunResult;
+  readonly evidenceBundleRef?: EvidenceBundleRef;
+}
+
+export function createXGate2SmokeOutput(request: RunRequest): XGate2SmokeOutput {
+  const observedAt = addSeconds(request.createdAt, 1);
+  const completedAt = addSeconds(request.createdAt, 2);
+  const plan = createRunRequestExecutionPlan(request);
+  const evidenceBundleRef = createXGate2EvidenceBundleRef(request, completedAt);
+  const status = plan.status === "blocked" ? "blocked" : "queued";
+  const resultStatus = plan.status === "blocked" ? "blocked" : "succeeded";
+
+  return {
+    schemaVersion: "ensen-loop.x-gate2-smoke.v1",
+    boundary: "local-cli-stdout",
+    requestId: request.id,
+    correlationId: request.correlationId,
+    mutatesRepository: false,
+    invokesProvider: false,
+    writesDurableEvidence: false,
+    statusSnapshot: createRunStatusSnapshot(plan, {
+      status,
+      observedAt,
+    }),
+    runResult: createRunResult(plan, {
+      status: resultStatus,
+      completedAt,
+      evidenceBundles:
+        plan.status === "blocked"
+          ? []
+          : [{ evidenceBundleId: evidenceBundleRef.id }],
+    }),
+    evidenceBundleRef: plan.status === "blocked" ? undefined : evidenceBundleRef,
+  };
+}
+
+export function createBlockedXGate2SmokeOutput(
+  value: unknown,
+  issues: readonly RunRequestValidationIssue[],
+): XGate2SmokeOutput | undefined {
+  const observedAt = addSeconds(extractCreatedAt(value), 1);
+  const completedAt = addSeconds(extractCreatedAt(value), 2);
+  const statusSnapshot = createBlockedRunStatusSnapshotFromValidationIssues(
+    value,
+    issues,
+    observedAt,
+  );
+  const runResult = createBlockedRunResultFromValidationIssues(value, issues, completedAt);
+
+  if (statusSnapshot === undefined || runResult === undefined) {
+    return undefined;
+  }
+
+  return {
+    schemaVersion: "ensen-loop.x-gate2-smoke.v1",
+    boundary: "local-cli-stdout",
+    requestId: statusSnapshot.requestId,
+    correlationId: statusSnapshot.correlationId,
+    mutatesRepository: false,
+    invokesProvider: false,
+    writesDurableEvidence: false,
+    statusSnapshot,
+    runResult,
+  };
+}
+
+function createXGate2EvidenceBundleRef(
+  request: RunRequest,
+  createdAt: string,
+): EvidenceBundleRef {
+  return {
+    schemaVersion: "eip.evidence-bundle-ref.v1",
+    id: replaceProtocolIdPrefix(request.id, "evb"),
+    correlationId: request.correlationId,
+    type: "local_path",
+    uri: `artifacts/evidence/x-gate2/${request.id}.json`,
+    createdAt,
+    contentType: "application/json",
+    metadata: {
+      producer: "ensen-loop",
+      artifactKind: "xGate2DryRunSmoke",
+      mutatesRepository: false,
+      invokesProvider: false,
+      writesDurableEvidence: false,
+    },
+  };
+}
+
+function extractCreatedAt(value: unknown): string {
+  if (
+    value !== null &&
+    typeof value === "object" &&
+    "createdAt" in value &&
+    typeof value.createdAt === "string"
+  ) {
+    return value.createdAt;
+  }
+
+  return "1970-01-01T00:00:00Z";
+}
+
+function addSeconds(timestamp: string, seconds: number): string {
+  const milliseconds = Date.parse(timestamp);
+
+  if (!Number.isFinite(milliseconds)) {
+    return addSeconds("1970-01-01T00:00:00Z", seconds);
+  }
+
+  return new Date(milliseconds + seconds * 1000).toISOString().replace(".000Z", "Z");
+}
+
+function replaceProtocolIdPrefix(id: string, prefix: "evb"): string {
+  return `${prefix}_${id.slice(id.indexOf("_") + 1)}`;
+}

--- a/test/x-gate2-smoke-cli.test.ts
+++ b/test/x-gate2-smoke-cli.test.ts
@@ -1,0 +1,104 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import path from "node:path";
+import test from "node:test";
+import { promisify } from "node:util";
+
+import {
+  validateEvidenceBundleRef,
+  validateRunResult,
+  validateRunStatusSnapshot,
+} from "../src/protocol/index.js";
+
+const execFileAsync = promisify(execFile);
+const fixtureRoot = path.join(
+  "protocol-snapshots",
+  "ensen-protocol",
+  "v0.1.0",
+  "fixtures",
+);
+
+test("X-Gate 2 smoke CLI emits deterministic status, result, and evidence ref", async () => {
+  const fixturePath = path.join(fixtureRoot, "run-request/v1/valid/github-issue-request.json");
+
+  const { stdout, stderr } = await execFileAsync(process.execPath, [
+    "dist/src/cli/index.js",
+    "x-gate2-smoke",
+    fixturePath,
+  ]);
+
+  assert.equal(stderr, "");
+
+  const output = JSON.parse(stdout) as {
+    schemaVersion: string;
+    boundary: string;
+    mutatesRepository: boolean;
+    invokesProvider: boolean;
+    statusSnapshot: unknown;
+    runResult: unknown;
+    evidenceBundleRef: unknown;
+  };
+
+  assert.equal(output.schemaVersion, "ensen-loop.x-gate2-smoke.v1");
+  assert.equal(output.boundary, "local-cli-stdout");
+  assert.equal(output.mutatesRepository, false);
+  assert.equal(output.invokesProvider, false);
+
+  const snapshot = validateRunStatusSnapshot(output.statusSnapshot);
+  const result = validateRunResult(output.runResult);
+  const evidenceRef = validateEvidenceBundleRef(output.evidenceBundleRef);
+
+  assert.equal(snapshot.ok, true);
+  assert.equal(snapshot.ok && snapshot.snapshot.status, "queued");
+  assert.equal(snapshot.ok && snapshot.snapshot.observedAt, "2026-04-29T01:45:46Z");
+
+  assert.equal(result.ok, true);
+  assert.equal(result.ok && result.result.status, "succeeded");
+  assert.equal(result.ok && result.result.completedAt, "2026-04-29T01:45:47Z");
+  assert.deepEqual(result.ok && result.result.evidenceBundles, [
+    {
+      evidenceBundleId: "evb_01HV7Y8M8F2KQ5W3P9R6T4N2AB",
+    },
+  ]);
+
+  assert.equal(evidenceRef.ok, true);
+  assert.equal(evidenceRef.ok && evidenceRef.ref.type, "local_path");
+  assert.equal(
+    evidenceRef.ok && evidenceRef.ref.uri,
+    "artifacts/evidence/x-gate2/req_01HV7Y8M8F2KQ5W3P9R6T4N2AB.json",
+  );
+});
+
+test("X-Gate 2 smoke CLI fails closed for unsupported EIP major versions", async () => {
+  const fixturePath = path.join(fixtureRoot, "run-request/v1/invalid/bad-schema-version.json");
+
+  await assert.rejects(
+    execFileAsync(process.execPath, [
+      "dist/src/cli/index.js",
+      "x-gate2-smoke",
+      fixturePath,
+    ]),
+    (error: unknown) => {
+      assert.ok(error && typeof error === "object");
+      assert.ok("code" in error);
+      assert.equal(error.code, 1);
+      assert.ok("stdout" in error && typeof error.stdout === "string");
+
+      const output = JSON.parse(error.stdout) as {
+        statusSnapshot: unknown;
+        runResult: unknown;
+      };
+
+      const snapshot = validateRunStatusSnapshot(output.statusSnapshot);
+      const result = validateRunResult(output.runResult);
+
+      assert.equal(snapshot.ok, true);
+      assert.equal(snapshot.ok && snapshot.snapshot.status, "blocked");
+      assert.match(snapshot.ok ? (snapshot.snapshot.message ?? "") : "", /schemaVersion/);
+      assert.equal(result.ok, true);
+      assert.equal(result.ok && result.result.status, "blocked");
+
+      return true;
+    },
+  );
+});


### PR DESCRIPTION
## Summary
- add an `x-gate2-smoke <run-request-json-file>` CLI boundary for X-Gate 2 narrow loop-flow dry-run smoke
- emit deterministic RunStatusSnapshot, RunResult, and EvidenceBundleRef-compatible output without repo/provider mutation
- document the invocation, stdout boundary, relative artifact URI, and no-real-repo constraints

## Verification
- `npm run typecheck`
- `npm run build && node --test dist/test/x-gate2-smoke-cli.test.js`
- `npm test`
- `node dist/src/cli/index.js x-gate2-smoke protocol-snapshots/ensen-protocol/v0.1.0/fixtures/run-request/v1/valid/github-issue-request.json`

Closes #35

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced `x-gate2-smoke` CLI subcommand that generates dry-run smoke test payloads from run-request JSON files, outputting deterministic status and results to stdout.

* **Documentation**
  * Updated CLI documentation with usage details for the new smoke command, including handling of valid and invalid inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->