### PR TITLE
LOOP-020 persist Phase 3 lane journal evidence refs

### DIFF
--- a/docs/architecture/core-model.md
+++ b/docs/architecture/core-model.md
@@ -44,7 +44,7 @@ The Lane Journal is embedded in the Lane Run State for Phase 1. It records short
 Audit and evidence surfaces are represented as explicit reference lists on the Lane Run State:
 
 - `audit.eventRefs` reserves the relationship to future audit events without emitting a full EIP AuditEvent.
-- `evidence.bundleRefs` reserves the relationship to future evidence bundles. Dry-run output may expose EvidenceBundleRef v1-compatible reference metadata, but that metadata is not a full evidence bundle artifact and does not claim durable compliance packaging.
+- `evidence.bundleRefs` reserves the relationship to future evidence bundles. Dry-run output and Phase 3 local lane persistence may expose EvidenceBundleRef v1-compatible reference metadata, but that metadata is not a full evidence bundle artifact and does not claim durable compliance packaging.
 
 Local storage helpers must resolve lane run state paths below a real configured state root, reject lane run identifiers containing path separators or traversal syntax, and fail closed when existing storage components are symbolic links. Derived summaries, detail projections, or operator-facing notes must be rebuilt from the Lane Run State instead of redefining the durable status.
 

--- a/docs/architecture/local-lane-execution.md
+++ b/docs/architecture/local-lane-execution.md
@@ -19,8 +19,9 @@ real provider work. The boundary:
 
 - does not invoke an Agent Provider;
 - does not create branches, commits, change requests, issues, or reviews;
-- does not write a durable evidence bundle unless a later issue explicitly adds
-  that behavior;
+- may write local development evidence metadata references, but does not write
+  a production evidence archive or durable compliance bundle unless a later
+  issue explicitly adds that behavior;
 - does not require Ensen-flow code, services, packages, fixtures, local paths,
   or runtime state;
 - treats every RunRequest field as external protocol input, not internal
@@ -98,6 +99,7 @@ The Phase 3 local lane state machine is:
 | `running` | Ensen-loop is normalizing scope, journal entries, and bounded execution intent. | None |
 | `verifying` | Repo-owned verification commands are selected or recorded. | None by default |
 | `reviewing` | Reviewable local output is ready for human or tool inspection. | None by default |
+| `blocked` | The local lane run stopped at a missing or unsafe prerequisite with diagnostic reasons preserved. | None |
 | `completed` | The local lane run reached a clear terminal success outcome. | None unless a later issue adds an explicit adapter |
 | `failed` | The local lane run reached a clear terminal failure outcome. | None |
 
@@ -125,6 +127,13 @@ EvidenceBundleRef is reference metadata. It can point to a future artifact
 location only when the URI or path is traversal-free, secret-safe, and scoped to
 the documented local artifact root. An EvidenceBundleRef does not by itself
 prove that a durable evidence bundle exists.
+
+Phase 3 local lane persistence may write Ensen-loop-owned metadata under the
+prepared local state path using an EvidenceBundleRef `local_path` URI. That file
+records bounded development facts such as lane identifiers, executor outcome,
+verification summary, blocked reasons, and the validated reference metadata. It
+must not embed raw evidence bodies, secrets, customer data, provider
+credentials, workstation-local absolute paths, or production compliance claims.
 
 ## Fail-Closed Rules
 

--- a/schemas/lane-run.schema.json
+++ b/schemas/lane-run.schema.json
@@ -27,7 +27,7 @@
     },
     "status": {
       "type": "string",
-      "enum": ["queued", "running", "verifying", "reviewing", "completed", "failed"]
+      "enum": ["queued", "running", "verifying", "reviewing", "blocked", "completed", "failed"]
     },
     "revision": {
       "type": "integer",

--- a/src/executor/index.ts
+++ b/src/executor/index.ts
@@ -1,18 +1,23 @@
 import { constants } from "node:fs";
-import { lstat, open } from "node:fs/promises";
+import { lstat, mkdir, open, realpath, rm, writeFile } from "node:fs/promises";
 import path from "node:path";
 
 import type {
   CreateRunResultOptions,
+  EvidenceBundleRef,
   RunRequestExecutionPlan,
   RunResult,
   VerificationCommand,
   VerificationSummary,
 } from "../protocol/index.js";
-import { createRunResult } from "../protocol/index.js";
+import { createRunResult, validateEvidenceBundleRef } from "../protocol/index.js";
 import {
+  type LaneJournalEntry,
+  createLaneJournal,
+  createLaneRunState,
   preparedLocalLaneMarkerFilename,
   preparedLocalLaneMarkerSchemaVersion,
+  writeLaneRunState,
 } from "../lane/index.js";
 
 export type LaneExecutorMode = "deterministic-local-fake";
@@ -71,6 +76,22 @@ export interface InvokeLaneExecutorInput {
   readonly preparedContext?: PreparedLaneExecutorContext;
   readonly completedAt: string;
   readonly fixture: LocalFakeExecutorFixture;
+}
+
+export interface PersistLaneExecutorResultInput {
+  readonly stateRoot: string;
+  readonly plan: RunRequestExecutionPlan;
+  readonly preparedContext: PreparedLaneExecutorContext;
+  readonly executorResult: LaneExecutorResult;
+  readonly recordedAt: string;
+  readonly evidenceBundleRefs?: readonly EvidenceBundleRef[];
+}
+
+export interface PersistedLaneExecutorResult {
+  readonly state: ReturnType<typeof createLaneRunState>;
+  readonly statePath: string;
+  readonly evidenceBundleRefs: readonly EvidenceBundleRef[];
+  readonly evidenceMetadataPaths: readonly string[];
 }
 
 const deterministicLocalFakeMode: LaneExecutorMode = "deterministic-local-fake";
@@ -164,6 +185,78 @@ export async function invokeLaneExecutor(input: InvokeLaneExecutorInput): Promis
   }
 }
 
+export async function persistLaneExecutorResult(
+  input: PersistLaneExecutorResultInput,
+): Promise<PersistedLaneExecutorResult> {
+  const contextIssues = await collectPreparedContextIssues(input.preparedContext);
+  if (contextIssues.length > 0) {
+    throw new Error(`Prepared lane context is unsafe for persistence: ${contextIssues.join("; ")}`);
+  }
+
+  const evidenceBundleRefs = input.evidenceBundleRefs ?? [
+    createLocalLaneEvidenceBundleRef(input),
+  ];
+  const evidenceMetadataPaths = evidenceBundleRefs.map((evidenceBundleRef) =>
+    resolveLocalEvidenceMetadataPath(input.preparedContext.statePath, evidenceBundleRef),
+  );
+  const state = createLaneRunState({
+    id: input.preparedContext.laneRunId,
+    workItemId: input.plan.workItem.id,
+    status: toLaneRunStatus(input.executorResult.status),
+    revision: 1,
+    createdAt: input.plan.provenance.createdAt,
+    updatedAt: input.recordedAt,
+    journal: createLaneJournal({
+      id: `journal-${input.preparedContext.laneRunId}`,
+      laneRunId: input.preparedContext.laneRunId,
+      workItemId: input.plan.workItem.id,
+      entries: createPersistenceJournalEntries(input),
+    }),
+    audit: {
+      eventRefs: [
+        `local-executor:${input.executorResult.invocation.executorId}`,
+        `run-result:${input.executorResult.runResult.id}`,
+      ],
+    },
+    evidence: {
+      bundleRefs: evidenceBundleRefs.map((evidenceBundleRef) => evidenceBundleRef.uri),
+    },
+  });
+
+  const writtenEvidencePaths: string[] = [];
+
+  try {
+    for (const [index, evidenceBundleRef] of evidenceBundleRefs.entries()) {
+      const metadataPath = evidenceMetadataPaths[index];
+      await assertLocalEvidenceMetadataPathSafe(input.preparedContext.statePath, metadataPath);
+      await mkdir(path.dirname(metadataPath), { recursive: true });
+      await assertLocalEvidenceMetadataPathSafe(input.preparedContext.statePath, metadataPath);
+      await writeFile(
+        metadataPath,
+        `${JSON.stringify(createEvidenceMetadata(input, evidenceBundleRef), null, 2)}\n`,
+        {
+          encoding: "utf8",
+          mode: 0o600,
+          flag: "wx",
+        },
+      );
+      writtenEvidencePaths.push(metadataPath);
+    }
+
+    const statePath = await writeLaneRunState(input.stateRoot, state);
+
+    return {
+      state,
+      statePath,
+      evidenceBundleRefs,
+      evidenceMetadataPaths,
+    };
+  } catch (error) {
+    await Promise.all(writtenEvidencePaths.map((metadataPath) => rm(metadataPath, { force: true })));
+    throw error;
+  }
+}
+
 async function collectPreparedContextIssues(
   preparedContext: PreparedLaneExecutorContext,
 ): Promise<readonly string[]> {
@@ -203,6 +296,198 @@ async function collectPreparedContextIssues(
   }
 
   return issues;
+}
+
+function createLocalLaneEvidenceBundleRef(input: PersistLaneExecutorResultInput): EvidenceBundleRef {
+  return {
+    schemaVersion: "eip.evidence-bundle-ref.v1",
+    id: replaceProtocolIdPrefix(input.preparedContext.laneRunId, "evb"),
+    correlationId: input.plan.provenance.correlationId,
+    type: "local_path",
+    uri: `artifacts/evidence/local-lane/${input.preparedContext.laneRunId}.json`,
+    createdAt: input.recordedAt,
+    contentType: "application/json",
+    metadata: {
+      producer: "ensen-loop",
+      artifactKind: "localLaneEvidenceMetadata",
+      localDevelopmentOnly: true,
+      writesDurableEvidence: false,
+    },
+  };
+}
+
+function resolveLocalEvidenceMetadataPath(
+  statePath: string,
+  evidenceBundleRef: EvidenceBundleRef,
+): string {
+  const validation = validateEvidenceBundleRef(evidenceBundleRef);
+
+  if (!validation.ok) {
+    throw new Error(
+      `EvidenceBundleRef output is unsafe: ${validation.issues.map((issue) => issue.message).join("; ")}`,
+    );
+  }
+
+  if (validation.ref.type !== "local_path") {
+    throw new Error("EvidenceBundleRef output is unsafe: persisted local lane evidence must use local_path.");
+  }
+
+  const resolvedStatePath = path.resolve(statePath);
+  const metadataPath = path.resolve(resolvedStatePath, validation.ref.uri);
+  const relativePath = path.relative(resolvedStatePath, metadataPath);
+
+  if (relativePath.startsWith("..") || path.isAbsolute(relativePath)) {
+    throw new Error("EvidenceBundleRef output is unsafe: metadata path escapes the prepared state path.");
+  }
+
+  return metadataPath;
+}
+
+async function assertLocalEvidenceMetadataPathSafe(
+  statePath: string,
+  metadataPath: string,
+): Promise<void> {
+  const realStatePath = await realpath(statePath);
+  const metadataDirectory = path.dirname(metadataPath);
+  const segments = path.relative(statePath, metadataDirectory).split(path.sep).filter(Boolean);
+  let currentPath = statePath;
+
+  for (const segment of segments) {
+    currentPath = path.join(currentPath, segment);
+    const stats = await lstat(currentPath).catch((error: unknown) => {
+      if (isNodeError(error) && error.code === "ENOENT") {
+        return undefined;
+      }
+
+      throw error;
+    });
+
+    if (!stats) {
+      return;
+    }
+
+    if (stats.isSymbolicLink()) {
+      throw new Error("Evidence metadata paths must not traverse symbolic links.");
+    }
+
+    if (!stats.isDirectory()) {
+      throw new Error("Evidence metadata directory paths must be real directories.");
+    }
+
+    const realCurrentPath = await realpath(currentPath);
+    const relativePath = path.relative(realStatePath, realCurrentPath);
+
+    if (relativePath.startsWith("..") || path.isAbsolute(relativePath)) {
+      throw new Error("Evidence metadata paths must stay inside the prepared state path.");
+    }
+  }
+
+  const metadataStats = await lstat(metadataPath).catch((error: unknown) => {
+    if (isNodeError(error) && error.code === "ENOENT") {
+      return undefined;
+    }
+
+    throw error;
+  });
+
+  if (metadataStats?.isSymbolicLink()) {
+    throw new Error("Evidence metadata paths must not traverse symbolic links.");
+  }
+}
+
+function createEvidenceMetadata(
+  input: PersistLaneExecutorResultInput,
+  evidenceBundleRef: EvidenceBundleRef,
+): Record<string, unknown> {
+  return {
+    schemaVersion: "ensen.local-lane-evidence-metadata.v1",
+    laneRunId: input.preparedContext.laneRunId,
+    requestId: input.plan.provenance.requestId,
+    workItemId: input.plan.workItem.id,
+    outcome: input.executorResult.status,
+    recordedAt: input.recordedAt,
+    localDevelopmentOnly: true,
+    writesProductionEvidenceArchive: false,
+    executor: {
+      id: input.executorResult.invocation.executorId,
+      mode: input.executorResult.invocation.mode,
+      fixtureName: input.executorResult.invocation.fixtureName,
+      invokesProvider: input.executorResult.invocation.invokesProvider,
+      mutatesScm: input.executorResult.invocation.mutatesScm,
+    },
+    verification: input.executorResult.runResult.verification
+      ? {
+          status: input.executorResult.runResult.verification.status,
+          summary: input.executorResult.runResult.verification.summary,
+          commands: input.executorResult.runResult.verification.commands ?? [],
+        }
+      : undefined,
+    blockedReasons: [...input.executorResult.blockedReasons],
+    evidenceBundleRef,
+  };
+}
+
+function createPersistenceJournalEntries(
+  input: PersistLaneExecutorResultInput,
+): readonly LaneJournalEntry[] {
+  const entries: LaneJournalEntry[] = [
+    {
+      id: `entry-${input.preparedContext.laneRunId}-prepared`,
+      recordedAt: input.recordedAt,
+      kind: "change",
+      message:
+        `prepared workspace facts recorded for lane ${input.preparedContext.laneRunId}; ` +
+        "workspace and state roots remain local-only and are not embedded",
+    },
+    {
+      id: `entry-${input.preparedContext.laneRunId}-executor`,
+      recordedAt: input.executorResult.invocation.invokedAt,
+      kind: input.executorResult.status === "failed" ? "failure" : "command",
+      message:
+        `executor outcome: ${input.executorResult.status}; ` +
+        `fixture: ${input.executorResult.invocation.fixtureName}; ` +
+        `provider invoked: ${String(input.executorResult.invocation.invokesProvider)}; ` +
+        `scm mutated: ${String(input.executorResult.invocation.mutatesScm)}`,
+    },
+  ];
+
+  if (input.executorResult.blockedReasons.length > 0) {
+    entries.push({
+      id: `entry-${input.preparedContext.laneRunId}-blocked`,
+      recordedAt: input.recordedAt,
+      kind: "failure",
+      message: `blocked reasons: ${input.executorResult.blockedReasons.join("; ")}`,
+    });
+  }
+
+  entries.push({
+    id: `entry-${input.preparedContext.laneRunId}-next`,
+    recordedAt: input.recordedAt,
+    kind: "next-action",
+    message: createNextActionMessage(input.executorResult.status),
+  });
+
+  return entries;
+}
+
+function createNextActionMessage(status: LocalFakeExecutorOutcome): string {
+  if (status === "succeeded") {
+    return "next action: review persisted local lane journal and evidence metadata before publication";
+  }
+
+  if (status === "failed") {
+    return "next action: inspect failed verification summary and repair before publication";
+  }
+
+  return "next action: resolve blocked prerequisites before retrying local lane execution";
+}
+
+function toLaneRunStatus(status: LocalFakeExecutorOutcome): "completed" | "failed" | "blocked" {
+  if (status === "succeeded") {
+    return "completed";
+  }
+
+  return status;
 }
 
 async function collectPreparedMarkerIssues(

--- a/src/executor/index.ts
+++ b/src/executor/index.ts
@@ -17,6 +17,7 @@ import {
   createLaneRunState,
   preparedLocalLaneMarkerFilename,
   preparedLocalLaneMarkerSchemaVersion,
+  resolveLaneRunStatePath,
   writeLaneRunState,
 } from "../lane/index.js";
 
@@ -188,6 +189,8 @@ export async function invokeLaneExecutor(input: InvokeLaneExecutorInput): Promis
 export async function persistLaneExecutorResult(
   input: PersistLaneExecutorResultInput,
 ): Promise<PersistedLaneExecutorResult> {
+  assertExecutorResultMatchesPersistenceInput(input);
+
   const contextIssues = await collectPreparedContextIssues(input.preparedContext);
   if (contextIssues.length > 0) {
     throw new Error(`Prepared lane context is unsafe for persistence: ${contextIssues.join("; ")}`);
@@ -224,6 +227,7 @@ export async function persistLaneExecutorResult(
   });
 
   const writtenEvidencePaths: string[] = [];
+  const statePath = resolveLaneRunStatePath(input.stateRoot, state.id);
 
   try {
     for (const [index, evidenceBundleRef] of evidenceBundleRefs.entries()) {
@@ -243,7 +247,7 @@ export async function persistLaneExecutorResult(
       writtenEvidencePaths.push(metadataPath);
     }
 
-    const statePath = await writeLaneRunState(input.stateRoot, state);
+    await writeLaneRunState(input.stateRoot, state);
 
     return {
       state,
@@ -253,7 +257,34 @@ export async function persistLaneExecutorResult(
     };
   } catch (error) {
     await Promise.all(writtenEvidencePaths.map((metadataPath) => rm(metadataPath, { force: true })));
+    await rm(statePath, { force: true });
     throw error;
+  }
+}
+
+function assertExecutorResultMatchesPersistenceInput(input: PersistLaneExecutorResultInput): void {
+  if (input.executorResult.invocation.laneRunId !== input.preparedContext.laneRunId) {
+    throw new Error("Executor result lane run identifier does not match the prepared context.");
+  }
+
+  if (input.executorResult.invocation.requestId !== input.plan.provenance.requestId) {
+    throw new Error("Executor result request identifier does not match the execution plan.");
+  }
+
+  if (input.executorResult.invocation.workItemId !== input.plan.workItem.id) {
+    throw new Error("Executor result work item identifier does not match the execution plan.");
+  }
+
+  if (input.executorResult.runResult.requestId !== input.plan.provenance.requestId) {
+    throw new Error("Executor run result request identifier does not match the execution plan.");
+  }
+
+  if (input.executorResult.runResult.correlationId !== input.plan.provenance.correlationId) {
+    throw new Error("Executor run result correlation identifier does not match the execution plan.");
+  }
+
+  if (input.executorResult.runResult.status !== input.executorResult.status) {
+    throw new Error("Executor run result status does not match the executor outcome.");
   }
 }
 

--- a/src/lane/index.ts
+++ b/src/lane/index.ts
@@ -15,6 +15,7 @@ export type LaneRunStatus =
   | "running"
   | "verifying"
   | "reviewing"
+  | "blocked"
   | "completed"
   | "failed";
 
@@ -95,6 +96,7 @@ const laneRunStatuses = new Set<unknown>([
   "running",
   "verifying",
   "reviewing",
+  "blocked",
   "completed",
   "failed",
 ]);

--- a/test/lane-run-persistence.test.ts
+++ b/test/lane-run-persistence.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { access, mkdtemp, readFile, rm } from "node:fs/promises";
+import { access, mkdir, mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -9,7 +9,11 @@ import {
   invokeLaneExecutor,
   persistLaneExecutorResult,
 } from "../src/executor/index.js";
-import { prepareLocalLaneWorkspace, readLaneRunState } from "../src/lane/index.js";
+import {
+  prepareLocalLaneWorkspace,
+  readLaneRunState,
+  resolveLaneRunStatePath,
+} from "../src/lane/index.js";
 import {
   createRunRequestExecutionPlan,
   parseRunRequest,
@@ -125,16 +129,72 @@ test("persists a succeeded Phase 3 lane journal and local evidence metadata for 
         readBack.journal.entries.map((entry) => entry.message).join("\n"),
         /prepared workspace facts recorded/,
       );
-      assert.doesNotMatch(
-        JSON.stringify({
-          state: persisted.state,
-          evidenceBundleRefs: persisted.evidenceBundleRefs,
-          metadata,
-        }),
-        new RegExp(os.tmpdir()),
-      );
+      const serialized = JSON.stringify({
+        state: persisted.state,
+        evidenceBundleRefs: persisted.evidenceBundleRefs,
+        metadata,
+      });
+      assert.equal(serialized.includes(os.tmpdir()), false);
     },
   );
+});
+
+test("rejects executor results that do not belong to the prepared lane", async () => {
+  const workspaceRoot = await mkdtemp(path.join(os.tmpdir(), "ensen-loop-workspace-"));
+  const stateRoot = await mkdtemp(path.join(os.tmpdir(), "ensen-loop-state-"));
+  const laneRunId = "run_01HV7Y8M8F2KQ5W3P9R6T4N2BA";
+  const plan = createRunRequestExecutionPlan(request);
+
+  try {
+    const preparedContext = await prepareLocalLaneWorkspace({
+      workspaceRoot,
+      stateRoot,
+      laneRunId,
+      workItemId: request.workItem.workItemId,
+    });
+    const executorContext = {
+      laneRunId,
+      workspacePath: preparedContext.workspacePath,
+      statePath: preparedContext.statePath,
+    };
+    const executorResult = await invokeLaneExecutor({
+      executor: createDeterministicLocalFakeExecutor(),
+      mode: "deterministic-local-fake",
+      plan,
+      preparedContext: executorContext,
+      completedAt: "2026-05-01T00:00:02Z",
+      fixture: {
+        name: "issue-41-mismatched-result",
+        outcome: "succeeded",
+      },
+    });
+
+    await assert.rejects(
+      () =>
+        persistLaneExecutorResult({
+          stateRoot,
+          plan,
+          preparedContext: executorContext,
+          executorResult: {
+            ...executorResult,
+            invocation: {
+              ...executorResult.invocation,
+              laneRunId: "run_01HV7Y8M8F2KQ5W3P9R6T4N2ZZ",
+            },
+          },
+          recordedAt: "2026-05-01T00:00:03Z",
+        }),
+      /Executor result lane run identifier does not match the prepared context/,
+    );
+    await assert.rejects(() => readLaneRunState(stateRoot, laneRunId), /ENOENT/);
+    await assert.rejects(
+      () => access(path.join(preparedContext.statePath, "artifacts")),
+      /ENOENT/,
+    );
+  } finally {
+    await rm(workspaceRoot, { recursive: true, force: true });
+    await rm(stateRoot, { recursive: true, force: true });
+  }
 });
 
 test("persists failed and blocked Phase 3 outcomes with diagnostic journal entries", async () => {
@@ -228,5 +288,71 @@ test("rejects unsafe EvidenceBundleRef output before writing evidence metadata o
   } finally {
     await rm(workspaceRoot, { recursive: true, force: true });
     await rm(stateRoot, { recursive: true, force: true });
+  }
+});
+
+test("cleans evidence metadata and lane-state path when persistence fails", async () => {
+  const workspaceRoot = await mkdtemp(path.join(os.tmpdir(), "ensen-loop-workspace-"));
+  const stateRoot = await mkdtemp(path.join(os.tmpdir(), "ensen-loop-state-"));
+  const outsideRoot = await mkdtemp(path.join(os.tmpdir(), "ensen-loop-outside-"));
+  const laneRunId = "run_01HV7Y8M8F2KQ5W3P9R6T4N2BA";
+  const plan = createRunRequestExecutionPlan(request);
+
+  try {
+    const preparedContext = await prepareLocalLaneWorkspace({
+      workspaceRoot,
+      stateRoot,
+      laneRunId,
+      workItemId: request.workItem.workItemId,
+    });
+    const executorContext = {
+      laneRunId,
+      workspacePath: preparedContext.workspacePath,
+      statePath: preparedContext.statePath,
+    };
+    const executorResult = await invokeLaneExecutor({
+      executor: createDeterministicLocalFakeExecutor(),
+      mode: "deterministic-local-fake",
+      plan,
+      preparedContext: executorContext,
+      completedAt: "2026-05-01T00:00:05Z",
+      fixture: {
+        name: "issue-41-cleanup-failure",
+        outcome: "succeeded",
+      },
+    });
+    const statePath = resolveLaneRunStatePath(stateRoot, laneRunId);
+    const outsideStatePath = path.join(outsideRoot, "outside-lane-state.json");
+    const evidenceMetadataPath = path.join(
+      preparedContext.statePath,
+      "artifacts",
+      "evidence",
+      "local-lane",
+      `${laneRunId}.json`,
+    );
+
+    await mkdir(path.dirname(statePath), { recursive: true });
+    await writeFile(outsideStatePath, "outside state must not be touched\n", "utf8");
+    await symlink(outsideStatePath, statePath);
+
+    await assert.rejects(
+      () =>
+        persistLaneExecutorResult({
+          stateRoot,
+          plan,
+          preparedContext: executorContext,
+          executorResult,
+          recordedAt: "2026-05-01T00:00:06Z",
+        }),
+      /Lane run state paths must not traverse symbolic links/,
+    );
+
+    await assert.rejects(() => access(statePath), /ENOENT/);
+    await assert.rejects(() => access(evidenceMetadataPath), /ENOENT/);
+    assert.equal(await readFile(outsideStatePath, "utf8"), "outside state must not be touched\n");
+  } finally {
+    await rm(workspaceRoot, { recursive: true, force: true });
+    await rm(stateRoot, { recursive: true, force: true });
+    await rm(outsideRoot, { recursive: true, force: true });
   }
 });

--- a/test/lane-run-persistence.test.ts
+++ b/test/lane-run-persistence.test.ts
@@ -1,0 +1,232 @@
+import assert from "node:assert/strict";
+import { access, mkdtemp, readFile, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import {
+  createDeterministicLocalFakeExecutor,
+  invokeLaneExecutor,
+  persistLaneExecutorResult,
+} from "../src/executor/index.js";
+import { prepareLocalLaneWorkspace, readLaneRunState } from "../src/lane/index.js";
+import {
+  createRunRequestExecutionPlan,
+  parseRunRequest,
+  validateEvidenceBundleRef,
+} from "../src/protocol/index.js";
+
+const request = parseRunRequest({
+  schemaVersion: "eip.run-request.v1",
+  id: "req_01HV7Y8M8F2KQ5W3P9R6T4N2BA",
+  correlationId: "corr_01HV7Y8M8F2KQ5W3P9R6T4N2BB",
+  idempotencyKey: "issue-41-test-key-001",
+  source: {
+    sourceId: "source_01HV7Y8M8F2KQ5W3P9R6T4N2BC",
+    sourceType: "github-issue",
+  },
+  requestedBy: {
+    actorId: "actor_01HV7Y8M8F2KQ5W3P9R6T4N2BD",
+    actorType: "workflow",
+  },
+  workItem: {
+    workItemId: "workitem_01HV7Y8M8F2KQ5W3P9R6T4N2BE",
+    externalId: "41",
+    title: "Persist Phase 3 lane journal and evidence references",
+  },
+  mode: "plan",
+  createdAt: "2026-05-01T00:00:00Z",
+  target: {
+    targetType: "repository",
+    targetId: "repo_01HV7Y8M8F2KQ5W3P9R6T4N2BF",
+  },
+  policyContext: {
+    policySetId: "policy_01HV7Y8M8F2KQ5W3P9R6T4N2BG",
+    riskClasses: [],
+    requiresApproval: false,
+  },
+});
+
+async function withPersistedFixture(
+  fixture: Parameters<typeof invokeLaneExecutor>[0]["fixture"],
+  callback: (context: {
+    readonly stateRoot: string;
+    readonly persisted: Awaited<ReturnType<typeof persistLaneExecutorResult>>;
+  }) => Promise<void>,
+): Promise<void> {
+  const workspaceRoot = await mkdtemp(path.join(os.tmpdir(), "ensen-loop-workspace-"));
+  const stateRoot = await mkdtemp(path.join(os.tmpdir(), "ensen-loop-state-"));
+  const laneRunId = "run_01HV7Y8M8F2KQ5W3P9R6T4N2BA";
+  const plan = createRunRequestExecutionPlan(request);
+
+  try {
+    const preparedContext = await prepareLocalLaneWorkspace({
+      workspaceRoot,
+      stateRoot,
+      laneRunId,
+      workItemId: request.workItem.workItemId,
+    });
+    const executorContext = {
+      laneRunId,
+      workspacePath: preparedContext.workspacePath,
+      statePath: preparedContext.statePath,
+    };
+    const executorResult = await invokeLaneExecutor({
+      executor: createDeterministicLocalFakeExecutor(),
+      mode: "deterministic-local-fake",
+      plan,
+      preparedContext: executorContext,
+      completedAt: "2026-05-01T00:00:01Z",
+      fixture,
+    });
+
+    const persisted = await persistLaneExecutorResult({
+      stateRoot,
+      plan,
+      preparedContext: executorContext,
+      executorResult,
+      recordedAt: "2026-05-01T00:00:02Z",
+    });
+
+    await callback({ stateRoot, persisted });
+  } finally {
+    await rm(workspaceRoot, { recursive: true, force: true });
+    await rm(stateRoot, { recursive: true, force: true });
+  }
+}
+
+test("persists a succeeded Phase 3 lane journal and local evidence metadata for restart readback", async () => {
+  await withPersistedFixture(
+    {
+      name: "issue-41-succeeded",
+      outcome: "succeeded",
+      verificationSummary: "sanitized issue 41 success",
+    },
+    async ({ stateRoot, persisted }) => {
+      assert.equal(persisted.state.status, "completed");
+      assert.equal(persisted.state.evidence.bundleRefs.length, 1);
+      assert.equal(validateEvidenceBundleRef(persisted.evidenceBundleRefs[0]).ok, true);
+      assert.deepEqual(persisted.state.evidence.bundleRefs, [
+        persisted.evidenceBundleRefs[0].uri,
+      ]);
+
+      const metadata = JSON.parse(await readFile(persisted.evidenceMetadataPaths[0], "utf8")) as {
+        outcome: string;
+        laneRunId: string;
+        evidenceBundleRef: { uri: string };
+      };
+      assert.equal(metadata.outcome, "succeeded");
+      assert.equal(metadata.laneRunId, persisted.state.id);
+      assert.equal(metadata.evidenceBundleRef.uri, persisted.evidenceBundleRefs[0].uri);
+
+      const readBack = await readLaneRunState(stateRoot, persisted.state.id);
+      assert.deepEqual(readBack, persisted.state);
+      assert.match(
+        readBack.journal.entries.map((entry) => entry.message).join("\n"),
+        /prepared workspace facts recorded/,
+      );
+      assert.doesNotMatch(
+        JSON.stringify({
+          state: persisted.state,
+          evidenceBundleRefs: persisted.evidenceBundleRefs,
+          metadata,
+        }),
+        new RegExp(os.tmpdir()),
+      );
+    },
+  );
+});
+
+test("persists failed and blocked Phase 3 outcomes with diagnostic journal entries", async () => {
+  await withPersistedFixture(
+    {
+      name: "issue-41-failed",
+      outcome: "failed",
+      verificationSummary: "sanitized issue 41 failure",
+    },
+    async ({ persisted }) => {
+      assert.equal(persisted.state.status, "failed");
+      assert.match(
+        persisted.state.journal.entries.map((entry) => entry.message).join("\n"),
+        /executor outcome: failed/,
+      );
+    },
+  );
+
+  await withPersistedFixture(
+    {
+      name: "issue-41-blocked",
+      outcome: "blocked",
+      blockedReasons: ["missing prepared verification evidence"],
+    },
+    async ({ persisted }) => {
+      assert.equal(persisted.state.status, "blocked");
+      assert.match(
+        persisted.state.journal.entries.map((entry) => entry.message).join("\n"),
+        /missing prepared verification evidence/,
+      );
+    },
+  );
+});
+
+test("rejects unsafe EvidenceBundleRef output before writing evidence metadata or lane state", async () => {
+  const workspaceRoot = await mkdtemp(path.join(os.tmpdir(), "ensen-loop-workspace-"));
+  const stateRoot = await mkdtemp(path.join(os.tmpdir(), "ensen-loop-state-"));
+  const laneRunId = "run_01HV7Y8M8F2KQ5W3P9R6T4N2BA";
+  const plan = createRunRequestExecutionPlan(request);
+
+  try {
+    const preparedContext = await prepareLocalLaneWorkspace({
+      workspaceRoot,
+      stateRoot,
+      laneRunId,
+      workItemId: request.workItem.workItemId,
+    });
+    const executorContext = {
+      laneRunId,
+      workspacePath: preparedContext.workspacePath,
+      statePath: preparedContext.statePath,
+    };
+    const executorResult = await invokeLaneExecutor({
+      executor: createDeterministicLocalFakeExecutor(),
+      mode: "deterministic-local-fake",
+      plan,
+      preparedContext: executorContext,
+      completedAt: "2026-05-01T00:00:03Z",
+      fixture: {
+        name: "issue-41-unsafe-ref",
+        outcome: "succeeded",
+      },
+    });
+
+    await assert.rejects(
+      () =>
+        persistLaneExecutorResult({
+          stateRoot,
+          plan,
+          preparedContext: executorContext,
+          executorResult,
+          recordedAt: "2026-05-01T00:00:04Z",
+          evidenceBundleRefs: [
+            {
+              schemaVersion: "eip.evidence-bundle-ref.v1",
+              id: "evb_01HV7Y8M8F2KQ5W3P9R6T4N2BH",
+              correlationId: request.correlationId,
+              type: "local_path",
+              uri: "../unsafe/bundle.json",
+              createdAt: "2026-05-01T00:00:04Z",
+            },
+          ],
+        }),
+      /EvidenceBundleRef output is unsafe/,
+    );
+    await assert.rejects(() => readLaneRunState(stateRoot, laneRunId), /ENOENT/);
+    await assert.rejects(
+      () => access(path.join(preparedContext.statePath, "artifacts")),
+      /ENOENT/,
+    );
+  } finally {
+    await rm(workspaceRoot, { recursive: true, force: true });
+    await rm(stateRoot, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary
- add Phase 3 local lane persistence for executor outcomes, lane journal entries, audit refs, and safe local EvidenceBundleRef metadata
- persist succeeded, failed, and blocked local lane outcomes with restart/readback support
- document local-only evidence metadata boundaries and add blocked to the lane state schema

## Verification
- npm run typecheck
- npm run build
- npm test

Closes #41

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified how evidence metadata is exposed in dry-run and local development scenarios
  * Documented Phase 3 lifecycle including new "blocked" run state for safety-halted executions

* **New Features**
  * Lane runs can now enter a "blocked" status when prerequisites are missing or unsafe
  * Added persistent local metadata storage with strict validation and safety checks

<!-- end of auto-generated comment: release notes by coderabbit.ai -->