### PR TITLE
LOOP-018: Prepare safe local lane roots

### DIFF
--- a/docs/architecture/local-lane-execution.md
+++ b/docs/architecture/local-lane-execution.md
@@ -70,6 +70,17 @@ state root resolution. A path that cannot be proven to stay inside the intended
 root is unsafe and must block the run before durable state or filesystem
 mutation occurs.
 
+`prepareLocalLaneWorkspace()` is the Ensen-loop-owned local preparation helper
+for one bounded lane run. Callers provide absolute `<workspace-root>` and
+`<state-root>` paths, plus a lane run identifier or work item identifier. The
+helper derives one stable local directory name, prepares
+`<workspace-root>/lane-runs/<lane-id>` and
+`<state-root>/lane-runs/<lane-id>`, rejects missing roots, relative roots,
+shared workspace/state roots, malformed identifiers, traversal-shaped
+identifiers, symlinked roots, and symlink-mediated lane paths, and rolls back
+only the lane workspace directory it created if state preparation fails. It does
+not start an agent, create SCM state, mutate GitHub, or delete unrelated files.
+
 Examples should use placeholders such as `<workspace-root>`, `<state-root>`,
 `<run-request-json-file>`, and `<supervisor-config-path>`.
 

--- a/src/lane/index.ts
+++ b/src/lane/index.ts
@@ -1,6 +1,6 @@
 import { constants } from "node:fs";
 import type { Stats } from "node:fs";
-import { lstat, mkdir, open, realpath } from "node:fs/promises";
+import { lstat, mkdir, open, realpath, rm } from "node:fs/promises";
 import type { FileHandle } from "node:fs/promises";
 import path from "node:path";
 
@@ -66,7 +66,25 @@ export interface CreateLaneRunStateInput {
   readonly evidence?: LaneEvidenceRefs;
 }
 
+export interface PrepareLocalLaneWorkspaceInput {
+  readonly workspaceRoot: string;
+  readonly stateRoot: string;
+  readonly laneRunId?: string;
+  readonly workItemId?: string;
+}
+
+export interface PreparedLocalLaneWorkspace {
+  readonly directoryName: string;
+  readonly workspacePath: string;
+  readonly statePath: string;
+  readonly created: {
+    readonly workspace: boolean;
+    readonly state: boolean;
+  };
+}
+
 const laneRunIdPattern = /^[A-Za-z0-9][A-Za-z0-9._-]*$/;
+const localLaneDirectoryNamePattern = /^[A-Za-z0-9._-]{1,128}$/;
 const isoDateTimePattern =
   /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.\d+)?(Z|[+-]\d{2}:\d{2})$/;
 const laneRunStatuses = new Set<unknown>([
@@ -100,6 +118,61 @@ export function createLaneRunState(input: CreateLaneRunStateInput): LaneRunState
     audit: input.audit ?? { eventRefs: [] },
     evidence: input.evidence ?? { bundleRefs: [] },
   };
+}
+
+export function resolveLocalLaneDirectoryName(
+  input: Pick<PrepareLocalLaneWorkspaceInput, "laneRunId" | "workItemId">,
+): string {
+  const identifier = input.laneRunId ?? input.workItemId;
+
+  if (typeof identifier !== "string" || identifier.length === 0) {
+    throw new Error("A lane run identifier or work item identifier is required for local lane preparation.");
+  }
+
+  if (!localLaneDirectoryNamePattern.test(identifier)) {
+    throw new Error("Local lane identifiers may only contain letters, numbers, dots, underscores, and hyphens.");
+  }
+
+  if (!/[A-Za-z0-9]/.test(identifier)) {
+    throw new Error("Local lane identifiers must include at least one letter or number.");
+  }
+
+  return identifier;
+}
+
+export async function prepareLocalLaneWorkspace(
+  input: PrepareLocalLaneWorkspaceInput,
+): Promise<PreparedLocalLaneWorkspace> {
+  const directoryName = resolveLocalLaneDirectoryName(input);
+  const workspaceRoot = await resolveCanonicalLocalLaneRoot("workspace", input.workspaceRoot);
+  const stateRoot = await resolveCanonicalLocalLaneRoot("state", input.stateRoot);
+
+  if (workspaceRoot.realPath === stateRoot.realPath) {
+    throw new Error("Local lane workspace root and state root must be separate directories.");
+  }
+
+  let workspaceResult: PreparedLocalLanePath | undefined;
+
+  try {
+    workspaceResult = await prepareLocalLanePath("workspace", workspaceRoot, directoryName);
+    const stateResult = await prepareLocalLanePath("state", stateRoot, directoryName);
+
+    return {
+      directoryName,
+      workspacePath: workspaceResult.path,
+      statePath: stateResult.path,
+      created: {
+        workspace: workspaceResult.created,
+        state: stateResult.created,
+      },
+    };
+  } catch (error) {
+    if (workspaceResult?.created) {
+      await rm(workspaceResult.path, { recursive: true, force: true });
+    }
+
+    throw error;
+  }
 }
 
 export function serializeLaneRunState(state: LaneRunState): string {
@@ -221,6 +294,126 @@ async function resolveCanonicalStateRoot(stateRoot: string): Promise<string> {
   }
 
   return realpath(resolvedRoot);
+}
+
+interface PreparedLocalLanePath {
+  readonly path: string;
+  readonly created: boolean;
+}
+
+interface CanonicalLocalLaneRoot {
+  readonly inputPath: string;
+  readonly realPath: string;
+}
+
+async function resolveCanonicalLocalLaneRoot(
+  kind: "workspace" | "state",
+  rootPath: string,
+): Promise<CanonicalLocalLaneRoot> {
+  if (!path.isAbsolute(rootPath)) {
+    throw new Error(`Local lane ${kind} root must be an absolute path.`);
+  }
+
+  const stats = await lstat(rootPath).catch((error: unknown) => {
+    if (isNodeError(error) && error.code === "ENOENT") {
+      throw new Error(`Local lane ${kind} root must exist before preparation.`);
+    }
+
+    throw error;
+  });
+
+  if (stats.isSymbolicLink() || !stats.isDirectory()) {
+    throw new Error(`Local lane ${kind} root must be a real directory.`);
+  }
+
+  return {
+    inputPath: path.resolve(rootPath),
+    realPath: await realpath(rootPath),
+  };
+}
+
+async function prepareLocalLanePath(
+  kind: "workspace" | "state",
+  root: CanonicalLocalLaneRoot,
+  directoryName: string,
+): Promise<PreparedLocalLanePath> {
+  const laneRunsRoot = path.join(root.inputPath, "lane-runs");
+  await ensureLocalLaneDirectory(kind, root, laneRunsRoot);
+
+  const lanePath = path.join(laneRunsRoot, directoryName);
+  const existingStats = await lstat(lanePath).catch((error: unknown) => {
+    if (isNodeError(error) && error.code === "ENOENT") {
+      return undefined;
+    }
+
+    throw error;
+  });
+  let created = false;
+
+  if (!existingStats) {
+    await mkdir(lanePath);
+    created = true;
+  } else if (existingStats.isSymbolicLink()) {
+    throw new Error(`Local lane ${kind} path must not traverse symbolic links.`);
+  } else if (!existingStats.isDirectory()) {
+    throw new Error(`Local lane ${kind} path must be a real directory.`);
+  }
+
+  await assertLocalLanePathInsideRoot(kind, root, lanePath);
+
+  return {
+    path: lanePath,
+    created,
+  };
+}
+
+async function ensureLocalLaneDirectory(
+  kind: "workspace" | "state",
+  root: CanonicalLocalLaneRoot,
+  directoryPath: string,
+): Promise<void> {
+  const stats = await lstat(directoryPath).catch((error: unknown) => {
+    if (isNodeError(error) && error.code === "ENOENT") {
+      return undefined;
+    }
+
+    throw error;
+  });
+
+  if (!stats) {
+    await mkdir(directoryPath);
+    await assertLocalLanePathInsideRoot(kind, root, directoryPath);
+    return;
+  }
+
+  if (stats.isSymbolicLink()) {
+    throw new Error(`Local lane ${kind} path must not traverse symbolic links.`);
+  }
+
+  if (!stats.isDirectory()) {
+    throw new Error(`Local lane ${kind} path must be a real directory.`);
+  }
+
+  await assertLocalLanePathInsideRoot(kind, root, directoryPath);
+}
+
+async function assertLocalLanePathInsideRoot(
+  kind: "workspace" | "state",
+  root: CanonicalLocalLaneRoot,
+  candidatePath: string,
+): Promise<void> {
+  const stats = await lstat(candidatePath);
+
+  if (stats.isSymbolicLink()) {
+    throw new Error(`Local lane ${kind} path must not traverse symbolic links.`);
+  }
+
+  const realCandidate = await realpath(candidatePath);
+  const relativePath = path.relative(root.realPath, realCandidate);
+
+  if (relativePath.startsWith("..") || path.isAbsolute(relativePath)) {
+    throw new Error(`Local lane ${kind} path must stay inside the configured root.`);
+  }
 }
 
 async function assertExistingPathSafe(

--- a/test/local-lane-workspace.test.ts
+++ b/test/local-lane-workspace.test.ts
@@ -1,0 +1,196 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import {
+  prepareLocalLaneWorkspace,
+  resolveLocalLaneDirectoryName,
+} from "../src/lane/index.js";
+
+test("prepares bounded local workspace and state directories for one lane run", async () => {
+  const workspaceRoot = await mkdtemp(path.join(os.tmpdir(), "ensen-loop-workspace-"));
+  const stateRoot = await mkdtemp(path.join(os.tmpdir(), "ensen-loop-state-"));
+
+  try {
+    const prepared = await prepareLocalLaneWorkspace({
+      workspaceRoot,
+      stateRoot,
+      laneRunId: "run_01HV7Y8M8F2KQ5W3P9R6T4N2AB",
+      workItemId: "workitem_01HV7Y8M8F2KQ5W3P9R6T4N2AC",
+    });
+
+    assert.equal(prepared.directoryName, "run_01HV7Y8M8F2KQ5W3P9R6T4N2AB");
+    assert.equal(prepared.workspacePath, path.join(workspaceRoot, "lane-runs", prepared.directoryName));
+    assert.equal(prepared.statePath, path.join(stateRoot, "lane-runs", prepared.directoryName));
+    assert.deepEqual(prepared.created, {
+      workspace: true,
+      state: true,
+    });
+  } finally {
+    await rm(workspaceRoot, { recursive: true, force: true });
+    await rm(stateRoot, { recursive: true, force: true });
+  }
+});
+
+test("derives the local lane directory name from the work item when no run id is provided", async () => {
+  const workspaceRoot = await mkdtemp(path.join(os.tmpdir(), "ensen-loop-workspace-"));
+  const stateRoot = await mkdtemp(path.join(os.tmpdir(), "ensen-loop-state-"));
+
+  try {
+    const prepared = await prepareLocalLaneWorkspace({
+      workspaceRoot,
+      stateRoot,
+      workItemId: "workitem_01HV7Y8M8F2KQ5W3P9R6T4N2AC",
+    });
+
+    assert.equal(prepared.directoryName, "workitem_01HV7Y8M8F2KQ5W3P9R6T4N2AC");
+    assert.equal(prepared.workspacePath, path.join(workspaceRoot, "lane-runs", prepared.directoryName));
+    assert.equal(prepared.statePath, path.join(stateRoot, "lane-runs", prepared.directoryName));
+  } finally {
+    await rm(workspaceRoot, { recursive: true, force: true });
+    await rm(stateRoot, { recursive: true, force: true });
+  }
+});
+
+test("reuses an empty prepared lane directory without deleting unrelated files", async () => {
+  const workspaceRoot = await mkdtemp(path.join(os.tmpdir(), "ensen-loop-workspace-"));
+  const stateRoot = await mkdtemp(path.join(os.tmpdir(), "ensen-loop-state-"));
+
+  try {
+    const first = await prepareLocalLaneWorkspace({
+      workspaceRoot,
+      stateRoot,
+      laneRunId: "reusable-run",
+    });
+
+    const unrelatedPath = path.join(workspaceRoot, "keep.txt");
+    await writeFile(unrelatedPath, "do not delete\n", "utf8");
+
+    const second = await prepareLocalLaneWorkspace({
+      workspaceRoot,
+      stateRoot,
+      laneRunId: "reusable-run",
+    });
+
+    assert.deepEqual(second, {
+      ...first,
+      created: {
+        workspace: false,
+        state: false,
+      },
+    });
+    assert.equal(await readFile(unrelatedPath, "utf8"), "do not delete\n");
+  } finally {
+    await rm(workspaceRoot, { recursive: true, force: true });
+    await rm(stateRoot, { recursive: true, force: true });
+  }
+});
+
+test("rejects malformed and traversal-shaped lane directory identifiers before creating lane paths", async () => {
+  const workspaceRoot = await mkdtemp(path.join(os.tmpdir(), "ensen-loop-workspace-"));
+  const stateRoot = await mkdtemp(path.join(os.tmpdir(), "ensen-loop-state-"));
+
+  try {
+    assert.throws(
+      () => resolveLocalLaneDirectoryName({ laneRunId: "../outside" }),
+      /Local lane identifiers may only contain/,
+    );
+
+    await assert.rejects(
+      () => prepareLocalLaneWorkspace({ workspaceRoot, stateRoot, laneRunId: "nested/outside" }),
+      /Local lane identifiers may only contain/,
+    );
+    await assert.rejects(
+      () => prepareLocalLaneWorkspace({ workspaceRoot, stateRoot, laneRunId: "..." }),
+      /Local lane identifiers must include at least one letter or number/,
+    );
+  } finally {
+    await rm(workspaceRoot, { recursive: true, force: true });
+    await rm(stateRoot, { recursive: true, force: true });
+  }
+});
+
+test("rejects missing, relative, and symlinked local lane roots before creating lane paths", async () => {
+  const workspaceRoot = await mkdtemp(path.join(os.tmpdir(), "ensen-loop-workspace-"));
+  const stateRoot = await mkdtemp(path.join(os.tmpdir(), "ensen-loop-state-"));
+  const outsideRoot = await mkdtemp(path.join(os.tmpdir(), "ensen-loop-outside-"));
+  const symlinkRoot = path.join(os.tmpdir(), `ensen-loop-root-link-${process.pid}`);
+
+  try {
+    await symlink(outsideRoot, symlinkRoot, "dir");
+
+    await assert.rejects(
+      () => prepareLocalLaneWorkspace({
+        workspaceRoot: path.join(workspaceRoot, "missing"),
+        stateRoot,
+        laneRunId: "missing-root-run",
+      }),
+      /Local lane workspace root must exist before preparation/,
+    );
+    await assert.rejects(
+      () => prepareLocalLaneWorkspace({
+        workspaceRoot: "relative-workspace-root",
+        stateRoot,
+        laneRunId: "relative-root-run",
+      }),
+      /Local lane workspace root must be an absolute path/,
+    );
+    await assert.rejects(
+      () => prepareLocalLaneWorkspace({
+        workspaceRoot: symlinkRoot,
+        stateRoot,
+        laneRunId: "symlink-root-run",
+      }),
+      /Local lane workspace root must be a real directory/,
+    );
+  } finally {
+    await rm(workspaceRoot, { recursive: true, force: true });
+    await rm(stateRoot, { recursive: true, force: true });
+    await rm(outsideRoot, { recursive: true, force: true });
+    await rm(symlinkRoot, { force: true });
+  }
+});
+
+test("rejects ambiguous shared workspace and state roots", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "ensen-loop-shared-root-"));
+
+  try {
+    await assert.rejects(
+      () => prepareLocalLaneWorkspace({
+        workspaceRoot: root,
+        stateRoot: root,
+        laneRunId: "shared-root-run",
+      }),
+      /workspace root and state root must be separate directories/,
+    );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("rejects symlink and outside-root lane paths without following the escape", async () => {
+  const workspaceRoot = await mkdtemp(path.join(os.tmpdir(), "ensen-loop-workspace-"));
+  const stateRoot = await mkdtemp(path.join(os.tmpdir(), "ensen-loop-state-"));
+  const outsideRoot = await mkdtemp(path.join(os.tmpdir(), "ensen-loop-outside-"));
+
+  try {
+    await mkdir(path.join(workspaceRoot, "lane-runs"), { recursive: true });
+    await symlink(outsideRoot, path.join(workspaceRoot, "lane-runs", "symlink-run"), "dir");
+
+    await assert.rejects(
+      () => prepareLocalLaneWorkspace({
+        workspaceRoot,
+        stateRoot,
+        laneRunId: "symlink-run",
+      }),
+      /Local lane workspace path must not traverse symbolic links/,
+    );
+    await assert.rejects(() => readFile(path.join(outsideRoot, "state.json"), "utf8"), /ENOENT/);
+  } finally {
+    await rm(workspaceRoot, { recursive: true, force: true });
+    await rm(stateRoot, { recursive: true, force: true });
+    await rm(outsideRoot, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary
- add Ensen-loop-native local lane workspace/state preparation helpers
- reject missing, relative, shared, symlinked, traversal-shaped, or malformed local lane roots and identifiers
- document the caller-provided workspace/state-root boundary for Phase 3 local lane execution

## Verification
- npm run typecheck
- npm run build
- node --test dist/test/local-lane-workspace.test.js
- npm test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced local lane workspace preparation functionality with automatic directory creation, path validation, and traversal detection for safe isolated execution environments.

* **Documentation**
  * Added architectural documentation detailing local lane execution configuration and workspace preparation requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->