### PR TITLE
LOOP-022: Add X-Gate 3 local lane smoke CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ The Phase 1 module boundaries and vocabulary are defined in [docs/architecture/c
 
 The Phase 3 bounded local lane execution contract is defined in [docs/architecture/local-lane-execution.md](docs/architecture/local-lane-execution.md).
 
+The X-Gate 3 local fake lane smoke command is documented in [docs/runbooks/x-gate3-local-lane-smoke.md](docs/runbooks/x-gate3-local-lane-smoke.md).
+
 The Ensen-loop mission and development charter alignment are summarized in [docs/mission.md](docs/mission.md).
 
 The Phase 1 local Work Item validation skeleton is documented in [docs/reference/work-item-contract.md](docs/reference/work-item-contract.md).
@@ -28,6 +30,7 @@ node dist/src/cli/index.js dry-run --sample
 node dist/src/cli/index.js run-request <run-request-json-file>
 node dist/src/cli/index.js run-request <run-request-json-file> --status-snapshot queued
 node dist/src/cli/index.js x-gate2-smoke <run-request-json-file>
+node dist/src/cli/index.js x-gate3-smoke <run-request-json-file> --workspace-root <workspace-root> --state-root <state-root>
 ```
 
 `npm test` includes the EIP conformance fixture suite. After `npm run build`, `node --test dist/test/eip-conformance-fixtures.test.js` runs only the focused suite for the vendored Ensen-protocol v0.1.0 RunRequest, RunStatusSnapshot, RunResult, and EvidenceBundleRef fixtures.
@@ -39,6 +42,8 @@ node dist/src/cli/index.js x-gate2-smoke <run-request-json-file>
 `run-request <run-request-json-file> --status-snapshot accepted|queued|running|blocked` emits a RunStatusSnapshot-compatible dry-run polling snapshot for the request. The mode maps only Ensen-loop dry-run lifecycle facts; it does not read Ensen-flow workflow state, approval state, or final RunResult fields. If validation or plan normalization blocks the dry run and valid request/correlation identifiers are available, the command emits a blocked status snapshot with actionable reasons under `extensions.x-ensen-loop-blocked-reasons`.
 
 `x-gate2-smoke <run-request-json-file>` emits the X-Gate 2 narrow loop-flow dry-run smoke payload to stdout. The JSON payload always contains deterministic `statusSnapshot` and `runResult` fields when stable request and correlation identifiers are available. Plannable smoke requests also include an `evidenceBundleRef`; blocked dry-runs omit that field. The EvidenceBundleRef uses a relative local artifact URI under `artifacts/evidence/x-gate2/<request-id>.json`; the command describes that artifact location but does not create or write the artifact. The smoke path does not create a repository, branch, worktree, GitHub issue, pull request, Codex session, durable evidence bundle, or provider call. Invalid RunRequest input and unsupported EIP major versions fail closed with blocked status/result output when stable request and correlation identifiers are available.
+
+`x-gate3-smoke <run-request-json-file> --workspace-root <workspace-root> --state-root <state-root>` runs the bounded Phase 3 local fake lane smoke path. It validates the RunRequest, prepares local lane workspace/state directories, invokes the deterministic local fake executor, persists LaneRunState plus local evidence metadata, and emits one aggregate JSON object with RunStatusSnapshot and RunResult projections. It does not create or mutate GitHub issues, branches, pull requests, reviews, commits, real agent-provider sessions, or production evidence archives. Invalid input, unsupported EIP major versions, unsafe roots, failed fake outcomes, and blocked fake outcomes fail closed with parseable JSON output.
 
 EvidenceBundleRef validation is exposed as an Ensen-loop-native protocol helper for copied Ensen-protocol v0.1.0 fixtures and dry-run metadata. It accepts relative traversal-free local paths and absolute `file:///` URIs, rejects credential-shaped URIs, query or fragment-bearing file URIs, traversal, absolute local paths, and ambiguous local path shapes, and keeps validation independent from any Ensen-flow runtime.
 

--- a/docs/runbooks/x-gate3-local-lane-smoke.md
+++ b/docs/runbooks/x-gate3-local-lane-smoke.md
@@ -1,0 +1,119 @@
+# X-Gate 3 Local Lane Smoke
+
+This runbook exercises the bounded Phase 3 fake lane path from an EIP
+RunRequest fixture through local workspace preparation, deterministic fake
+executor invocation, LaneRunState persistence, local evidence metadata, and
+RunStatusSnapshot / RunResult projection.
+
+It is a local development smoke boundary. It does not create or mutate GitHub
+issues, branches, pull requests, reviews, commits, real agent-provider sessions,
+or production evidence archives.
+
+## Invocation
+
+Build the CLI first:
+
+```sh
+npm run build
+```
+
+Run a succeeded local smoke:
+
+```sh
+node dist/src/cli/index.js x-gate3-smoke <run-request-json-file> \
+  --workspace-root <workspace-root> \
+  --state-root <state-root>
+```
+
+Run failure-routing variants:
+
+```sh
+node dist/src/cli/index.js x-gate3-smoke <run-request-json-file> \
+  --workspace-root <workspace-root> \
+  --state-root <state-root> \
+  --fixture failed
+
+node dist/src/cli/index.js x-gate3-smoke <run-request-json-file> \
+  --workspace-root <workspace-root> \
+  --state-root <state-root> \
+  --fixture blocked
+```
+
+`<workspace-root>` and `<state-root>` must already exist, must be absolute local
+paths, must be separate directories, and must not be symbolic links. Public
+examples should keep those values as placeholders or documented environment
+variables.
+
+## Output
+
+The command writes one parseable JSON aggregate to stdout. Diagnostics and local
+execution details are represented either by the aggregate status/result fields
+or by local evidence metadata under the state root.
+
+The aggregate uses:
+
+- `schemaVersion: ensen-loop.x-gate3-local-lane-smoke.v1`
+- `boundary: local-cli-bounded-fake-lane`
+- `mutatesRepository: false`
+- `invokesProvider: false`
+- `startsAgentProviderSession: false`
+- `writesProductionEvidenceArchive: false`
+- `statusSnapshot`: EIP RunStatusSnapshot v1 projection from persisted local
+  LaneRunState
+- `runResult`: EIP RunResult v1 projection from persisted local LaneRunState
+- `localArtifacts`: repo-portable paths relative to `<state-root>`
+
+Expected local state artifacts:
+
+```text
+<state-root>/lane-runs/<lane-run-id>.json
+<state-root>/lane-runs/<lane-run-id>/artifacts/evidence/local-lane/<lane-run-id>.json
+```
+
+The evidence metadata is local-development metadata. It records bounded facts
+such as lane identifiers, fake executor outcome, verification summary, blocked
+reasons, and a safe EvidenceBundleRef. It must not be treated as a production
+evidence archive or compliance bundle.
+
+## Failure Routing
+
+Invalid RunRequest input and unsupported EIP major versions fail closed. When
+stable request and correlation identifiers are available, the command emits a
+blocked RunStatusSnapshot and blocked RunResult. If those identifiers are not
+available, it emits a validation failure object.
+
+Unsafe local roots fail before lane state or evidence metadata is written. This
+includes missing roots, relative roots, shared workspace/state roots, symlinked
+roots, malformed lane identifiers, and symlink-mediated lane paths.
+
+Fake executor outcomes are explicit:
+
+- `--fixture succeeded` exits `0` and projects a succeeded RunResult.
+- `--fixture failed` exits `1` and projects a failed RunResult.
+- `--fixture blocked` exits `1` and projects blocked status/result surfaces.
+
+## Cleanup
+
+The command only writes under the supplied local roots. Remove the local smoke
+roots after inspection:
+
+```sh
+rm -rf <workspace-root> <state-root>
+```
+
+Do not point cleanup commands at a repository root, a shared supervisor root, or
+any path that is not dedicated to the local smoke run.
+
+## Flow Boundary
+
+Flow Phase 3 callers should treat this command as a process boundary:
+
+```sh
+node dist/src/cli/index.js x-gate3-smoke <run-request-json-file> \
+  --workspace-root <workspace-root> \
+  --state-root <state-root>
+```
+
+Callers should parse stdout JSON and should not import Ensen-loop TypeScript
+implementation code. Any future integration should pass protocol-shaped input
+and consume protocol-shaped status/result output across an explicit boundary.

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,11 +1,21 @@
 #!/usr/bin/env node
 
 import { readFile } from "node:fs/promises";
+import path from "node:path";
 
 import {
   createSampleDryRunExecutionPlan,
   describeProduct,
 } from "../index.js";
+import {
+  createDeterministicLocalFakeExecutor,
+  invokeLaneExecutor,
+  persistLaneExecutorResult,
+} from "../executor/index.js";
+import type { LocalFakeExecutorOutcome } from "../executor/index.js";
+import {
+  prepareLocalLaneWorkspace,
+} from "../lane/index.js";
 import {
   createBlockedRunResultFromValidationIssues,
   createBlockedRunStatusSnapshotFromValidationIssues,
@@ -14,8 +24,11 @@ import {
   createRunResult,
   createRunStatusSnapshot,
   createXGate2SmokeOutput,
+  projectLaneRunResult,
+  projectLaneRunStatusSnapshot,
   validateRunRequest,
 } from "../protocol/index.js";
+import type { RunRequestValidationIssue } from "../protocol/index.js";
 import type { CreateRunResultOptions } from "../protocol/index.js";
 import type { CreateRunStatusSnapshotOptions } from "../protocol/index.js";
 
@@ -144,6 +157,94 @@ async function main(): Promise<number> {
     return output.runResult.status === "succeeded" ? 0 : 1;
   }
 
+  if (command === "x-gate3-smoke") {
+    const options = parseXGate3SmokeArgs(args);
+    if (options === undefined) {
+      console.error(
+        "Usage: ensen-loop x-gate3-smoke <run-request-json-file> --workspace-root <workspace-root> --state-root <state-root> [--fixture succeeded|failed|blocked]",
+      );
+      return 1;
+    }
+
+    const input = await readJsonFile(options.filePath);
+    const result = validateRunRequest(input);
+
+    if (!result.ok) {
+      const output = createBlockedXGate3SmokeOutput(input, result.issues);
+
+      printJson(output ?? result);
+      return 1;
+    }
+
+    const plan = createRunRequestExecutionPlan(result.request);
+    const laneRunId = replaceProtocolIdPrefix(result.request.id, "run");
+    const observedAt = addSeconds(result.request.createdAt, 1);
+    const completedAt = addSeconds(result.request.createdAt, 2);
+    const recordedAt = addSeconds(result.request.createdAt, 3);
+
+    const prepared = await prepareLocalLaneWorkspace({
+      workspaceRoot: options.workspaceRoot,
+      stateRoot: options.stateRoot,
+      laneRunId,
+      workItemId: result.request.workItem.workItemId,
+    });
+    const preparedContext = {
+      laneRunId,
+      workspacePath: prepared.workspacePath,
+      statePath: prepared.statePath,
+    };
+    const executorResult = await invokeLaneExecutor({
+      executor: createDeterministicLocalFakeExecutor(),
+      mode: "deterministic-local-fake",
+      plan,
+      preparedContext,
+      completedAt,
+      fixture: createXGate3Fixture(options.fixture),
+    });
+    const persisted = await persistLaneExecutorResult({
+      stateRoot: options.stateRoot,
+      plan,
+      preparedContext,
+      executorResult,
+      recordedAt,
+    });
+    const statusSnapshot = projectLaneRunStatusSnapshot({
+      state: persisted.state,
+      requestId: result.request.id,
+      correlationId: result.request.correlationId,
+      observedAt,
+    });
+    const runResult = projectLaneRunResult({
+      state: persisted.state,
+      requestId: result.request.id,
+      correlationId: result.request.correlationId,
+      completedAt,
+      evidenceBundleRefs: persisted.evidenceBundleRefs,
+    });
+    const output = {
+      schemaVersion: "ensen-loop.x-gate3-local-lane-smoke.v1",
+      boundary: "local-cli-bounded-fake-lane",
+      requestId: result.request.id,
+      correlationId: result.request.correlationId,
+      mutatesRepository: false,
+      invokesProvider: false,
+      startsAgentProviderSession: false,
+      writesProductionEvidenceArchive: false,
+      statusSnapshot,
+      runResult,
+      localArtifacts: {
+        laneRunId,
+        stateFile: toPortableRelativePath(options.stateRoot, persisted.statePath),
+        evidenceMetadata: persisted.evidenceMetadataPaths.map((metadataPath) =>
+          toPortableRelativePath(options.stateRoot, metadataPath),
+        ),
+      },
+    };
+
+    printJson(output);
+    return runResult.status === "succeeded" ? 0 : 1;
+  }
+
   if (command === undefined) {
     console.log(describeProduct());
     return 0;
@@ -155,6 +256,9 @@ async function main(): Promise<number> {
     "Usage: ensen-loop run-request <run-request-json-file> [--status-snapshot accepted|queued|running|blocked|--run-result succeeded|failed|blocked]",
   );
   console.error("Usage: ensen-loop x-gate2-smoke <run-request-json-file>");
+  console.error(
+    "Usage: ensen-loop x-gate3-smoke <run-request-json-file> --workspace-root <workspace-root> --state-root <state-root> [--fixture succeeded|failed|blocked]",
+  );
   return 1;
 }
 
@@ -203,6 +307,144 @@ function parseRunResultMode(
   }
 
   return false;
+}
+
+interface XGate3SmokeOptions {
+  readonly filePath: string;
+  readonly workspaceRoot: string;
+  readonly stateRoot: string;
+  readonly fixture: LocalFakeExecutorOutcome;
+}
+
+function parseXGate3SmokeArgs(args: readonly string[]): XGate3SmokeOptions | undefined {
+  const [filePath, ...optionArgs] = args;
+
+  if (filePath === undefined) {
+    return undefined;
+  }
+
+  let workspaceRoot: string | undefined;
+  let stateRoot: string | undefined;
+  let fixture: LocalFakeExecutorOutcome = "succeeded";
+
+  for (let index = 0; index < optionArgs.length; index += 2) {
+    const flag = optionArgs[index];
+    const value = optionArgs[index + 1];
+
+    if (value === undefined) {
+      return undefined;
+    }
+
+    if (flag === "--workspace-root") {
+      workspaceRoot = value;
+      continue;
+    }
+
+    if (flag === "--state-root") {
+      stateRoot = value;
+      continue;
+    }
+
+    if (
+      flag === "--fixture" &&
+      (value === "succeeded" || value === "failed" || value === "blocked")
+    ) {
+      fixture = value;
+      continue;
+    }
+
+    return undefined;
+  }
+
+  if (workspaceRoot === undefined || stateRoot === undefined) {
+    return undefined;
+  }
+
+  return {
+    filePath,
+    workspaceRoot,
+    stateRoot,
+    fixture,
+  };
+}
+
+function createXGate3Fixture(outcome: LocalFakeExecutorOutcome) {
+  return {
+    name: `x-gate3-${outcome}`,
+    outcome,
+    verificationSummary:
+      outcome === "succeeded"
+        ? "x-gate3 local fake lane smoke completed"
+        : outcome === "failed"
+          ? "x-gate3 local fake lane smoke failed by fixture"
+          : undefined,
+    blockedReasons:
+      outcome === "blocked"
+        ? ["x-gate3 local fake lane smoke blocked by fixture"]
+        : undefined,
+  };
+}
+
+function createBlockedXGate3SmokeOutput(
+  value: unknown,
+  issues: readonly RunRequestValidationIssue[],
+): Record<string, unknown> | undefined {
+  const observedAt = addSeconds(extractCreatedAt(value), 1);
+  const completedAt = addSeconds(extractCreatedAt(value), 2);
+  const statusSnapshot = createBlockedRunStatusSnapshotFromValidationIssues(
+    value,
+    issues,
+    observedAt,
+  );
+  const runResult = createBlockedRunResultFromValidationIssues(value, issues, completedAt);
+
+  if (statusSnapshot === undefined || runResult === undefined) {
+    return undefined;
+  }
+
+  return {
+    schemaVersion: "ensen-loop.x-gate3-local-lane-smoke.v1",
+    boundary: "local-cli-bounded-fake-lane",
+    requestId: statusSnapshot.requestId,
+    correlationId: statusSnapshot.correlationId,
+    mutatesRepository: false,
+    invokesProvider: false,
+    startsAgentProviderSession: false,
+    writesProductionEvidenceArchive: false,
+    statusSnapshot,
+    runResult,
+  };
+}
+
+function extractCreatedAt(value: unknown): string {
+  if (
+    value !== null &&
+    typeof value === "object" &&
+    "createdAt" in value &&
+    typeof value.createdAt === "string"
+  ) {
+    return value.createdAt;
+  }
+
+  return "1970-01-01T00:00:00Z";
+}
+
+function addSeconds(timestamp: string, seconds: number): string {
+  const milliseconds = Date.parse(timestamp);
+
+  if (!Number.isFinite(milliseconds)) {
+    return addSeconds("1970-01-01T00:00:00Z", seconds);
+  }
+
+  return new Date(milliseconds + seconds * 1000).toISOString().replace(".000Z", "Z");
+}
+
+function replaceProtocolIdPrefix(id: string, prefix: "run"): string {
+  return `${prefix}_${id.slice(id.indexOf("_") + 1)}`;
+}
+
+function toPortableRelativePath(root: string, filePath: string): string {
+  return path.relative(path.resolve(root), filePath).split(path.sep).join("/");
 }
 
 main()

--- a/test/x-gate3-smoke-cli.test.ts
+++ b/test/x-gate3-smoke-cli.test.ts
@@ -1,0 +1,213 @@
+import assert from "node:assert/strict";
+import { access, mkdtemp, readFile, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { execFile } from "node:child_process";
+import test from "node:test";
+import { promisify } from "node:util";
+
+import {
+  validateRunResult,
+  validateRunStatusSnapshot,
+} from "../src/protocol/index.js";
+
+const execFileAsync = promisify(execFile);
+const fixtureRoot = path.join(
+  "protocol-snapshots",
+  "ensen-protocol",
+  "v0.1.0",
+  "fixtures",
+);
+
+async function withRoots(
+  callback: (roots: { readonly workspaceRoot: string; readonly stateRoot: string }) => Promise<void>,
+): Promise<void> {
+  const workspaceRoot = await mkdtemp(path.join(os.tmpdir(), "ensen-loop-xgate3-workspace-"));
+  const stateRoot = await mkdtemp(path.join(os.tmpdir(), "ensen-loop-xgate3-state-"));
+
+  try {
+    await callback({ workspaceRoot, stateRoot });
+  } finally {
+    await rm(workspaceRoot, { recursive: true, force: true });
+    await rm(stateRoot, { recursive: true, force: true });
+  }
+}
+
+function smokeArgs(
+  fixturePath: string,
+  roots: { readonly workspaceRoot: string; readonly stateRoot: string },
+  extraArgs: readonly string[] = [],
+): readonly string[] {
+  return [
+    "dist/src/cli/index.js",
+    "x-gate3-smoke",
+    fixturePath,
+    "--workspace-root",
+    roots.workspaceRoot,
+    "--state-root",
+    roots.stateRoot,
+    ...extraArgs,
+  ];
+}
+
+test("X-Gate 3 smoke CLI persists a succeeded local fake lane and emits protocol aggregate JSON", async () => {
+  await withRoots(async (roots) => {
+    const fixturePath = path.join(fixtureRoot, "run-request/v1/valid/github-issue-request.json");
+
+    const { stdout, stderr } = await execFileAsync(process.execPath, smokeArgs(fixturePath, roots));
+
+    assert.equal(stderr, "");
+
+    const output = JSON.parse(stdout) as {
+      schemaVersion: string;
+      boundary: string;
+      mutatesRepository: boolean;
+      invokesProvider: boolean;
+      startsAgentProviderSession: boolean;
+      statusSnapshot: unknown;
+      runResult: unknown;
+      localArtifacts: {
+        laneRunId: string;
+        stateFile: string;
+        evidenceMetadata: readonly string[];
+      };
+    };
+
+    assert.equal(output.schemaVersion, "ensen-loop.x-gate3-local-lane-smoke.v1");
+    assert.equal(output.boundary, "local-cli-bounded-fake-lane");
+    assert.equal(output.mutatesRepository, false);
+    assert.equal(output.invokesProvider, false);
+    assert.equal(output.startsAgentProviderSession, false);
+
+    const snapshot = validateRunStatusSnapshot(output.statusSnapshot);
+    const result = validateRunResult(output.runResult);
+
+    assert.equal(snapshot.ok, true);
+    assert.equal(snapshot.ok && snapshot.snapshot.status, "completed");
+    assert.equal(result.ok, true);
+    assert.equal(result.ok && result.result.status, "succeeded");
+
+    assert.equal(output.localArtifacts.laneRunId, "run_01HV7Y8M8F2KQ5W3P9R6T4N2AB");
+    assert.equal(output.localArtifacts.stateFile, "lane-runs/run_01HV7Y8M8F2KQ5W3P9R6T4N2AB.json");
+    assert.deepEqual(output.localArtifacts.evidenceMetadata, [
+      "lane-runs/run_01HV7Y8M8F2KQ5W3P9R6T4N2AB/artifacts/evidence/local-lane/run_01HV7Y8M8F2KQ5W3P9R6T4N2AB.json",
+    ]);
+
+    const persistedState = JSON.parse(
+      await readFile(path.join(roots.stateRoot, output.localArtifacts.stateFile), "utf8"),
+    ) as { status: string; startsAgentExecution: boolean };
+    assert.equal(persistedState.status, "completed");
+    assert.equal(persistedState.startsAgentExecution, false);
+    await access(path.join(roots.stateRoot, output.localArtifacts.evidenceMetadata[0]));
+  });
+});
+
+test("X-Gate 3 smoke CLI routes failed and blocked fake outcomes through terminal projections", async () => {
+  const fixturePath = path.join(fixtureRoot, "run-request/v1/valid/github-issue-request.json");
+
+  await withRoots(async (roots) => {
+    await assert.rejects(
+      execFileAsync(process.execPath, smokeArgs(fixturePath, roots, ["--fixture", "failed"])),
+      (error: unknown) => {
+        assert.ok(error && typeof error === "object" && "stdout" in error);
+        const output = JSON.parse(String(error.stdout)) as { runResult: unknown };
+        const result = validateRunResult(output.runResult);
+        assert.equal(result.ok, true);
+        assert.equal(result.ok && result.result.status, "failed");
+        return true;
+      },
+    );
+  });
+
+  await withRoots(async (roots) => {
+    await assert.rejects(
+      execFileAsync(process.execPath, smokeArgs(fixturePath, roots, ["--fixture", "blocked"])),
+      (error: unknown) => {
+        assert.ok(error && typeof error === "object" && "stdout" in error);
+        const output = JSON.parse(String(error.stdout)) as { statusSnapshot: unknown; runResult: unknown };
+        const snapshot = validateRunStatusSnapshot(output.statusSnapshot);
+        const result = validateRunResult(output.runResult);
+        assert.equal(snapshot.ok, true);
+        assert.equal(snapshot.ok && snapshot.snapshot.status, "blocked");
+        assert.equal(result.ok, true);
+        assert.equal(result.ok && result.result.status, "blocked");
+        return true;
+      },
+    );
+  });
+});
+
+test("X-Gate 3 smoke CLI fails closed for invalid input and unsupported EIP major versions", async () => {
+  await withRoots(async (roots) => {
+    const invalidFixturePath = path.join(fixtureRoot, "run-request/v1/invalid/source-string.json");
+
+    await assert.rejects(
+      execFileAsync(process.execPath, smokeArgs(invalidFixturePath, roots)),
+      (error: unknown) => {
+        assert.ok(error && typeof error === "object" && "stdout" in error);
+        const output = JSON.parse(String(error.stdout)) as { statusSnapshot: unknown; runResult: unknown };
+        const snapshot = validateRunStatusSnapshot(output.statusSnapshot);
+        const result = validateRunResult(output.runResult);
+        assert.equal(snapshot.ok, true);
+        assert.equal(snapshot.ok && snapshot.snapshot.status, "blocked");
+        assert.match(snapshot.ok ? (snapshot.snapshot.message ?? "") : "", /source/);
+        assert.equal(result.ok, true);
+        assert.equal(result.ok && result.result.status, "blocked");
+        return true;
+      },
+    );
+  });
+
+  await withRoots(async (roots) => {
+    const unsupportedFixturePath = path.join(
+      fixtureRoot,
+      "run-request/v1/invalid/bad-schema-version.json",
+    );
+
+    await assert.rejects(
+      execFileAsync(process.execPath, smokeArgs(unsupportedFixturePath, roots)),
+      (error: unknown) => {
+        assert.ok(error && typeof error === "object" && "stdout" in error);
+        const output = JSON.parse(String(error.stdout)) as { statusSnapshot: unknown; runResult: unknown };
+        const snapshot = validateRunStatusSnapshot(output.statusSnapshot);
+        const result = validateRunResult(output.runResult);
+        assert.equal(snapshot.ok, true);
+        assert.equal(snapshot.ok && snapshot.snapshot.status, "blocked");
+        assert.match(snapshot.ok ? (snapshot.snapshot.message ?? "") : "", /schemaVersion/);
+        assert.equal(result.ok, true);
+        assert.equal(result.ok && result.result.status, "blocked");
+        return true;
+      },
+    );
+  });
+});
+
+test("X-Gate 3 smoke CLI rejects unsafe local roots before durable lane state writes", async () => {
+  await withRoots(async (roots) => {
+    const fixturePath = path.join(fixtureRoot, "run-request/v1/valid/github-issue-request.json");
+
+    await assert.rejects(
+      execFileAsync(process.execPath, [
+        "dist/src/cli/index.js",
+        "x-gate3-smoke",
+        fixturePath,
+        "--workspace-root",
+        "relative-workspace-root",
+        "--state-root",
+        roots.stateRoot,
+      ]),
+      (error: unknown) => {
+        assert.ok(error && typeof error === "object" && "stdout" in error);
+        const output = JSON.parse(String(error.stdout)) as { ok: boolean; issues: readonly { message: string }[] };
+        assert.equal(output.ok, false);
+        assert.match(output.issues.map((issue) => issue.message).join("\n"), /absolute path/);
+        return true;
+      },
+    );
+
+    await assert.rejects(
+      () => access(path.join(roots.stateRoot, "lane-runs")),
+      /ENOENT/,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add x-gate3-smoke CLI for bounded local fake lane execution from a RunRequest fixture
- persist local lane state/evidence metadata and emit protocol-shaped status/result aggregate JSON
- document invocation, artifacts, cleanup, failure routing, and non-production boundaries

## Verification
- npm run typecheck
- npm run build
- npm test
- node dist/src/cli/index.js x-gate3-smoke <run-request-json-file> --workspace-root <workspace-root> --state-root <state-root>

Closes #43

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced `x-gate3-smoke` CLI command for local lane smoke testing with run request validation
  * Generates JSON output containing run status snapshots and execution results
  * Includes fail-closed error handling with parseable JSON responses

* **Documentation**
  * Added runbook for `x-gate3-smoke` command usage, preconditions, and output specifications

* **Tests**
  * Comprehensive test coverage for successful execution, failure scenarios, and input validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->