### PR TITLE
LOOP-019: Add deterministic local executor boundary

### DIFF
--- a/src/executor/index.ts
+++ b/src/executor/index.ts
@@ -72,8 +72,9 @@ const fixtureNamePattern = /^[a-z0-9][a-z0-9._-]{2,127}$/;
 const localLaneIdPattern = /^[A-Za-z0-9][A-Za-z0-9._-]{2,127}$/;
 const credentialPattern =
   /(?:password|passwd|token|secret|credential|api[_-]?key)\s*[:=]\s*\S+/i;
-const unixHomePathPattern = /\/Users\/[^/\s]+|\/home\/[^/\s]+/;
-const windowsProfilePathPattern = /[A-Za-z]:\\Users\\[^\\\s]+/;
+const unsafeLocalPathPattern =
+  /(?:^|[\s"'([{<>=])(?:\/(?:[^\s"'`<>]*)?|~(?:[/\\]|\s|$)|\$HOME(?:[/\\]|\s|$)|%USERPROFILE%(?:[/\\]|\s|$)|[A-Za-z]:\\[^\s"'`<>]+|\\\\[^\\\s]+\\[^\\\s]+)/i;
+const redactedFixtureName = "[REDACTED_FIXTURE]";
 
 export function createDeterministicLocalFakeExecutor(): LaneExecutorAdapter {
   return {
@@ -81,7 +82,7 @@ export function createDeterministicLocalFakeExecutor(): LaneExecutorAdapter {
     async invoke(input) {
       const fixtureIssues = collectFixtureIssues(input.fixture);
       if (fixtureIssues.length > 0) {
-        return createBlockedExecutorResult(input, fixtureIssues);
+        return createBlockedExecutorResult(input, fixtureIssues, true);
       }
 
       if (input.plan.status === "blocked") {
@@ -113,6 +114,11 @@ export function createDeterministicLocalFakeExecutor(): LaneExecutorAdapter {
 }
 
 export async function invokeLaneExecutor(input: InvokeLaneExecutorInput): Promise<LaneExecutorResult> {
+  const fixtureIssues = collectFixtureIssues(input.fixture);
+  if (fixtureIssues.length > 0) {
+    return createBlockedResultWithoutAdapter(input, fixtureIssues, undefined, true);
+  }
+
   if (input.mode !== deterministicLocalFakeMode || input.executor.id !== deterministicLocalFakeMode) {
     return createBlockedResultWithoutAdapter(input, [
       `Unsupported executor mode: ${input.mode}`,
@@ -153,12 +159,12 @@ async function collectPreparedContextIssues(
     ["state", preparedContext.statePath],
   ] as const) {
     const stats = await lstat(candidatePath).catch((error: unknown) => {
-      if (isNodeError(error) && error.code === "ENOENT") {
-        issues.push(`Prepared lane ${label} path must exist before executor invocation.`);
-        return undefined;
-      }
-
-      throw error;
+      issues.push(
+        isNodeError(error) && error.code === "ENOENT"
+          ? `Prepared lane ${label} path must exist before executor invocation.`
+          : `Prepared lane ${label} path is not accessible before executor invocation.`,
+      );
+      return undefined;
     });
 
     if (stats?.isSymbolicLink()) {
@@ -175,6 +181,7 @@ function createBlockedResultWithoutAdapter(
   input: InvokeLaneExecutorInput,
   blockedReasons: readonly string[],
   preparedContext?: PreparedLaneExecutorContext,
+  redactFixtureMetadata = false,
 ): LaneExecutorResult {
   const adapterInput: LaneExecutorAdapterInput = {
     mode: deterministicLocalFakeMode,
@@ -188,16 +195,17 @@ function createBlockedResultWithoutAdapter(
     fixture: input.fixture,
   };
 
-  return createBlockedExecutorResult(adapterInput, blockedReasons);
+  return createBlockedExecutorResult(adapterInput, blockedReasons, redactFixtureMetadata);
 }
 
 function createBlockedExecutorResult(
   input: LaneExecutorAdapterInput,
   blockedReasons: readonly string[],
+  redactFixtureMetadata = false,
 ): LaneExecutorResult {
   return {
     status: "blocked",
-    invocation: createInvocationMetadata(input),
+    invocation: createInvocationMetadata(input, redactFixtureMetadata),
     runResult: createRunResult(
       {
         ...input.plan,
@@ -223,14 +231,17 @@ function createBlockedExecutorResult(
   };
 }
 
-function createInvocationMetadata(input: LaneExecutorAdapterInput): LaneExecutorInvocationMetadata {
+function createInvocationMetadata(
+  input: LaneExecutorAdapterInput,
+  redactFixtureMetadata = false,
+): LaneExecutorInvocationMetadata {
   return {
     executorId: deterministicLocalFakeMode,
     mode: deterministicLocalFakeMode,
     laneRunId: input.preparedContext.laneRunId,
     requestId: input.plan.provenance.requestId,
     workItemId: input.plan.workItem.id,
-    fixtureName: input.fixture.name,
+    fixtureName: redactFixtureMetadata ? redactedFixtureName : input.fixture.name,
     invokedAt: input.completedAt,
     invokesProvider: false,
     mutatesScm: false,
@@ -241,7 +252,7 @@ function createVerificationSummary(
   fixture: LocalFakeExecutorFixture,
   status: Exclude<LocalFakeExecutorOutcome, "blocked">,
 ): VerificationSummary {
-  const verificationStatus: CreateRunResultOptions["verification"] = {
+  const verificationStatus: NonNullable<CreateRunResultOptions["verification"]> = {
     status: status === "succeeded" ? "passed" : "failed",
     summary:
       fixture.verificationSummary ??
@@ -285,8 +296,7 @@ function collectFixtureIssues(fixture: LocalFakeExecutorFixture): readonly strin
 function containsUnsafeFixtureText(value: string): boolean {
   return (
     credentialPattern.test(value) ||
-    unixHomePathPattern.test(value) ||
-    windowsProfilePathPattern.test(value)
+    unsafeLocalPathPattern.test(value)
   );
 }
 

--- a/src/executor/index.ts
+++ b/src/executor/index.ts
@@ -214,7 +214,13 @@ async function collectPreparedMarkerIssues(
     directoryKind === "workspace" ? preparedContext.workspacePath : preparedContext.statePath,
     preparedLocalLaneMarkerFilename,
   );
-  const markerFile = await open(markerPath, constants.O_RDONLY | noFollowFlag()).catch((error: unknown) => {
+  const markerNoFollowFlag = noFollowFlag();
+  if (markerNoFollowFlag === 0) {
+    issues.push(`Prepared lane ${directoryKind} marker cannot be verified without no-follow file open support.`);
+    return issues;
+  }
+
+  const markerFile = await open(markerPath, constants.O_RDONLY | markerNoFollowFlag).catch((error: unknown) => {
     issues.push(
       isNodeError(error) && error.code === "ENOENT"
         ? `Prepared lane ${directoryKind} marker must exist before executor invocation.`

--- a/src/executor/index.ts
+++ b/src/executor/index.ts
@@ -75,6 +75,7 @@ const credentialPattern =
 const unsafeLocalPathPattern =
   /(?:^|[\s"'([{<>=])(?:\/(?:[^\s"'`<>]*)?|~(?:[/\\]|\s|$)|\$HOME(?:[/\\]|\s|$)|%USERPROFILE%(?:[/\\]|\s|$)|[A-Za-z]:\\[^\s"'`<>]+|\\\\[^\\\s]+\\[^\\\s]+)/i;
 const redactedFixtureName = "[REDACTED_FIXTURE]";
+const unsupportedExecutorConfigurationReason = "Unsupported executor configuration.";
 
 export function createDeterministicLocalFakeExecutor(): LaneExecutorAdapter {
   return {
@@ -121,7 +122,7 @@ export async function invokeLaneExecutor(input: InvokeLaneExecutorInput): Promis
 
   if (input.mode !== deterministicLocalFakeMode || input.executor.id !== deterministicLocalFakeMode) {
     return createBlockedResultWithoutAdapter(input, [
-      `Unsupported executor mode: ${input.mode}`,
+      unsupportedExecutorConfigurationReason,
     ]);
   }
 
@@ -133,7 +134,11 @@ export async function invokeLaneExecutor(input: InvokeLaneExecutorInput): Promis
 
   const contextIssues = await collectPreparedContextIssues(input.preparedContext);
   if (contextIssues.length > 0) {
-    return createBlockedResultWithoutAdapter(input, contextIssues, input.preparedContext);
+    return createBlockedResultWithoutAdapter(
+      input,
+      contextIssues,
+      sanitizePreparedContextForBlockedResult(input.preparedContext, input.plan),
+    );
   }
 
   return input.executor.invoke({
@@ -175,6 +180,20 @@ async function collectPreparedContextIssues(
   }
 
   return issues;
+}
+
+function sanitizePreparedContextForBlockedResult(
+  preparedContext: PreparedLaneExecutorContext,
+  plan: RunRequestExecutionPlan,
+): PreparedLaneExecutorContext {
+  if (localLaneIdPattern.test(preparedContext.laneRunId)) {
+    return preparedContext;
+  }
+
+  return {
+    ...preparedContext,
+    laneRunId: replaceProtocolIdPrefix(plan.provenance.requestId, "run"),
+  };
 }
 
 function createBlockedResultWithoutAdapter(

--- a/src/executor/index.ts
+++ b/src/executor/index.ts
@@ -1,4 +1,5 @@
-import { lstat, readFile } from "node:fs/promises";
+import { constants } from "node:fs";
+import { lstat, open } from "node:fs/promises";
 import path from "node:path";
 
 import type {
@@ -213,33 +214,38 @@ async function collectPreparedMarkerIssues(
     directoryKind === "workspace" ? preparedContext.workspacePath : preparedContext.statePath,
     preparedLocalLaneMarkerFilename,
   );
-  const markerStats = await lstat(markerPath).catch((error: unknown) => {
+  const markerFile = await open(markerPath, constants.O_RDONLY | noFollowFlag()).catch((error: unknown) => {
     issues.push(
       isNodeError(error) && error.code === "ENOENT"
         ? `Prepared lane ${directoryKind} marker must exist before executor invocation.`
-        : `Prepared lane ${directoryKind} marker is not accessible before executor invocation.`,
+        : isNodeError(error) && error.code === "ELOOP"
+          ? `Prepared lane ${directoryKind} marker must not be a symbolic link.`
+          : `Prepared lane ${directoryKind} marker is not accessible before executor invocation.`,
     );
     return undefined;
   });
 
-  if (markerStats?.isSymbolicLink()) {
-    issues.push(`Prepared lane ${directoryKind} marker must not be a symbolic link.`);
+  if (!markerFile) {
     return issues;
   }
 
-  if (markerStats && !markerStats.isFile()) {
-    issues.push(`Prepared lane ${directoryKind} marker must be a regular file.`);
-    return issues;
-  }
+  let rawMarker: string | undefined;
 
-  if (!markerStats) {
-    return issues;
-  }
+  try {
+    const markerStats = await markerFile.stat();
 
-  const rawMarker = await readFile(markerPath, "utf8").catch(() => {
-    issues.push(`Prepared lane ${directoryKind} marker is not readable before executor invocation.`);
-    return undefined;
-  });
+    if (!markerStats.isFile()) {
+      issues.push(`Prepared lane ${directoryKind} marker must be a regular file.`);
+      return issues;
+    }
+
+    rawMarker = await markerFile.readFile("utf8").catch(() => {
+      issues.push(`Prepared lane ${directoryKind} marker is not readable before executor invocation.`);
+      return undefined;
+    });
+  } finally {
+    await markerFile.close();
+  }
 
   if (rawMarker === undefined) {
     return issues;
@@ -406,6 +412,10 @@ function replaceProtocolIdPrefix(value: string, prefix: string): string {
   }
 
   return `${prefix}_${value.slice(separatorIndex + 1)}`;
+}
+
+function noFollowFlag(): number {
+  return typeof constants.O_NOFOLLOW === "number" ? constants.O_NOFOLLOW : 0;
 }
 
 function isPreparedMarkerForLane(value: unknown, laneRunId: string): boolean {

--- a/src/executor/index.ts
+++ b/src/executor/index.ts
@@ -1,4 +1,5 @@
-import { lstat } from "node:fs/promises";
+import { lstat, readFile } from "node:fs/promises";
+import path from "node:path";
 
 import type {
   CreateRunResultOptions,
@@ -8,6 +9,10 @@ import type {
   VerificationSummary,
 } from "../protocol/index.js";
 import { createRunResult } from "../protocol/index.js";
+import {
+  preparedLocalLaneMarkerFilename,
+  preparedLocalLaneMarkerSchemaVersion,
+} from "../lane/index.js";
 
 export type LaneExecutorMode = "deterministic-local-fake";
 export type LocalFakeExecutorOutcome = "succeeded" | "failed" | "blocked";
@@ -141,19 +146,28 @@ export async function invokeLaneExecutor(input: InvokeLaneExecutorInput): Promis
     );
   }
 
-  return input.executor.invoke({
-    mode: deterministicLocalFakeMode,
-    plan: input.plan,
-    preparedContext: input.preparedContext,
-    completedAt: input.completedAt,
-    fixture: input.fixture,
-  });
+  try {
+    return await input.executor.invoke({
+      mode: deterministicLocalFakeMode,
+      plan: input.plan,
+      preparedContext: input.preparedContext,
+      completedAt: input.completedAt,
+      fixture: input.fixture,
+    });
+  } catch {
+    return createBlockedResultWithoutAdapter(
+      input,
+      ["Executor adapter failed before returning a result."],
+      input.preparedContext,
+    );
+  }
 }
 
 async function collectPreparedContextIssues(
   preparedContext: PreparedLaneExecutorContext,
 ): Promise<readonly string[]> {
   const issues: string[] = [];
+  const directoryKinds: Array<"workspace" | "state"> = [];
 
   if (!localLaneIdPattern.test(preparedContext.laneRunId)) {
     issues.push("Prepared lane context has an invalid lane run identifier.");
@@ -176,7 +190,72 @@ async function collectPreparedContextIssues(
       issues.push(`Prepared lane ${label} path must not be a symbolic link.`);
     } else if (stats && !stats.isDirectory()) {
       issues.push(`Prepared lane ${label} path must be a real directory.`);
+    } else if (stats) {
+      directoryKinds.push(label);
     }
+  }
+
+  if (localLaneIdPattern.test(preparedContext.laneRunId)) {
+    for (const directoryKind of directoryKinds) {
+      issues.push(...await collectPreparedMarkerIssues(preparedContext, directoryKind));
+    }
+  }
+
+  return issues;
+}
+
+async function collectPreparedMarkerIssues(
+  preparedContext: PreparedLaneExecutorContext,
+  directoryKind: "workspace" | "state",
+): Promise<readonly string[]> {
+  const issues: string[] = [];
+  const markerPath = path.join(
+    directoryKind === "workspace" ? preparedContext.workspacePath : preparedContext.statePath,
+    preparedLocalLaneMarkerFilename,
+  );
+  const markerStats = await lstat(markerPath).catch((error: unknown) => {
+    issues.push(
+      isNodeError(error) && error.code === "ENOENT"
+        ? `Prepared lane ${directoryKind} marker must exist before executor invocation.`
+        : `Prepared lane ${directoryKind} marker is not accessible before executor invocation.`,
+    );
+    return undefined;
+  });
+
+  if (markerStats?.isSymbolicLink()) {
+    issues.push(`Prepared lane ${directoryKind} marker must not be a symbolic link.`);
+    return issues;
+  }
+
+  if (markerStats && !markerStats.isFile()) {
+    issues.push(`Prepared lane ${directoryKind} marker must be a regular file.`);
+    return issues;
+  }
+
+  if (!markerStats) {
+    return issues;
+  }
+
+  const rawMarker = await readFile(markerPath, "utf8").catch(() => {
+    issues.push(`Prepared lane ${directoryKind} marker is not readable before executor invocation.`);
+    return undefined;
+  });
+
+  if (rawMarker === undefined) {
+    return issues;
+  }
+
+  let parsed: unknown;
+
+  try {
+    parsed = JSON.parse(rawMarker);
+  } catch {
+    issues.push(`Prepared lane ${directoryKind} marker is malformed.`);
+    return issues;
+  }
+
+  if (!isPreparedMarkerForLane(parsed, preparedContext.laneRunId)) {
+    issues.push(`Prepared lane ${directoryKind} marker does not match the lane run identifier.`);
   }
 
   return issues;
@@ -327,6 +406,19 @@ function replaceProtocolIdPrefix(value: string, prefix: string): string {
   }
 
   return `${prefix}_${value.slice(separatorIndex + 1)}`;
+}
+
+function isPreparedMarkerForLane(value: unknown, laneRunId: string): boolean {
+  return (
+    isRecord(value) &&
+    Object.keys(value).length === 2 &&
+    value.schemaVersion === preparedLocalLaneMarkerSchemaVersion &&
+    value.laneRunId === laneRunId
+  );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 function isNodeError(error: unknown): error is NodeJS.ErrnoException {

--- a/src/executor/index.ts
+++ b/src/executor/index.ts
@@ -1,0 +1,305 @@
+import { lstat } from "node:fs/promises";
+
+import type {
+  CreateRunResultOptions,
+  RunRequestExecutionPlan,
+  RunResult,
+  VerificationCommand,
+  VerificationSummary,
+} from "../protocol/index.js";
+import { createRunResult } from "../protocol/index.js";
+
+export type LaneExecutorMode = "deterministic-local-fake";
+export type LocalFakeExecutorOutcome = "succeeded" | "failed" | "blocked";
+
+export interface PreparedLaneExecutorContext {
+  readonly laneRunId: string;
+  readonly workspacePath: string;
+  readonly statePath: string;
+}
+
+export interface LocalFakeExecutorFixture {
+  readonly name: string;
+  readonly outcome: LocalFakeExecutorOutcome;
+  readonly verificationSummary?: string;
+  readonly verificationCommands?: readonly VerificationCommand[];
+  readonly blockedReasons?: readonly string[];
+}
+
+export interface LaneExecutorInvocationMetadata {
+  readonly executorId: string;
+  readonly mode: LaneExecutorMode;
+  readonly laneRunId: string;
+  readonly requestId: string;
+  readonly workItemId: string;
+  readonly fixtureName: string;
+  readonly invokedAt: string;
+  readonly invokesProvider: false;
+  readonly mutatesScm: false;
+}
+
+export interface LaneExecutorResult {
+  readonly status: LocalFakeExecutorOutcome;
+  readonly invocation: LaneExecutorInvocationMetadata;
+  readonly runResult: RunResult;
+  readonly blockedReasons: readonly string[];
+}
+
+export interface LaneExecutorAdapterInput {
+  readonly mode: LaneExecutorMode;
+  readonly plan: RunRequestExecutionPlan;
+  readonly preparedContext: PreparedLaneExecutorContext;
+  readonly completedAt: string;
+  readonly fixture: LocalFakeExecutorFixture;
+}
+
+export interface LaneExecutorAdapter {
+  readonly id: string;
+  invoke(input: LaneExecutorAdapterInput): Promise<LaneExecutorResult>;
+}
+
+export interface InvokeLaneExecutorInput {
+  readonly executor: LaneExecutorAdapter;
+  readonly mode: string;
+  readonly plan: RunRequestExecutionPlan;
+  readonly preparedContext?: PreparedLaneExecutorContext;
+  readonly completedAt: string;
+  readonly fixture: LocalFakeExecutorFixture;
+}
+
+const deterministicLocalFakeMode: LaneExecutorMode = "deterministic-local-fake";
+const fixtureNamePattern = /^[a-z0-9][a-z0-9._-]{2,127}$/;
+const localLaneIdPattern = /^[A-Za-z0-9][A-Za-z0-9._-]{2,127}$/;
+const credentialPattern =
+  /(?:password|passwd|token|secret|credential|api[_-]?key)\s*[:=]\s*\S+/i;
+const unixHomePathPattern = /\/Users\/[^/\s]+|\/home\/[^/\s]+/;
+const windowsProfilePathPattern = /[A-Za-z]:\\Users\\[^\\\s]+/;
+
+export function createDeterministicLocalFakeExecutor(): LaneExecutorAdapter {
+  return {
+    id: deterministicLocalFakeMode,
+    async invoke(input) {
+      const fixtureIssues = collectFixtureIssues(input.fixture);
+      if (fixtureIssues.length > 0) {
+        return createBlockedExecutorResult(input, fixtureIssues);
+      }
+
+      if (input.plan.status === "blocked") {
+        return createBlockedExecutorResult(input, input.plan.blockedReasons);
+      }
+
+      const status = input.fixture.outcome;
+      if (status === "blocked") {
+        return createBlockedExecutorResult(
+          input,
+          input.fixture.blockedReasons?.length
+            ? input.fixture.blockedReasons
+            : ["deterministic local fake executor fixture requested a blocked outcome"],
+        );
+      }
+
+      return {
+        status,
+        invocation: createInvocationMetadata(input),
+        runResult: createRunResult(input.plan, {
+          status,
+          completedAt: input.completedAt,
+          verification: createVerificationSummary(input.fixture, status),
+        }),
+        blockedReasons: [],
+      };
+    },
+  };
+}
+
+export async function invokeLaneExecutor(input: InvokeLaneExecutorInput): Promise<LaneExecutorResult> {
+  if (input.mode !== deterministicLocalFakeMode || input.executor.id !== deterministicLocalFakeMode) {
+    return createBlockedResultWithoutAdapter(input, [
+      `Unsupported executor mode: ${input.mode}`,
+    ]);
+  }
+
+  if (input.preparedContext === undefined) {
+    return createBlockedResultWithoutAdapter(input, [
+      "Prepared lane context is required before executor invocation.",
+    ]);
+  }
+
+  const contextIssues = await collectPreparedContextIssues(input.preparedContext);
+  if (contextIssues.length > 0) {
+    return createBlockedResultWithoutAdapter(input, contextIssues, input.preparedContext);
+  }
+
+  return input.executor.invoke({
+    mode: deterministicLocalFakeMode,
+    plan: input.plan,
+    preparedContext: input.preparedContext,
+    completedAt: input.completedAt,
+    fixture: input.fixture,
+  });
+}
+
+async function collectPreparedContextIssues(
+  preparedContext: PreparedLaneExecutorContext,
+): Promise<readonly string[]> {
+  const issues: string[] = [];
+
+  if (!localLaneIdPattern.test(preparedContext.laneRunId)) {
+    issues.push("Prepared lane context has an invalid lane run identifier.");
+  }
+
+  for (const [label, candidatePath] of [
+    ["workspace", preparedContext.workspacePath],
+    ["state", preparedContext.statePath],
+  ] as const) {
+    const stats = await lstat(candidatePath).catch((error: unknown) => {
+      if (isNodeError(error) && error.code === "ENOENT") {
+        issues.push(`Prepared lane ${label} path must exist before executor invocation.`);
+        return undefined;
+      }
+
+      throw error;
+    });
+
+    if (stats?.isSymbolicLink()) {
+      issues.push(`Prepared lane ${label} path must not be a symbolic link.`);
+    } else if (stats && !stats.isDirectory()) {
+      issues.push(`Prepared lane ${label} path must be a real directory.`);
+    }
+  }
+
+  return issues;
+}
+
+function createBlockedResultWithoutAdapter(
+  input: InvokeLaneExecutorInput,
+  blockedReasons: readonly string[],
+  preparedContext?: PreparedLaneExecutorContext,
+): LaneExecutorResult {
+  const adapterInput: LaneExecutorAdapterInput = {
+    mode: deterministicLocalFakeMode,
+    plan: input.plan,
+    preparedContext: preparedContext ?? {
+      laneRunId: replaceProtocolIdPrefix(input.plan.provenance.requestId, "run"),
+      workspacePath: "<blocked-before-workspace-preparation>",
+      statePath: "<blocked-before-state-preparation>",
+    },
+    completedAt: input.completedAt,
+    fixture: input.fixture,
+  };
+
+  return createBlockedExecutorResult(adapterInput, blockedReasons);
+}
+
+function createBlockedExecutorResult(
+  input: LaneExecutorAdapterInput,
+  blockedReasons: readonly string[],
+): LaneExecutorResult {
+  return {
+    status: "blocked",
+    invocation: createInvocationMetadata(input),
+    runResult: createRunResult(
+      {
+        ...input.plan,
+        status: "blocked",
+        blockedReasons: [...blockedReasons],
+      },
+      {
+        status: "blocked",
+        completedAt: input.completedAt,
+        verification: {
+          status: "blocked",
+          summary: `Deterministic local executor blocked: ${blockedReasons.join("; ")}`,
+        },
+        warnings: [
+          {
+            code: "LOCAL_EXECUTOR_BLOCKED",
+            message: "The deterministic local executor stopped before provider or SCM work.",
+          },
+        ],
+      },
+    ),
+    blockedReasons: [...blockedReasons],
+  };
+}
+
+function createInvocationMetadata(input: LaneExecutorAdapterInput): LaneExecutorInvocationMetadata {
+  return {
+    executorId: deterministicLocalFakeMode,
+    mode: deterministicLocalFakeMode,
+    laneRunId: input.preparedContext.laneRunId,
+    requestId: input.plan.provenance.requestId,
+    workItemId: input.plan.workItem.id,
+    fixtureName: input.fixture.name,
+    invokedAt: input.completedAt,
+    invokesProvider: false,
+    mutatesScm: false,
+  };
+}
+
+function createVerificationSummary(
+  fixture: LocalFakeExecutorFixture,
+  status: Exclude<LocalFakeExecutorOutcome, "blocked">,
+): VerificationSummary {
+  const verificationStatus: CreateRunResultOptions["verification"] = {
+    status: status === "succeeded" ? "passed" : "failed",
+    summary:
+      fixture.verificationSummary ??
+      (status === "succeeded"
+        ? "Deterministic local fake executor completed successfully."
+        : "Deterministic local fake executor returned a failed outcome."),
+    commands: fixture.verificationCommands?.map((command) => ({ ...command })),
+  };
+
+  return verificationStatus;
+}
+
+function collectFixtureIssues(fixture: LocalFakeExecutorFixture): readonly string[] {
+  const issues: string[] = [];
+
+  if (!fixtureNamePattern.test(fixture.name)) {
+    issues.push("Deterministic fake executor fixture name is malformed.");
+  }
+
+  const fields = [
+    fixture.name,
+    fixture.verificationSummary,
+    ...(fixture.blockedReasons ?? []),
+    ...(fixture.verificationCommands ?? []).flatMap((command) => [
+      command.command,
+      command.summary,
+      command.completedAt,
+    ]),
+  ];
+
+  for (const field of fields) {
+    if (field !== undefined && containsUnsafeFixtureText(field)) {
+      issues.push("Deterministic fake executor fixture contains unsafe metadata.");
+      break;
+    }
+  }
+
+  return issues;
+}
+
+function containsUnsafeFixtureText(value: string): boolean {
+  return (
+    credentialPattern.test(value) ||
+    unixHomePathPattern.test(value) ||
+    windowsProfilePathPattern.test(value)
+  );
+}
+
+function replaceProtocolIdPrefix(value: string, prefix: string): string {
+  const separatorIndex = value.indexOf("_");
+
+  if (separatorIndex < 0) {
+    return `${prefix}_${value}`;
+  }
+
+  return `${prefix}_${value.slice(separatorIndex + 1)}`;
+}
+
+function isNodeError(error: unknown): error is NodeJS.ErrnoException {
+  return error instanceof Error && "code" in error;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ export function describeProduct(): string {
 }
 
 export * from "./core/index.js";
+export * from "./executor/index.js";
 export * from "./lane/index.js";
 export * from "./protocol/index.js";
 export * from "./work-item/index.js";

--- a/src/lane/index.ts
+++ b/src/lane/index.ts
@@ -83,6 +83,9 @@ export interface PreparedLocalLaneWorkspace {
   };
 }
 
+export const preparedLocalLaneMarkerFilename = ".ensen-loop-prepared.json";
+export const preparedLocalLaneMarkerSchemaVersion = "ensen.local-lane-prepared.v1";
+
 const laneRunIdPattern = /^[A-Za-z0-9][A-Za-z0-9._-]*$/;
 const localLaneDirectoryNamePattern = /^[A-Za-z0-9._-]{1,128}$/;
 const isoDateTimePattern =
@@ -156,6 +159,8 @@ export async function prepareLocalLaneWorkspace(
   try {
     workspaceResult = await prepareLocalLanePath("workspace", workspaceRoot, directoryName);
     const stateResult = await prepareLocalLanePath("state", stateRoot, directoryName);
+    await writePreparedLocalLaneMarker(workspaceResult.path, directoryName);
+    await writePreparedLocalLaneMarker(stateResult.path, directoryName);
 
     return {
       directoryName,
@@ -522,6 +527,35 @@ function toSerializableLaneRunState(state: LaneRunState): LaneRunState {
       bundleRefs: [...state.evidence.bundleRefs],
     },
   };
+}
+
+async function writePreparedLocalLaneMarker(statePath: string, laneRunId: string): Promise<void> {
+  const markerPath = path.join(statePath, preparedLocalLaneMarkerFilename);
+  const marker = `${JSON.stringify(
+    {
+      schemaVersion: preparedLocalLaneMarkerSchemaVersion,
+      laneRunId,
+    },
+    null,
+    2,
+  )}\n`;
+  const file = await open(
+    markerPath,
+    constants.O_WRONLY | constants.O_CREAT | constants.O_TRUNC | noFollowFlag() | nonBlockingFlag(),
+    0o600,
+  );
+
+  try {
+    const stats = await file.stat();
+
+    if (!stats.isFile()) {
+      throw new Error("Local lane preparation marker path must be a regular file.");
+    }
+
+    await file.writeFile(marker, "utf8");
+  } finally {
+    await file.close();
+  }
 }
 
 function parseLaneRunState(value: unknown): LaneRunState {

--- a/test/executor-boundary.test.ts
+++ b/test/executor-boundary.test.ts
@@ -172,8 +172,54 @@ test("fails closed for unsupported executor modes before invoking an adapter", a
   });
 });
 
+test("validates unsafe fixture metadata before unsupported mode and missing context fallbacks", async () => {
+  await withPreparedLane(async (preparedContext) => {
+    let invoked = false;
+    const unsupported = await invokeLaneExecutor({
+      executor: {
+        id: "not-supported",
+        async invoke() {
+          invoked = true;
+          throw new Error("unexpected invocation");
+        },
+      },
+      mode: "remote-provider",
+      plan: createRunRequestExecutionPlan(request),
+      preparedContext,
+      completedAt: "2026-05-01T00:00:08Z",
+      fixture: {
+        name: "token=raw-test-token",
+        outcome: "succeeded",
+      },
+    });
+
+    const missingContext = await invokeLaneExecutor({
+      executor: createDeterministicLocalFakeExecutor(),
+      mode: "deterministic-local-fake",
+      plan: createRunRequestExecutionPlan(request),
+      completedAt: "2026-05-01T00:00:09Z",
+      fixture: {
+        name: "issue-40-env-path",
+        outcome: "succeeded",
+        verificationSummary: ["uses", "$HOME", "fixture"].join(" "),
+      },
+    });
+
+    assert.equal(invoked, false);
+    assert.equal(unsupported.status, "blocked");
+    assert.match(unsupported.blockedReasons.join("\n"), /unsafe metadata/);
+    assert.doesNotMatch(unsupported.blockedReasons.join("\n"), /Unsupported executor mode/);
+    assert.equal(unsupported.invocation.fixtureName, "[REDACTED_FIXTURE]");
+    assert.doesNotMatch(JSON.stringify(unsupported), /raw-test-token/);
+    assert.equal(missingContext.status, "blocked");
+    assert.match(missingContext.blockedReasons.join("\n"), /unsafe metadata/);
+    assert.doesNotMatch(missingContext.blockedReasons.join("\n"), /Prepared lane context is required/);
+  });
+});
+
 test("blocks unsafe fake fixture metadata without echoing raw secret or workstation paths", async () => {
   await withPreparedLane(async (preparedContext) => {
+    const unixAbsolutePath = ["", "etc", "ensen-loop", "fixture.txt"].join(path.posix.sep);
     const result = await invokeLaneExecutor({
       executor: createDeterministicLocalFakeExecutor(),
       mode: "deterministic-local-fake",
@@ -183,7 +229,7 @@ test("blocks unsafe fake fixture metadata without echoing raw secret or workstat
       fixture: {
         name: "issue-40-unsafe",
         outcome: "succeeded",
-        verificationSummary: "token=raw-test-token at /Users/example/project",
+        verificationSummary: `token=raw-test-token at ${unixAbsolutePath}`,
       },
     });
     const serialized = JSON.stringify(result);
@@ -191,7 +237,38 @@ test("blocks unsafe fake fixture metadata without echoing raw secret or workstat
     assert.equal(result.status, "blocked");
     assert.match(result.blockedReasons.join("\n"), /unsafe metadata/);
     assert.doesNotMatch(serialized, /raw-test-token/);
-    assert.doesNotMatch(serialized, /\/Users\/example/);
+    assert.doesNotMatch(serialized, /ensen-loop\/fixture/);
+  });
+});
+
+test("blocks common local workstation path forms in fake fixture metadata", async () => {
+  await withPreparedLane(async (preparedContext) => {
+    const fixtureTexts = [
+      ["", "var", "folders", "fixture"].join(path.posix.sep),
+      ["C:", "tmp", "fixture"].join("\\"),
+      ["", "", "server", "share", "fixture"].join("\\"),
+      ["uses", "~", "fixture"].join(" "),
+      ["uses", "%USERPROFILE%", "fixture"].join(" "),
+    ];
+
+    for (const [index, verificationSummary] of fixtureTexts.entries()) {
+      const result = await invokeLaneExecutor({
+        executor: createDeterministicLocalFakeExecutor(),
+        mode: "deterministic-local-fake",
+        plan: createRunRequestExecutionPlan(request),
+        preparedContext,
+        completedAt: "2026-05-01T00:00:10Z",
+        fixture: {
+          name: `issue-40-path-${index}`,
+          outcome: "succeeded",
+          verificationSummary,
+        },
+      });
+
+      assert.equal(result.status, "blocked");
+      assert.match(result.blockedReasons.join("\n"), /unsafe metadata/);
+      assert.equal(JSON.stringify(result).includes(verificationSummary), false);
+    }
   });
 });
 
@@ -233,6 +310,25 @@ test("fails closed when prepared lane context is missing or unprepared", async (
     assert.equal(unprepared.status, "blocked");
     assert.match(unprepared.blockedReasons.join("\n"), /Prepared lane workspace path must exist/);
     await assert.rejects(() => mkdir(path.join(unpreparedWorkspacePath, "should-not-exist")), /ENOENT/);
+
+    const inaccessible = await invokeLaneExecutor({
+      executor: createDeterministicLocalFakeExecutor(),
+      mode: "deterministic-local-fake",
+      plan: createRunRequestExecutionPlan(request),
+      preparedContext: {
+        laneRunId: "run_01HV7Y8M8F2KQ5W3P9R6T4N2AA",
+        workspacePath: `bad\0path-${process.pid}`,
+        statePath: stateRoot,
+      },
+      completedAt: "2026-05-01T00:00:11Z",
+      fixture: {
+        name: "issue-40-inaccessible-context",
+        outcome: "succeeded",
+      },
+    });
+
+    assert.equal(inaccessible.status, "blocked");
+    assert.match(inaccessible.blockedReasons.join("\n"), /workspace path is not accessible/);
   } finally {
     await rm(stateRoot, { recursive: true, force: true });
   }

--- a/test/executor-boundary.test.ts
+++ b/test/executor-boundary.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -8,7 +8,11 @@ import {
   createDeterministicLocalFakeExecutor,
   invokeLaneExecutor,
 } from "../src/executor/index.js";
-import { prepareLocalLaneWorkspace } from "../src/lane/index.js";
+import {
+  prepareLocalLaneWorkspace,
+  preparedLocalLaneMarkerFilename,
+  preparedLocalLaneMarkerSchemaVersion,
+} from "../src/lane/index.js";
 import {
   createRunRequestExecutionPlan,
   parseRunRequest,
@@ -173,6 +177,32 @@ test("fails closed for unsupported executor modes before invoking an adapter", a
   });
 });
 
+test("fails closed when a supported adapter rejects before returning a result", async () => {
+  await withPreparedLane(async (preparedContext) => {
+    const result = await invokeLaneExecutor({
+      executor: {
+        id: "deterministic-local-fake",
+        async invoke() {
+          throw new Error("token=raw-test-token");
+        },
+      },
+      mode: "deterministic-local-fake",
+      plan: createRunRequestExecutionPlan(request),
+      preparedContext,
+      completedAt: "2026-05-01T00:00:13Z",
+      fixture: {
+        name: "issue-40-adapter-rejects",
+        outcome: "succeeded",
+      },
+    });
+
+    assert.equal(result.status, "blocked");
+    assert.deepEqual(result.blockedReasons, ["Executor adapter failed before returning a result."]);
+    assert.equal(result.invocation.laneRunId, preparedContext.laneRunId);
+    assert.doesNotMatch(JSON.stringify(result), /raw-test-token/);
+  });
+});
+
 test("validates unsafe fixture metadata before unsupported mode and missing context fallbacks", async () => {
   await withPreparedLane(async (preparedContext) => {
     let invoked = false;
@@ -275,6 +305,7 @@ test("blocks common local workstation path forms in fake fixture metadata", asyn
 
 test("fails closed when prepared lane context is missing or unprepared", async () => {
   const stateRoot = await mkdtemp(path.join(os.tmpdir(), "ensen-loop-state-"));
+  const workspaceRoot = await mkdtemp(path.join(os.tmpdir(), "ensen-loop-workspace-"));
 
   try {
     const missing = await invokeLaneExecutor({
@@ -311,6 +342,71 @@ test("fails closed when prepared lane context is missing or unprepared", async (
     assert.equal(unprepared.status, "blocked");
     assert.match(unprepared.blockedReasons.join("\n"), /Prepared lane workspace path must exist/);
     await assert.rejects(() => mkdir(path.join(unpreparedWorkspacePath, "should-not-exist")), /ENOENT/);
+
+    const unmarkedWorkspacePath = await mkdtemp(path.join(workspaceRoot, "existing-workspace-"));
+    const unmarkedStatePath = await mkdtemp(path.join(stateRoot, "existing-state-"));
+    let invokedWithoutMarker = false;
+    const unmarked = await invokeLaneExecutor({
+      executor: {
+        id: "deterministic-local-fake",
+        async invoke() {
+          invokedWithoutMarker = true;
+          throw new Error("unexpected invocation");
+        },
+      },
+      mode: "deterministic-local-fake",
+      plan: createRunRequestExecutionPlan(request),
+      preparedContext: {
+        laneRunId: "run_01HV7Y8M8F2KQ5W3P9R6T4N2AA",
+        workspacePath: unmarkedWorkspacePath,
+        statePath: unmarkedStatePath,
+      },
+      completedAt: "2026-05-01T00:00:14Z",
+      fixture: {
+        name: "issue-40-unmarked-context",
+        outcome: "succeeded",
+      },
+    });
+
+    assert.equal(invokedWithoutMarker, false);
+    assert.equal(unmarked.status, "blocked");
+    assert.match(unmarked.blockedReasons.join("\n"), /marker must exist/);
+
+    await writeFile(
+      path.join(unmarkedWorkspacePath, preparedLocalLaneMarkerFilename),
+      `${JSON.stringify({
+        schemaVersion: preparedLocalLaneMarkerSchemaVersion,
+        laneRunId: "run_01HV7Y8M8F2KQ5W3P9R6T4N2AA",
+      })}\n`,
+      "utf8",
+    );
+    await writeFile(
+      path.join(unmarkedStatePath, preparedLocalLaneMarkerFilename),
+      `${JSON.stringify({
+        schemaVersion: preparedLocalLaneMarkerSchemaVersion,
+        laneRunId: "run_01HV7Y8M8F2KQ5W3P9R6T4N2ZZ",
+      })}\n`,
+      "utf8",
+    );
+
+    const mismatched = await invokeLaneExecutor({
+      executor: createDeterministicLocalFakeExecutor(),
+      mode: "deterministic-local-fake",
+      plan: createRunRequestExecutionPlan(request),
+      preparedContext: {
+        laneRunId: "run_01HV7Y8M8F2KQ5W3P9R6T4N2AA",
+        workspacePath: unmarkedWorkspacePath,
+        statePath: unmarkedStatePath,
+      },
+      completedAt: "2026-05-01T00:00:15Z",
+      fixture: {
+        name: "issue-40-mismatched-marker",
+        outcome: "succeeded",
+      },
+    });
+
+    assert.equal(mismatched.status, "blocked");
+    assert.match(mismatched.blockedReasons.join("\n"), /state marker does not match/);
 
     const inaccessible = await invokeLaneExecutor({
       executor: createDeterministicLocalFakeExecutor(),
@@ -353,5 +449,6 @@ test("fails closed when prepared lane context is missing or unprepared", async (
     assert.doesNotMatch(JSON.stringify(invalidLaneRunId), /raw-test-token/);
   } finally {
     await rm(stateRoot, { recursive: true, force: true });
+    await rm(workspaceRoot, { recursive: true, force: true });
   }
 });

--- a/test/executor-boundary.test.ts
+++ b/test/executor-boundary.test.ts
@@ -156,7 +156,7 @@ test("fails closed for unsupported executor modes before invoking an adapter", a
           throw new Error("unexpected invocation");
         },
       },
-      mode: "remote-provider",
+      mode: "remote-provider token=raw-test-token",
       plan: createRunRequestExecutionPlan(request),
       preparedContext,
       completedAt: "2026-05-01T00:00:04Z",
@@ -168,7 +168,8 @@ test("fails closed for unsupported executor modes before invoking an adapter", a
 
     assert.equal(invoked, false);
     assert.equal(result.status, "blocked");
-    assert.match(result.blockedReasons.join("\n"), /Unsupported executor mode/);
+    assert.deepEqual(result.blockedReasons, ["Unsupported executor configuration."]);
+    assert.doesNotMatch(JSON.stringify(result), /raw-test-token/);
   });
 });
 
@@ -329,6 +330,27 @@ test("fails closed when prepared lane context is missing or unprepared", async (
 
     assert.equal(inaccessible.status, "blocked");
     assert.match(inaccessible.blockedReasons.join("\n"), /workspace path is not accessible/);
+
+    const invalidLaneRunId = await invokeLaneExecutor({
+      executor: createDeterministicLocalFakeExecutor(),
+      mode: "deterministic-local-fake",
+      plan: createRunRequestExecutionPlan(request),
+      preparedContext: {
+        laneRunId: "token=raw-test-token",
+        workspacePath: stateRoot,
+        statePath: stateRoot,
+      },
+      completedAt: "2026-05-01T00:00:12Z",
+      fixture: {
+        name: "issue-40-invalid-lane-id",
+        outcome: "succeeded",
+      },
+    });
+
+    assert.equal(invalidLaneRunId.status, "blocked");
+    assert.match(invalidLaneRunId.blockedReasons.join("\n"), /invalid lane run identifier/);
+    assert.equal(invalidLaneRunId.invocation.laneRunId, "run_01HV7Y8M8F2KQ5W3P9R6T4N2AA");
+    assert.doesNotMatch(JSON.stringify(invalidLaneRunId), /raw-test-token/);
   } finally {
     await rm(stateRoot, { recursive: true, force: true });
   }

--- a/test/executor-boundary.test.ts
+++ b/test/executor-boundary.test.ts
@@ -1,0 +1,239 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import {
+  createDeterministicLocalFakeExecutor,
+  invokeLaneExecutor,
+} from "../src/executor/index.js";
+import { prepareLocalLaneWorkspace } from "../src/lane/index.js";
+import {
+  createRunRequestExecutionPlan,
+  parseRunRequest,
+  validateRunResult,
+} from "../src/protocol/index.js";
+
+const request = parseRunRequest({
+  schemaVersion: "eip.run-request.v1",
+  id: "req_01HV7Y8M8F2KQ5W3P9R6T4N2AA",
+  correlationId: "corr_01HV7Y8M8F2KQ5W3P9R6T4N2AB",
+  idempotencyKey: "issue-40-test-key-001",
+  source: {
+    sourceId: "source_01HV7Y8M8F2KQ5W3P9R6T4N2AC",
+    sourceType: "github-issue",
+  },
+  requestedBy: {
+    actorId: "actor_01HV7Y8M8F2KQ5W3P9R6T4N2AD",
+    actorType: "workflow",
+  },
+  workItem: {
+    workItemId: "workitem_01HV7Y8M8F2KQ5W3P9R6T4N2AE",
+    externalId: "40",
+    title: "Add deterministic local executor boundary",
+  },
+  mode: "plan",
+  createdAt: "2026-05-01T00:00:00Z",
+  target: {
+    targetType: "repository",
+    targetId: "repo_01HV7Y8M8F2KQ5W3P9R6T4N2AF",
+  },
+  policyContext: {
+    policySetId: "policy_01HV7Y8M8F2KQ5W3P9R6T4N2AG",
+    riskClasses: [],
+    requiresApproval: false,
+  },
+});
+
+async function withPreparedLane(
+  callback: (preparedContext: {
+    readonly laneRunId: string;
+    readonly workspacePath: string;
+    readonly statePath: string;
+  }) => Promise<void>,
+): Promise<void> {
+  const workspaceRoot = await mkdtemp(path.join(os.tmpdir(), "ensen-loop-workspace-"));
+  const stateRoot = await mkdtemp(path.join(os.tmpdir(), "ensen-loop-state-"));
+
+  try {
+    const laneRunId = "run_01HV7Y8M8F2KQ5W3P9R6T4N2AA";
+    const prepared = await prepareLocalLaneWorkspace({
+      workspaceRoot,
+      stateRoot,
+      laneRunId,
+      workItemId: request.workItem.workItemId,
+    });
+
+    await callback({
+      laneRunId,
+      workspacePath: prepared.workspacePath,
+      statePath: prepared.statePath,
+    });
+  } finally {
+    await rm(workspaceRoot, { recursive: true, force: true });
+    await rm(stateRoot, { recursive: true, force: true });
+  }
+}
+
+test("invokes the deterministic local fake executor through the provider boundary", async () => {
+  await withPreparedLane(async (preparedContext) => {
+    const result = await invokeLaneExecutor({
+      executor: createDeterministicLocalFakeExecutor(),
+      mode: "deterministic-local-fake",
+      plan: createRunRequestExecutionPlan(request),
+      preparedContext,
+      completedAt: "2026-05-01T00:00:01Z",
+      fixture: {
+        name: "issue-40-succeeded",
+        outcome: "succeeded",
+        verificationSummary: "sanitized fake executor success",
+      },
+    });
+
+    assert.equal(result.status, "succeeded");
+    assert.equal(validateRunResult(result.runResult).ok, true);
+    assert.equal(result.runResult.status, "succeeded");
+    assert.deepEqual(result.invocation, {
+      executorId: "deterministic-local-fake",
+      mode: "deterministic-local-fake",
+      laneRunId: preparedContext.laneRunId,
+      requestId: request.id,
+      workItemId: request.workItem.workItemId,
+      fixtureName: "issue-40-succeeded",
+      invokedAt: "2026-05-01T00:00:01Z",
+      invokesProvider: false,
+      mutatesScm: false,
+    });
+    assert.doesNotMatch(JSON.stringify(result), new RegExp(os.tmpdir()));
+  });
+});
+
+test("emits deterministic failed and blocked fake executor outcomes", async () => {
+  await withPreparedLane(async (preparedContext) => {
+    const failed = await invokeLaneExecutor({
+      executor: createDeterministicLocalFakeExecutor(),
+      mode: "deterministic-local-fake",
+      plan: createRunRequestExecutionPlan(request),
+      preparedContext,
+      completedAt: "2026-05-01T00:00:02Z",
+      fixture: {
+        name: "issue-40-failed",
+        outcome: "failed",
+        verificationSummary: "sanitized fake executor failure",
+      },
+    });
+    const blocked = await invokeLaneExecutor({
+      executor: createDeterministicLocalFakeExecutor(),
+      mode: "deterministic-local-fake",
+      plan: createRunRequestExecutionPlan(request),
+      preparedContext,
+      completedAt: "2026-05-01T00:00:03Z",
+      fixture: {
+        name: "issue-40-blocked",
+        outcome: "blocked",
+        blockedReasons: ["missing prepared verification evidence"],
+      },
+    });
+
+    assert.equal(failed.status, "failed");
+    assert.equal(failed.runResult.status, "failed");
+    assert.equal(failed.runResult.verification?.status, "failed");
+    assert.equal(blocked.status, "blocked");
+    assert.equal(blocked.runResult.status, "blocked");
+    assert.deepEqual(blocked.blockedReasons, ["missing prepared verification evidence"]);
+  });
+});
+
+test("fails closed for unsupported executor modes before invoking an adapter", async () => {
+  await withPreparedLane(async (preparedContext) => {
+    let invoked = false;
+    const result = await invokeLaneExecutor({
+      executor: {
+        id: "not-supported",
+        async invoke() {
+          invoked = true;
+          throw new Error("unexpected invocation");
+        },
+      },
+      mode: "remote-provider",
+      plan: createRunRequestExecutionPlan(request),
+      preparedContext,
+      completedAt: "2026-05-01T00:00:04Z",
+      fixture: {
+        name: "issue-40-unsupported",
+        outcome: "succeeded",
+      },
+    });
+
+    assert.equal(invoked, false);
+    assert.equal(result.status, "blocked");
+    assert.match(result.blockedReasons.join("\n"), /Unsupported executor mode/);
+  });
+});
+
+test("blocks unsafe fake fixture metadata without echoing raw secret or workstation paths", async () => {
+  await withPreparedLane(async (preparedContext) => {
+    const result = await invokeLaneExecutor({
+      executor: createDeterministicLocalFakeExecutor(),
+      mode: "deterministic-local-fake",
+      plan: createRunRequestExecutionPlan(request),
+      preparedContext,
+      completedAt: "2026-05-01T00:00:05Z",
+      fixture: {
+        name: "issue-40-unsafe",
+        outcome: "succeeded",
+        verificationSummary: "token=raw-test-token at /Users/example/project",
+      },
+    });
+    const serialized = JSON.stringify(result);
+
+    assert.equal(result.status, "blocked");
+    assert.match(result.blockedReasons.join("\n"), /unsafe metadata/);
+    assert.doesNotMatch(serialized, /raw-test-token/);
+    assert.doesNotMatch(serialized, /\/Users\/example/);
+  });
+});
+
+test("fails closed when prepared lane context is missing or unprepared", async () => {
+  const stateRoot = await mkdtemp(path.join(os.tmpdir(), "ensen-loop-state-"));
+
+  try {
+    const missing = await invokeLaneExecutor({
+      executor: createDeterministicLocalFakeExecutor(),
+      mode: "deterministic-local-fake",
+      plan: createRunRequestExecutionPlan(request),
+      completedAt: "2026-05-01T00:00:06Z",
+      fixture: {
+        name: "issue-40-missing-context",
+        outcome: "succeeded",
+      },
+    });
+
+    assert.equal(missing.status, "blocked");
+    assert.match(missing.blockedReasons.join("\n"), /Prepared lane context is required/);
+
+    const unpreparedWorkspacePath = path.join(os.tmpdir(), `ensen-loop-unprepared-${process.pid}`);
+    const unprepared = await invokeLaneExecutor({
+      executor: createDeterministicLocalFakeExecutor(),
+      mode: "deterministic-local-fake",
+      plan: createRunRequestExecutionPlan(request),
+      preparedContext: {
+        laneRunId: "run_01HV7Y8M8F2KQ5W3P9R6T4N2AA",
+        workspacePath: unpreparedWorkspacePath,
+        statePath: stateRoot,
+      },
+      completedAt: "2026-05-01T00:00:07Z",
+      fixture: {
+        name: "issue-40-unprepared-context",
+        outcome: "succeeded",
+      },
+    });
+
+    assert.equal(unprepared.status, "blocked");
+    assert.match(unprepared.blockedReasons.join("\n"), /Prepared lane workspace path must exist/);
+    await assert.rejects(() => mkdir(path.join(unpreparedWorkspacePath, "should-not-exist")), /ENOENT/);
+  } finally {
+    await rm(stateRoot, { recursive: true, force: true });
+  }
+});

--- a/test/executor-boundary.test.ts
+++ b/test/executor-boundary.test.ts
@@ -81,6 +81,12 @@ async function withPreparedLane(
   }
 }
 
+function jsonStringContentPattern(value: string): RegExp {
+  const serializedValue = JSON.stringify(value).slice(1, -1);
+
+  return new RegExp(serializedValue.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"));
+}
+
 test("invokes the deterministic local fake executor through the provider boundary", async () => {
   await withPreparedLane(async (preparedContext) => {
     const result = await invokeLaneExecutor({
@@ -299,7 +305,7 @@ test("blocks common local workstation path forms in fake fixture metadata", asyn
 
       assert.equal(result.status, "blocked");
       assert.match(result.blockedReasons.join("\n"), /unsafe metadata/);
-      assert.equal(JSON.stringify(result).includes(verificationSummary), false);
+      assert.doesNotMatch(JSON.stringify(result), jsonStringContentPattern(verificationSummary));
     }
   });
 });

--- a/test/executor-boundary.test.ts
+++ b/test/executor-boundary.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { constants } from "node:fs";
+import { mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -371,6 +372,60 @@ test("fails closed when prepared lane context is missing or unprepared", async (
     assert.equal(invokedWithoutMarker, false);
     assert.equal(unmarked.status, "blocked");
     assert.match(unmarked.blockedReasons.join("\n"), /marker must exist/);
+
+    if (typeof constants.O_NOFOLLOW === "number") {
+      const symlinkWorkspacePath = await mkdtemp(path.join(workspaceRoot, "symlink-workspace-"));
+      const symlinkStatePath = await mkdtemp(path.join(stateRoot, "symlink-state-"));
+      const workspaceMarkerTarget = path.join(symlinkWorkspacePath, "marker-target.json");
+      let invokedWithSymlinkMarker = false;
+
+      await writeFile(
+        workspaceMarkerTarget,
+        `${JSON.stringify({
+          schemaVersion: preparedLocalLaneMarkerSchemaVersion,
+          laneRunId: "run_01HV7Y8M8F2KQ5W3P9R6T4N2AA",
+        })}\n`,
+        "utf8",
+      );
+      await symlink(
+        workspaceMarkerTarget,
+        path.join(symlinkWorkspacePath, preparedLocalLaneMarkerFilename),
+      );
+      await writeFile(
+        path.join(symlinkStatePath, preparedLocalLaneMarkerFilename),
+        `${JSON.stringify({
+          schemaVersion: preparedLocalLaneMarkerSchemaVersion,
+          laneRunId: "run_01HV7Y8M8F2KQ5W3P9R6T4N2AA",
+        })}\n`,
+        "utf8",
+      );
+
+      const symlinkMarker = await invokeLaneExecutor({
+        executor: {
+          id: "deterministic-local-fake",
+          async invoke() {
+            invokedWithSymlinkMarker = true;
+            throw new Error("unexpected invocation");
+          },
+        },
+        mode: "deterministic-local-fake",
+        plan: createRunRequestExecutionPlan(request),
+        preparedContext: {
+          laneRunId: "run_01HV7Y8M8F2KQ5W3P9R6T4N2AA",
+          workspacePath: symlinkWorkspacePath,
+          statePath: symlinkStatePath,
+        },
+        completedAt: "2026-05-01T00:00:16Z",
+        fixture: {
+          name: "issue-40-symlink-marker",
+          outcome: "succeeded",
+        },
+      });
+
+      assert.equal(invokedWithSymlinkMarker, false);
+      assert.equal(symlinkMarker.status, "blocked");
+      assert.match(symlinkMarker.blockedReasons.join("\n"), /workspace marker must not be a symbolic link/);
+    }
 
     await writeFile(
       path.join(unmarkedWorkspacePath, preparedLocalLaneMarkerFilename),

--- a/test/local-lane-workspace.test.ts
+++ b/test/local-lane-workspace.test.ts
@@ -6,6 +6,8 @@ import test from "node:test";
 
 import {
   prepareLocalLaneWorkspace,
+  preparedLocalLaneMarkerFilename,
+  preparedLocalLaneMarkerSchemaVersion,
   resolveLocalLaneDirectoryName,
 } from "../src/lane/index.js";
 
@@ -28,6 +30,20 @@ test("prepares bounded local workspace and state directories for one lane run", 
       workspace: true,
       state: true,
     });
+    assert.deepEqual(
+      JSON.parse(await readFile(path.join(prepared.workspacePath, preparedLocalLaneMarkerFilename), "utf8")),
+      {
+        schemaVersion: preparedLocalLaneMarkerSchemaVersion,
+        laneRunId: prepared.directoryName,
+      },
+    );
+    assert.deepEqual(
+      JSON.parse(await readFile(path.join(prepared.statePath, preparedLocalLaneMarkerFilename), "utf8")),
+      {
+        schemaVersion: preparedLocalLaneMarkerSchemaVersion,
+        laneRunId: prepared.directoryName,
+      },
+    );
   } finally {
     await rm(workspaceRoot, { recursive: true, force: true });
     await rm(stateRoot, { recursive: true, force: true });


### PR DESCRIPTION
## Summary
- add an Ensen-loop-owned executor adapter boundary
- implement the deterministic local fake executor for succeeded, failed, and blocked outcomes
- keep invocation metadata path-free and block unsupported modes, unsafe fixture metadata, and missing prepared lane context

## Verification
- npm run typecheck
- npm run build
- npm test
- npm run build && node --test dist/test/executor-boundary.test.js

Closes #40

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a deterministic local-fake lane executor with outcome tracking (succeeded/failed/blocked) and package-level re-exports for executor APIs.

* **Behavior**
  * Performs strict pre-execution safety and configuration checks for fixtures, execution plans, and prepared workspace/state, returning standardized blocked results and redacting sensitive fixture/path tokens.
  * Records durable prepared workspace/state markers.

* **Tests**
  * Added comprehensive tests covering executor behavior, safety checks, blocked-fail semantics, marker creation, and output redaction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->