### PR TITLE
Fix lane persistence retry rollback

### DIFF
--- a/src/executor/index.ts
+++ b/src/executor/index.ts
@@ -228,6 +228,7 @@ export async function persistLaneExecutorResult(
 
   const writtenEvidencePaths: string[] = [];
   const statePath = resolveLaneRunStatePath(input.stateRoot, state.id);
+  const statePathExistedBeforeAttempt = await laneRunStatePathExists(statePath);
 
   try {
     for (const [index, evidenceBundleRef] of evidenceBundleRefs.entries()) {
@@ -257,9 +258,24 @@ export async function persistLaneExecutorResult(
     };
   } catch (error) {
     await Promise.all(writtenEvidencePaths.map((metadataPath) => rm(metadataPath, { force: true })));
-    await rm(statePath, { force: true });
+    if (!statePathExistedBeforeAttempt) {
+      await rm(statePath, { force: true });
+    }
     throw error;
   }
+}
+
+async function laneRunStatePathExists(statePath: string): Promise<boolean> {
+  return lstat(statePath).then(
+    () => true,
+    (error: unknown) => {
+      if (isNodeError(error) && error.code === "ENOENT") {
+        return false;
+      }
+
+      throw error;
+    },
+  );
 }
 
 function assertExecutorResultMatchesPersistenceInput(input: PersistLaneExecutorResultInput): void {

--- a/test/lane-run-persistence.test.ts
+++ b/test/lane-run-persistence.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { access, mkdir, mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises";
+import { access, lstat, mkdir, mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -55,6 +55,11 @@ async function withPersistedFixture(
   fixture: Parameters<typeof invokeLaneExecutor>[0]["fixture"],
   callback: (context: {
     readonly stateRoot: string;
+    readonly preparedContext: {
+      readonly laneRunId: string;
+      readonly workspacePath: string;
+      readonly statePath: string;
+    };
     readonly persisted: Awaited<ReturnType<typeof persistLaneExecutorResult>>;
   }) => Promise<void>,
 ): Promise<void> {
@@ -92,7 +97,7 @@ async function withPersistedFixture(
       recordedAt: "2026-05-01T00:00:02Z",
     });
 
-    await callback({ stateRoot, persisted });
+    await callback({ stateRoot, preparedContext: executorContext, persisted });
   } finally {
     await rm(workspaceRoot, { recursive: true, force: true });
     await rm(stateRoot, { recursive: true, force: true });
@@ -135,6 +140,49 @@ test("persists a succeeded Phase 3 lane journal and local evidence metadata for 
         metadata,
       });
       assert.equal(serialized.includes(os.tmpdir()), false);
+    },
+  );
+});
+
+test("preserves existing lane state when a retry fails on existing evidence metadata", async () => {
+  await withPersistedFixture(
+    {
+      name: "issue-50-retry-existing-metadata",
+      outcome: "succeeded",
+      verificationSummary: "sanitized issue 50 initial success",
+    },
+    async ({ stateRoot, preparedContext, persisted }) => {
+      const originalStateFile = await readFile(persisted.statePath, "utf8");
+      const originalMetadataFile = await readFile(persisted.evidenceMetadataPaths[0], "utf8");
+      const plan = createRunRequestExecutionPlan(request);
+      const executorResult = await invokeLaneExecutor({
+        executor: createDeterministicLocalFakeExecutor(),
+        mode: "deterministic-local-fake",
+        plan,
+        preparedContext,
+        completedAt: "2026-05-01T00:00:07Z",
+        fixture: {
+          name: "issue-50-retry-existing-metadata",
+          outcome: "succeeded",
+          verificationSummary: "sanitized issue 50 retry",
+        },
+      });
+
+      await assert.rejects(
+        () =>
+          persistLaneExecutorResult({
+            stateRoot,
+            plan,
+            preparedContext,
+            executorResult,
+            recordedAt: "2026-05-01T00:00:08Z",
+          }),
+        /EEXIST/,
+      );
+
+      assert.equal(await readFile(persisted.statePath, "utf8"), originalStateFile);
+      assert.equal(await readFile(persisted.evidenceMetadataPaths[0], "utf8"), originalMetadataFile);
+      assert.deepEqual(await readLaneRunState(stateRoot, persisted.state.id), persisted.state);
     },
   );
 });
@@ -347,7 +395,7 @@ test("cleans evidence metadata and lane-state path when persistence fails", asyn
       /Lane run state paths must not traverse symbolic links/,
     );
 
-    await assert.rejects(() => access(statePath), /ENOENT/);
+    assert.equal((await lstat(statePath)).isSymbolicLink(), true);
     await assert.rejects(() => access(evidenceMetadataPath), /ENOENT/);
     assert.equal(await readFile(outsideStatePath, "utf8"), "outside state must not be touched\n");
   } finally {


### PR DESCRIPTION
## Summary
- preserve existing lane state when a retry fails before writing state
- keep cleanup scoped to evidence metadata written by the current failed attempt
- add regression coverage for retry failure on existing evidence metadata

## Verification
- npm run typecheck
- npm run build
- npm test

Closes #50

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved lane execution state persistence to safely preserve pre-existing state during failed retry attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->