### PR TITLE
LOOP-021 project lane state to EIP output

### DIFF
--- a/src/protocol/index.ts
+++ b/src/protocol/index.ts
@@ -1,4 +1,5 @@
 export * from "./evidence-bundle-ref.js";
+export * from "./local-lane-projection.js";
 export * from "./run-request.js";
 export * from "./run-result.js";
 export * from "./run-status.js";

--- a/src/protocol/local-lane-projection.ts
+++ b/src/protocol/local-lane-projection.ts
@@ -1,0 +1,391 @@
+import type { LaneRunState, LaneRunStatus } from "../lane/index.js";
+import type { EvidenceBundleRef } from "./evidence-bundle-ref.js";
+import { validateEvidenceBundleRef } from "./evidence-bundle-ref.js";
+import type {
+  RunResult,
+  RunResultEvidenceBundleRef,
+  RunResultErrorInfo,
+  RunResultStatus,
+  RunResultWarningInfo,
+  VerificationSummary,
+} from "./run-result.js";
+import { validateRunResult } from "./run-result.js";
+import type {
+  RunStatusProgress,
+  RunStatusSnapshot,
+  RunStatusSnapshotStatus,
+} from "./run-status.js";
+import { validateRunStatusSnapshot } from "./run-status.js";
+
+export interface ProjectLaneRunStatusSnapshotInput {
+  readonly state: LaneRunState;
+  readonly requestId: string;
+  readonly correlationId: string;
+  readonly observedAt: string;
+  readonly protocolSchemaVersion?: string;
+}
+
+export interface ProjectLaneRunResultInput {
+  readonly state: LaneRunState;
+  readonly requestId: string;
+  readonly correlationId: string;
+  readonly completedAt: string;
+  readonly evidenceBundleRefs?: readonly EvidenceBundleRef[];
+  readonly protocolSchemaVersion?: string;
+}
+
+const terminalLaneStatuses = new Set<LaneRunStatus>(["completed", "failed", "blocked"]);
+
+export function projectLaneRunStatusSnapshot(
+  input: ProjectLaneRunStatusSnapshotInput,
+): RunStatusSnapshot {
+  assertSupportedSchemaVersion(
+    input.protocolSchemaVersion ?? "eip.run-status.v1",
+    "eip.run-status.v1",
+  );
+  assertProjectableLaneRunState(input.state);
+
+  const status = toRunStatusSnapshotStatus(input.state.status);
+  const snapshot = stripUndefined({
+    schemaVersion: "eip.run-status.v1" as const,
+    id: replaceProtocolIdPrefix(input.state.id, "sts"),
+    requestId: input.requestId,
+    correlationId: input.correlationId,
+    runId: input.state.id,
+    status,
+    observedAt: input.observedAt,
+    message: createStatusMessage(input.state.status),
+    progress: createStatusProgress(input.state.status),
+    extensions: createBlockedReasonsExtension(input.state),
+  }) as RunStatusSnapshot;
+  const validation = validateRunStatusSnapshot(snapshot);
+
+  if (!validation.ok) {
+    throw new Error(
+      `Lane run state cannot be projected to RunStatusSnapshot: ${formatIssues(validation.issues)}`,
+    );
+  }
+
+  return validation.snapshot;
+}
+
+export function projectLaneRunResult(input: ProjectLaneRunResultInput): RunResult {
+  assertSupportedSchemaVersion(
+    input.protocolSchemaVersion ?? "eip.run-result.v1",
+    "eip.run-result.v1",
+  );
+  assertProjectableLaneRunState(input.state);
+
+  if (!terminalLaneStatuses.has(input.state.status)) {
+    throw new Error("Lane run state cannot be projected to RunResult until it is terminal.");
+  }
+
+  const resultStatus = toRunResultStatus(input.state.status);
+  const evidenceBundles = resultStatus === "succeeded"
+    ? projectEvidenceBundleRefs(input.state, input.correlationId, input.evidenceBundleRefs ?? [])
+    : undefined;
+  const blockedReasons = collectBlockedReasons(input.state);
+  const result = stripUndefined({
+    schemaVersion: "eip.run-result.v1" as const,
+    id: input.state.id,
+    requestId: input.requestId,
+    correlationId: input.correlationId,
+    status: resultStatus,
+    completedAt: input.completedAt,
+    evidenceBundles,
+    verification: createProjectedVerification(input.state, resultStatus, blockedReasons),
+    errors: resultStatus === "failed" ? createFailureErrors(input.state) : undefined,
+    warnings: resultStatus === "blocked" ? createBlockedWarnings(blockedReasons) : undefined,
+    metrics: {
+      attempts: 1,
+    },
+    extensions: createProjectionExtensions(input.state, blockedReasons),
+  }) as RunResult;
+  const validation = validateRunResult(result);
+
+  if (!validation.ok) {
+    throw new Error(
+      `Lane run state cannot be projected to RunResult: ${formatIssues(validation.issues)}`,
+    );
+  }
+
+  return validation.result;
+}
+
+function assertSupportedSchemaVersion(actual: string, expected: string): void {
+  if (actual !== expected) {
+    throw new Error(`Unsupported EIP schema version: ${actual}. Expected ${expected}.`);
+  }
+}
+
+function assertProjectableLaneRunState(state: LaneRunState): void {
+  if (!isRecord(state)) {
+    throw new Error("Lane run state cannot be projected because it is malformed.");
+  }
+
+  if (state.startsAgentExecution !== false) {
+    throw new Error("Lane run state cannot be projected because it is malformed.");
+  }
+
+  if (
+    typeof state.id !== "string" ||
+    typeof state.workItemId !== "string" ||
+    !isLaneRunStatus(state.status) ||
+    typeof state.updatedAt !== "string" ||
+    !isRecord(state.journal) ||
+    state.journal.laneRunId !== state.id ||
+    state.journal.workItemId !== state.workItemId ||
+    !Array.isArray(state.journal.entries) ||
+    !isRecord(state.evidence) ||
+    !Array.isArray(state.evidence.bundleRefs) ||
+    !state.evidence.bundleRefs.every((bundleRef) => typeof bundleRef === "string")
+  ) {
+    throw new Error("Lane run state cannot be projected because it is malformed.");
+  }
+}
+
+function toRunStatusSnapshotStatus(status: LaneRunStatus): RunStatusSnapshotStatus {
+  if (status === "completed") {
+    return "completed";
+  }
+
+  if (status === "failed") {
+    return "failed";
+  }
+
+  if (status === "blocked") {
+    return "blocked";
+  }
+
+  if (status === "queued") {
+    return "queued";
+  }
+
+  return "running";
+}
+
+function toRunResultStatus(status: LaneRunStatus): RunResultStatus {
+  if (status === "completed") {
+    return "succeeded";
+  }
+
+  if (status === "failed") {
+    return "failed";
+  }
+
+  return "blocked";
+}
+
+function createStatusMessage(status: LaneRunStatus): string {
+  if (status === "completed") {
+    return "Local lane run completed. Retrieve final details from RunResult.";
+  }
+
+  if (status === "failed") {
+    return "Local lane run failed. Retrieve final details from RunResult.";
+  }
+
+  if (status === "blocked") {
+    return "Local lane run is blocked by recorded prerequisites.";
+  }
+
+  if (status === "queued") {
+    return "Local lane run is queued.";
+  }
+
+  return `Local lane run is ${status}.`;
+}
+
+function createStatusProgress(status: LaneRunStatus): RunStatusProgress | undefined {
+  if (status === "running") {
+    return {
+      current: 1,
+      total: 3,
+      percent: 33,
+      unit: "local-lane-stages",
+    };
+  }
+
+  if (status === "verifying") {
+    return {
+      current: 2,
+      total: 3,
+      percent: 67,
+      unit: "local-lane-stages",
+    };
+  }
+
+  if (status === "reviewing") {
+    return {
+      current: 3,
+      total: 3,
+      percent: 100,
+      unit: "local-lane-stages",
+    };
+  }
+
+  return undefined;
+}
+
+function createProjectedVerification(
+  state: LaneRunState,
+  status: RunResultStatus,
+  blockedReasons: readonly string[],
+): VerificationSummary {
+  if (status === "succeeded") {
+    return {
+      status: "passed",
+      summary: "Local lane run completed with persisted local evidence metadata.",
+    };
+  }
+
+  if (status === "failed") {
+    return {
+      status: "failed",
+      summary: collectFailureMessages(state).join("; ") || "Local lane run failed.",
+    };
+  }
+
+  return {
+    status: "blocked",
+    summary: blockedReasons.join("; ") || "Local lane run is blocked.",
+  };
+}
+
+function projectEvidenceBundleRefs(
+  state: LaneRunState,
+  correlationId: string,
+  evidenceBundleRefs: readonly EvidenceBundleRef[],
+): readonly RunResultEvidenceBundleRef[] | undefined {
+  if (state.evidence.bundleRefs.length === 0) {
+    return undefined;
+  }
+
+  const projected: RunResultEvidenceBundleRef[] = [];
+
+  for (const uri of state.evidence.bundleRefs) {
+    const evidenceBundleRef = evidenceBundleRefs.find((candidate) => candidate.uri === uri);
+
+    if (evidenceBundleRef === undefined) {
+      throw new Error("Lane run evidence cannot be projected without a matching EvidenceBundleRef.");
+    }
+
+    const validation = validateEvidenceBundleRef(evidenceBundleRef);
+    if (!validation.ok) {
+      throw new Error(`Lane run evidence is unsafe: ${formatIssues(validation.issues)}`);
+    }
+
+    if (validation.ref.type !== "local_path") {
+      throw new Error("Lane run evidence must use a safe local EvidenceBundleRef.");
+    }
+
+    if (validation.ref.correlationId !== correlationId) {
+      throw new Error("Lane run evidence correlation identifier does not match the projection input.");
+    }
+
+    projected.push(stripUndefined({
+      evidenceBundleId: validation.ref.id,
+      digest: validation.ref.checksum === undefined
+        ? undefined
+        : `${validation.ref.checksum.algorithm}:${validation.ref.checksum.value}`,
+    }));
+  }
+
+  return projected;
+}
+
+function createFailureErrors(state: LaneRunState): readonly RunResultErrorInfo[] {
+  return [
+    {
+      code: "LOCAL_LANE_FAILED",
+      message: collectFailureMessages(state).join("; ") || "Local lane run failed.",
+      retryable: true,
+    },
+  ];
+}
+
+function createBlockedWarnings(blockedReasons: readonly string[]): readonly RunResultWarningInfo[] {
+  return [
+    {
+      code: "LOCAL_LANE_BLOCKED",
+      message: blockedReasons.join("; ") || "Local lane run is blocked.",
+    },
+  ];
+}
+
+function createBlockedReasonsExtension(state: LaneRunState): Record<string, unknown> | undefined {
+  const blockedReasons = collectBlockedReasons(state);
+
+  if (blockedReasons.length === 0) {
+    return undefined;
+  }
+
+  return {
+    "x-ensen-loop-blocked-reasons": blockedReasons,
+  };
+}
+
+function createProjectionExtensions(
+  state: LaneRunState,
+  blockedReasons: readonly string[],
+): Record<string, unknown> {
+  return {
+    "x-ensen-loop-lane-run-status": state.status,
+    "x-ensen-loop-lane-run-revision": state.revision,
+    ...(blockedReasons.length > 0
+      ? {
+          "x-ensen-loop-blocked-reasons": blockedReasons,
+        }
+      : {}),
+  };
+}
+
+function collectBlockedReasons(state: LaneRunState): readonly string[] {
+  return state.journal.entries
+    .filter((entry) => entry.kind === "failure" && entry.message.startsWith("blocked reasons: "))
+    .map((entry) => entry.message.slice("blocked reasons: ".length))
+    .filter((message) => message.length > 0);
+}
+
+function collectFailureMessages(state: LaneRunState): readonly string[] {
+  return state.journal.entries
+    .filter((entry) => entry.kind === "failure")
+    .map((entry) => entry.message)
+    .filter((message) => message.length > 0);
+}
+
+function replaceProtocolIdPrefix(value: string, prefix: string): string {
+  const separatorIndex = value.indexOf("_");
+
+  if (separatorIndex < 0) {
+    return `${prefix}_${value}`;
+  }
+
+  return `${prefix}_${value.slice(separatorIndex + 1)}`;
+}
+
+function stripUndefined<T extends Record<string, unknown>>(value: T): T {
+  return Object.fromEntries(
+    Object.entries(value).filter(([, entryValue]) => entryValue !== undefined),
+  ) as T;
+}
+
+function formatIssues(issues: readonly { readonly path: string; readonly message: string }[]): string {
+  return issues.map((issue) => `${issue.path}: ${issue.message}`).join("; ");
+}
+
+function isLaneRunStatus(value: unknown): value is LaneRunStatus {
+  return (
+    value === "queued" ||
+    value === "running" ||
+    value === "verifying" ||
+    value === "reviewing" ||
+    value === "blocked" ||
+    value === "completed" ||
+    value === "failed"
+  );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/test/local-lane-eip-projection.test.ts
+++ b/test/local-lane-eip-projection.test.ts
@@ -1,0 +1,279 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import {
+  createDeterministicLocalFakeExecutor,
+  invokeLaneExecutor,
+  persistLaneExecutorResult,
+} from "../src/executor/index.js";
+import {
+  type LaneRunState,
+  prepareLocalLaneWorkspace,
+} from "../src/lane/index.js";
+import {
+  createRunRequestExecutionPlan,
+  parseRunRequest,
+  projectLaneRunResult,
+  projectLaneRunStatusSnapshot,
+  validateRunResult,
+  validateRunStatusSnapshot,
+} from "../src/protocol/index.js";
+
+const fixtureRoot = path.join(
+  "protocol-snapshots",
+  "ensen-protocol",
+  "v0.1.0",
+  "fixtures",
+);
+
+async function readJson(relativePath: string): Promise<unknown> {
+  return JSON.parse(await readFile(path.join(fixtureRoot, relativePath), "utf8")) as unknown;
+}
+
+async function withPersistedLaneRun(
+  fixture: {
+    readonly name: string;
+    readonly outcome: "succeeded" | "failed" | "blocked";
+    readonly verificationSummary?: string;
+    readonly blockedReasons?: readonly string[];
+  },
+  callback: (context: Awaited<ReturnType<typeof createPersistedLaneRun>>) => Promise<void>,
+): Promise<void> {
+  const context = await createPersistedLaneRun(fixture);
+
+  try {
+    await callback(context);
+  } finally {
+    await rm(context.workspaceRoot, { recursive: true, force: true });
+    await rm(context.stateRoot, { recursive: true, force: true });
+  }
+}
+
+async function createPersistedLaneRun(fixture: {
+  readonly name: string;
+  readonly outcome: "succeeded" | "failed" | "blocked";
+  readonly verificationSummary?: string;
+  readonly blockedReasons?: readonly string[];
+}) {
+  const request = parseRunRequest(await readJson("run-request/v1/valid/github-issue-request.json"));
+  const plan = createRunRequestExecutionPlan(request);
+  const workspaceRoot = await mkdtemp(path.join(os.tmpdir(), "ensen-loop-projection-workspace-"));
+  const stateRoot = await mkdtemp(path.join(os.tmpdir(), "ensen-loop-projection-state-"));
+  const laneRunId = "run_01HV7Y8M8F2KQ5W3P9R6T4N2AB";
+  const prepared = await prepareLocalLaneWorkspace({
+    workspaceRoot,
+    stateRoot,
+    laneRunId,
+    workItemId: request.workItem.workItemId,
+  });
+  const preparedContext = {
+    laneRunId,
+    workspacePath: prepared.workspacePath,
+    statePath: prepared.statePath,
+  };
+  const executorResult = await invokeLaneExecutor({
+    executor: createDeterministicLocalFakeExecutor(),
+    mode: "deterministic-local-fake",
+    plan,
+    preparedContext,
+    completedAt: "2026-05-01T00:00:01Z",
+    fixture,
+  });
+  const persisted = await persistLaneExecutorResult({
+    stateRoot,
+    plan,
+    preparedContext,
+    executorResult,
+    recordedAt: "2026-05-01T00:00:02Z",
+  });
+
+  return {
+    request,
+    persisted,
+    stateRoot,
+    workspaceRoot,
+  };
+}
+
+test("projects persisted completed lane state to EIP status and succeeded result output", async () => {
+  await withPersistedLaneRun(
+    {
+      name: "issue-42-succeeded",
+      outcome: "succeeded",
+      verificationSummary: "issue 42 projection verification passed",
+    },
+    async ({ request, persisted }) => {
+      const succeededFixture = await readJson("run-result/v1/valid/succeeded-result.json") as {
+        schemaVersion: string;
+        status: string;
+      };
+      const snapshot = projectLaneRunStatusSnapshot({
+        state: persisted.state,
+        requestId: request.id,
+        correlationId: request.correlationId,
+        observedAt: "2026-05-01T00:00:03Z",
+      });
+      const result = projectLaneRunResult({
+        state: persisted.state,
+        requestId: request.id,
+        correlationId: request.correlationId,
+        completedAt: "2026-05-01T00:00:03Z",
+        evidenceBundleRefs: persisted.evidenceBundleRefs,
+      });
+
+      assert.equal(validateRunStatusSnapshot(snapshot).ok, true);
+      assert.equal(snapshot.status, "completed");
+      assert.equal(snapshot.runId, persisted.state.id);
+      assert.equal(validateRunResult(result).ok, true);
+      assert.equal(result.schemaVersion, succeededFixture.schemaVersion);
+      assert.equal(result.status, succeededFixture.status);
+      assert.deepEqual(result.evidenceBundles, [
+        {
+          evidenceBundleId: persisted.evidenceBundleRefs[0].id,
+        },
+      ]);
+    },
+  );
+});
+
+test("projects failed and blocked terminal lane state without inventing success evidence", async () => {
+  await withPersistedLaneRun(
+    {
+      name: "issue-42-failed",
+      outcome: "failed",
+      verificationSummary: "issue 42 verification failed",
+    },
+    async ({ request, persisted }) => {
+      const result = projectLaneRunResult({
+        state: persisted.state,
+        requestId: request.id,
+        correlationId: request.correlationId,
+        completedAt: "2026-05-01T00:00:03Z",
+        evidenceBundleRefs: persisted.evidenceBundleRefs,
+      });
+
+      assert.equal(validateRunResult(result).ok, true);
+      assert.equal(result.status, "failed");
+      assert.equal(result.evidenceBundles, undefined);
+      assert.equal(result.errors?.[0]?.code, "LOCAL_LANE_FAILED");
+    },
+  );
+
+  await withPersistedLaneRun(
+    {
+      name: "issue-42-blocked",
+      outcome: "blocked",
+      blockedReasons: ["required verification evidence is missing"],
+    },
+    async ({ request, persisted }) => {
+      const result = projectLaneRunResult({
+        state: persisted.state,
+        requestId: request.id,
+        correlationId: request.correlationId,
+        completedAt: "2026-05-01T00:00:03Z",
+        evidenceBundleRefs: persisted.evidenceBundleRefs,
+      });
+
+      assert.equal(validateRunResult(result).ok, true);
+      assert.equal(result.status, "blocked");
+      assert.equal(result.evidenceBundles, undefined);
+      assert.match(result.verification?.summary ?? "", /required verification evidence/);
+      assert.equal(result.warnings?.[0]?.code, "LOCAL_LANE_BLOCKED");
+    },
+  );
+});
+
+test("projects in-progress lane state to status snapshots but not final results", async () => {
+  await withPersistedLaneRun(
+    {
+      name: "issue-42-succeeded",
+      outcome: "succeeded",
+    },
+    async ({ request, persisted }) => {
+      const runningState: LaneRunState = {
+        ...persisted.state,
+        status: "verifying",
+        evidence: {
+          bundleRefs: [],
+        },
+      };
+      const snapshot = projectLaneRunStatusSnapshot({
+        state: runningState,
+        requestId: request.id,
+        correlationId: request.correlationId,
+        observedAt: "2026-05-01T00:00:03Z",
+      });
+
+      assert.equal(validateRunStatusSnapshot(snapshot).ok, true);
+      assert.equal(snapshot.status, "running");
+      assert.deepEqual(snapshot.progress, {
+        current: 2,
+        total: 3,
+        percent: 67,
+        unit: "local-lane-stages",
+      });
+      assert.throws(
+        () =>
+          projectLaneRunResult({
+            state: runningState,
+            requestId: request.id,
+            correlationId: request.correlationId,
+            completedAt: "2026-05-01T00:00:03Z",
+          }),
+        /until it is terminal/,
+      );
+    },
+  );
+});
+
+test("fails closed for stale evidence, unsupported versions, and malformed state", async () => {
+  await withPersistedLaneRun(
+    {
+      name: "issue-42-succeeded",
+      outcome: "succeeded",
+    },
+    async ({ request, persisted }) => {
+      assert.throws(
+        () =>
+          projectLaneRunResult({
+            state: persisted.state,
+            requestId: request.id,
+            correlationId: request.correlationId,
+            completedAt: "2026-05-01T00:00:03Z",
+            evidenceBundleRefs: [],
+          }),
+        /without a matching EvidenceBundleRef/,
+      );
+      assert.throws(
+        () =>
+          projectLaneRunStatusSnapshot({
+            state: persisted.state,
+            requestId: request.id,
+            correlationId: request.correlationId,
+            observedAt: "2026-05-01T00:00:03Z",
+            protocolSchemaVersion: "eip.run-status.v2",
+          }),
+        /Unsupported EIP schema version/,
+      );
+      assert.throws(
+        () =>
+          projectLaneRunStatusSnapshot({
+            state: {
+              ...persisted.state,
+              journal: {
+                ...persisted.state.journal,
+                laneRunId: "run_01HV7Y8M8F2KQ5W3P9R6T4N2ZZ",
+              },
+            },
+            requestId: request.id,
+            correlationId: request.correlationId,
+            observedAt: "2026-05-01T00:00:03Z",
+          }),
+        /malformed/,
+      );
+    },
+  );
+});


### PR DESCRIPTION
## Summary
- add fail-closed helpers to project persisted local lane state to EIP RunStatusSnapshot and RunResult output
- preserve terminal and in-progress lane status semantics, blocked/failure reasons, request/correlation identifiers, and safe local evidence references
- cover completed, failed, blocked, in-progress, stale evidence, unsupported schema, and malformed state paths

## Verification
- npm run typecheck
- npm run build
- node --test dist/test/local-lane-eip-projection.test.js
- npm test

Closes #42

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced protocol projection module for local lane runs, enabling conversion of lane execution states into run status snapshots and final results with comprehensive validation and evidence bundle handling.

* **Tests**
  * Added extensive test suite covering local lane projection behavior across terminal and in-progress states, validation scenarios, and error cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->