### PR TITLE
Sanitize X-Gate 3 CLI filesystem diagnostics

### DIFF
--- a/src/cli/diagnostics.ts
+++ b/src/cli/diagnostics.ts
@@ -1,0 +1,15 @@
+const localPathPlaceholder = "<local-path>";
+
+const quotedAbsolutePathPattern =
+  /(["'])(\/[^"'\r\n]+|[A-Za-z]:[\\/][^"'\r\n]+|\\\\[^"'\r\n]+)\1/g;
+const windowsDrivePathPattern = /\b[A-Za-z]:[\\/][^\s"'\r\n]+/g;
+const windowsUncPathPattern = /\\\\[^\s"'\r\n]+/g;
+const posixAbsolutePathPattern = /(^|[\s(:])\/[^\s"'\r\n)]+/g;
+
+export function sanitizeCliErrorMessage(message: string): string {
+  return message
+    .replace(quotedAbsolutePathPattern, (_match, quote: string) => `${quote}${localPathPlaceholder}${quote}`)
+    .replace(windowsDrivePathPattern, localPathPlaceholder)
+    .replace(windowsUncPathPattern, localPathPlaceholder)
+    .replace(posixAbsolutePathPattern, (match: string, prefix: string) => `${prefix}${localPathPlaceholder}`);
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -31,6 +31,7 @@ import {
 import type { RunRequestValidationIssue } from "../protocol/index.js";
 import type { CreateRunResultOptions } from "../protocol/index.js";
 import type { CreateRunStatusSnapshotOptions } from "../protocol/index.js";
+import { sanitizeCliErrorMessage } from "./diagnostics.js";
 
 const [, , command, ...args] = process.argv;
 
@@ -452,7 +453,8 @@ main()
     process.exitCode = exitCode;
   })
   .catch((error: unknown) => {
-    const message = error instanceof Error ? error.message : String(error);
+    const rawMessage = error instanceof Error ? error.message : String(error);
+    const message = sanitizeCliErrorMessage(rawMessage);
     printJson({
       ok: false,
       issues: [

--- a/test/cli-diagnostics.test.ts
+++ b/test/cli-diagnostics.test.ts
@@ -1,0 +1,35 @@
+import assert from "node:assert/strict";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { sanitizeCliErrorMessage } from "../src/cli/diagnostics.js";
+
+test("CLI filesystem diagnostics redact local absolute path shapes", () => {
+  const homePath = path.join(os.homedir(), "ensen-loop", "marker.json");
+  const posixTempPath = path.join(os.tmpdir(), "ensen-loop-xgate3-state", "marker.json");
+  const windowsHomePath = ["C:", "Users", "operator", "AppData", "Local", "Temp", "marker.json"].join("\\");
+  const windowsSlashPath = ["D:", "Users", "operator", "workspace", "marker.json"].join("/");
+
+  const message = [
+    `ENOENT: no such file or directory, open '${homePath}'`,
+    `EISDIR: illegal operation on a directory, open "${posixTempPath}"`,
+    `EPERM: operation not permitted, open '${windowsHomePath}'`,
+    `EACCES: permission denied, open ${windowsSlashPath}`,
+  ].join("\n");
+
+  const sanitized = sanitizeCliErrorMessage(message);
+
+  assert.doesNotMatch(sanitized, new RegExp(escapeRegExp(homePath)));
+  assert.doesNotMatch(sanitized, new RegExp(escapeRegExp(posixTempPath)));
+  assert.doesNotMatch(sanitized, new RegExp(escapeRegExp(windowsHomePath)));
+  assert.doesNotMatch(sanitized, new RegExp(escapeRegExp(windowsSlashPath)));
+  assert.match(sanitized, /ENOENT: no such file or directory, open '<local-path>'/);
+  assert.match(sanitized, /EISDIR: illegal operation on a directory, open "<local-path>"/);
+  assert.match(sanitized, /EPERM: operation not permitted, open '<local-path>'/);
+  assert.match(sanitized, /EACCES: permission denied, open <local-path>/);
+});
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}

--- a/test/cli-diagnostics.test.ts
+++ b/test/cli-diagnostics.test.ts
@@ -10,12 +10,14 @@ test("CLI filesystem diagnostics redact local absolute path shapes", () => {
   const posixTempPath = path.join(os.tmpdir(), "ensen-loop-xgate3-state", "marker.json");
   const windowsHomePath = ["C:", "Users", "operator", "AppData", "Local", "Temp", "marker.json"].join("\\");
   const windowsSlashPath = ["D:", "Users", "operator", "workspace", "marker.json"].join("/");
+  const windowsUncPath = ["", "", "server", "share", "folder", "marker.json"].join("\\");
 
   const message = [
     `ENOENT: no such file or directory, open '${homePath}'`,
     `EISDIR: illegal operation on a directory, open "${posixTempPath}"`,
     `EPERM: operation not permitted, open '${windowsHomePath}'`,
     `EACCES: permission denied, open ${windowsSlashPath}`,
+    `EBUSY: resource busy or locked, open '${windowsUncPath}'`,
   ].join("\n");
 
   const sanitized = sanitizeCliErrorMessage(message);
@@ -24,10 +26,12 @@ test("CLI filesystem diagnostics redact local absolute path shapes", () => {
   assert.doesNotMatch(sanitized, new RegExp(escapeRegExp(posixTempPath)));
   assert.doesNotMatch(sanitized, new RegExp(escapeRegExp(windowsHomePath)));
   assert.doesNotMatch(sanitized, new RegExp(escapeRegExp(windowsSlashPath)));
+  assert.doesNotMatch(sanitized, new RegExp(escapeRegExp(windowsUncPath)));
   assert.match(sanitized, /ENOENT: no such file or directory, open '<local-path>'/);
   assert.match(sanitized, /EISDIR: illegal operation on a directory, open "<local-path>"/);
   assert.match(sanitized, /EPERM: operation not permitted, open '<local-path>'/);
   assert.match(sanitized, /EACCES: permission denied, open <local-path>/);
+  assert.match(sanitized, /EBUSY: resource busy or locked, open '<local-path>'/);
 });
 
 function escapeRegExp(value: string): string {

--- a/test/x-gate3-smoke-cli.test.ts
+++ b/test/x-gate3-smoke-cli.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { access, mkdtemp, readFile, rm } from "node:fs/promises";
+import { access, mkdir, mkdtemp, readFile, rm } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { execFile } from "node:child_process";
@@ -211,3 +211,43 @@ test("X-Gate 3 smoke CLI rejects unsafe local roots before durable lane state wr
     );
   });
 });
+
+test("X-Gate 3 smoke CLI redacts filesystem paths from preparation failures", async () => {
+  await withRoots(async (roots) => {
+    const fixturePath = path.join(fixtureRoot, "run-request/v1/valid/github-issue-request.json");
+    const laneRunId = "run_01HV7Y8M8F2KQ5W3P9R6T4N2AB";
+    const markerPath = path.join(
+      roots.workspaceRoot,
+      "lane-runs",
+      laneRunId,
+      ".ensen-loop-prepared.json",
+    );
+
+    await mkdir(markerPath, { recursive: true });
+    await mkdir(path.join(roots.stateRoot, "lane-runs", laneRunId), { recursive: true });
+
+    await assert.rejects(
+      execFileAsync(process.execPath, smokeArgs(fixturePath, roots)),
+      (error: unknown) => {
+        assert.ok(error && typeof error === "object" && "stdout" in error);
+        const output = JSON.parse(String(error.stdout)) as {
+          ok: boolean;
+          issues: readonly { message: string }[];
+        };
+        const messages = output.issues.map((issue) => issue.message).join("\n");
+
+        assert.equal(output.ok, false);
+        assert.match(messages, /EISDIR|illegal operation|directory/);
+        assert.match(messages, /<local-path>/);
+        assert.doesNotMatch(messages, new RegExp(escapeRegExp(roots.workspaceRoot)));
+        assert.doesNotMatch(messages, new RegExp(escapeRegExp(roots.stateRoot)));
+        assert.doesNotMatch(messages, new RegExp(escapeRegExp(markerPath)));
+        return true;
+      },
+    );
+  });
+});
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}


### PR DESCRIPTION
## Summary
- redact local absolute filesystem paths in the top-level CLI JSON error boundary
- preserve filesystem failure class text while replacing local paths with <local-path>
- add focused sanitizer coverage and an X-Gate 3 marker-write regression test

## Verification
- npm run typecheck
- npm run build
- node --test dist/test/cli-diagnostics.test.js
- node --test dist/test/x-gate3-smoke-cli.test.js
- npm test

Closes #51

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * CLI error output now sanitizes and redacts real filesystem paths, replacing them with a `<local-path>` placeholder before emitting error JSON.

* **Tests**
  * Added comprehensive tests covering POSIX and Windows path formats.
  * Added a CLI smoke test that verifies error messages redact workspace and marker paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->