### PR TITLE
LOOP-030 define provider capability boundaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ The Phase 1 module boundaries and vocabulary are defined in [docs/architecture/c
 
 The Phase 3 bounded local lane execution contract is defined in [docs/architecture/local-lane-execution.md](docs/architecture/local-lane-execution.md).
 
+The Phase 4 dogfood provider capability boundary is defined in [docs/architecture/provider-capabilities.md](docs/architecture/provider-capabilities.md).
+
 The X-Gate 3 local fake lane smoke command is documented in [docs/runbooks/x-gate3-local-lane-smoke.md](docs/runbooks/x-gate3-local-lane-smoke.md).
 
 The Ensen-loop mission and development charter alignment are summarized in [docs/mission.md](docs/mission.md).

--- a/docs/architecture/core-model.md
+++ b/docs/architecture/core-model.md
@@ -24,8 +24,8 @@ These modules may share the small contracts from `src/core/`, but the core model
 | --- | --- |
 | Work Item | A unit of lane work selected for execution. It has a stable identifier, title, source, and lifecycle status, but it is not tied to a specific issue tracker. |
 | Change Request | A proposed source change produced for a Work Item. It can later map to a pull request, patch, or another SCM-native review object through an adapter. |
-| Agent Provider | A boundary for an implementation that can perform lane work. The core model only requires an identifier and display name. |
-| SCM Provider | A boundary for source-control operations. The core model does not require any specific host, token, repository service, or remote API. |
+| Agent Provider | A boundary for an implementation that can perform lane work. The core model records provider-neutral capability names, not provider command syntax. |
+| SCM Provider | A boundary for source-control operations. The core model records provider-neutral capability names and does not require any specific host, token, repository service, or remote API. |
 | Verification Result | The outcome of a repo-owned verification command or check, including the command, outcome, and summary. |
 | Review Event | A review signal attached to a Change Request, such as a comment, approval, requested change, or dismissal. |
 | Lane Journal | The short-horizon record for current lane work: hypothesis, commands, failures, changes, and next action. |
@@ -51,6 +51,8 @@ Local storage helpers must resolve lane run state paths below a real configured 
 ## Provider Posture
 
 GitHub and Codex are future adapter examples, not core model requirements. A future GitHub adapter may bind Work Items to issues and Change Requests to pull requests. A future Codex adapter may satisfy the Agent Provider boundary. Neither adapter is required for this repository to build, test, or explain its Phase 1 model.
+
+The Phase 4 dogfood provider capability boundary is documented in [provider-capabilities.md](provider-capabilities.md). It keeps SCMProvider and AgentProvider capability names provider-neutral so GitHub/Codex can be initial adapters without becoming core concepts.
 
 ## Independence Rules
 

--- a/docs/architecture/provider-capabilities.md
+++ b/docs/architecture/provider-capabilities.md
@@ -1,0 +1,66 @@
+# Phase 4 Provider Capability Boundaries
+
+This document defines the provider-neutral boundary for the first Ensen-loop
+dogfood slice. The boundary is intentionally capability-shaped: core lane logic
+describes intent and required capability, while concrete adapters decide how a
+provider satisfies that capability.
+
+## SCMProvider Capabilities
+
+| Capability | Core lane meaning | Adapter responsibility |
+| --- | --- | --- |
+| `work-item-pickup` | Select or normalize a Work Item for lane execution from explicit scope. | Translate a provider issue, ticket, or manual record into Ensen-loop Work Item vocabulary. |
+| `lane-branch-intent` | Describe the branch name or branch policy needed for a Lane Run. | Create, find, or update the provider-native branch only when an adapter is explicitly invoked. |
+| `lane-worktree-intent` | Describe the workspace checkout intent needed for bounded execution. | Prepare provider-specific clone, worktree, checkout, or repository state outside core lane logic. |
+| `change-request-intent` | Describe the review artifact that should represent a Change Request. | Open or update a pull request, merge request, patch review, or equivalent provider-native object. |
+| `status-reporting` | Describe lane status that may be reported externally. | Publish provider-native issue comments, checks, labels, commit statuses, or summaries. |
+
+Core lane logic may store these capability names and intent records. It must not
+call a provider API, `gh`, Git commands that mutate a remote, or another
+provider-specific CLI directly.
+
+## AgentProvider Capabilities
+
+| Capability | Core lane meaning | Adapter responsibility |
+| --- | --- | --- |
+| `dry-run-intent` | Describe what an agent session would do without starting one. | Return deterministic planning metadata or adapter-specific preview output. |
+| `execute-intent` | Describe an approved execution request for a bounded Lane Run. | Start, monitor, and summarize a real provider session only at the adapter boundary. |
+
+Core lane logic may decide that a Lane Run needs dry-run or execute capability.
+It must not start provider sessions, shell out to provider commands, or encode
+provider-specific command arguments as core model vocabulary.
+
+## Dogfood Adapter Positions
+
+The first dogfood slice can use a GitHub adapter for SCMProvider behavior and a
+Codex adapter for AgentProvider behavior. Those names identify initial adapter
+positions, not core concepts. The core model remains the same if later adapters
+bind the same capability names to GitLab, OpenCode, Claude Code, or a local
+manual provider.
+
+Future providers stay visible by reserving capability names rather than
+implementation hooks. Adding a provider should add an adapter that declares
+which existing capabilities it satisfies, or a new provider-neutral capability
+with tests and docs explaining why the existing vocabulary is insufficient.
+
+## Core Lane Versus Adapter Logic
+
+Provider-neutral core lane logic:
+
+- validates Work Item, Lane Run, and Change Request intent;
+- records provider capability requirements;
+- keeps dry-run and execute intent separate;
+- records status that can be projected to external systems;
+- fails closed when scope, provenance, auth, or durable state is missing.
+
+GitHub/Codex adapter logic:
+
+- authenticates to the provider;
+- maps provider-native issue, branch, worktree, pull request, status, and session
+  objects to Ensen-loop vocabulary;
+- invokes provider APIs or CLIs;
+- handles provider-specific retry, rate limit, and permission failures.
+
+This repository remains independently buildable and testable. It does not import
+or require an Ensen-flow runtime, checkout, service, package, or fixture to
+define these boundaries.

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -1,1 +1,5 @@
-export type { AgentProvider } from "../core/index.js";
+export {
+  AGENT_PROVIDER_CAPABILITIES,
+  type AgentProvider,
+  type AgentProviderCapability,
+} from "../core/index.js";

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -27,6 +27,23 @@ export const MODULE_BOUNDARIES = [
 
 export type ModuleBoundary = (typeof MODULE_BOUNDARIES)[number];
 
+export const SCM_PROVIDER_CAPABILITIES = [
+  "work-item-pickup",
+  "lane-branch-intent",
+  "lane-worktree-intent",
+  "change-request-intent",
+  "status-reporting",
+] as const;
+
+export type ScmProviderCapability = (typeof SCM_PROVIDER_CAPABILITIES)[number];
+
+export const AGENT_PROVIDER_CAPABILITIES = [
+  "dry-run-intent",
+  "execute-intent",
+] as const;
+
+export type AgentProviderCapability = (typeof AGENT_PROVIDER_CAPABILITIES)[number];
+
 export interface WorkItem {
   readonly id: string;
   readonly title: string;
@@ -43,11 +60,13 @@ export interface ChangeRequest {
 export interface AgentProvider {
   readonly id: string;
   readonly displayName: string;
+  readonly capabilities: readonly AgentProviderCapability[];
 }
 
 export interface ScmProvider {
   readonly id: string;
   readonly displayName: string;
+  readonly capabilities: readonly ScmProviderCapability[];
 }
 
 export interface VerificationResult {

--- a/src/lane/index.ts
+++ b/src/lane/index.ts
@@ -5,7 +5,11 @@ import type { FileHandle } from "node:fs/promises";
 import path from "node:path";
 
 import type { LaneAuditRefs } from "../audit/index.js";
-import type { WorkItem } from "../core/index.js";
+import {
+  AGENT_PROVIDER_CAPABILITIES,
+  SCM_PROVIDER_CAPABILITIES,
+  type WorkItem,
+} from "../core/index.js";
 import type { LaneEvidenceRefs } from "../evidence/index.js";
 import type { EvidenceBundleRef } from "../protocol/index.js";
 import { sampleLocalWorkItem } from "../work-item/index.js";
@@ -713,10 +717,12 @@ export interface DryRunExecutionPlan {
   };
   readonly agentProvider: {
     readonly intent: string;
+    readonly capabilities: typeof AGENT_PROVIDER_CAPABILITIES;
     readonly invokesProvider: false;
   };
   readonly scmProvider: {
     readonly intent: string;
+    readonly capabilities: typeof SCM_PROVIDER_CAPABILITIES;
     readonly createsBranch: false;
     readonly opensChangeRequest: false;
   };
@@ -742,10 +748,12 @@ export function createSampleDryRunExecutionPlan(): DryRunExecutionPlan {
     },
     agentProvider: {
       intent: "describe agent selection without invoking an agent provider",
+      capabilities: AGENT_PROVIDER_CAPABILITIES,
       invokesProvider: false,
     },
     scmProvider: {
       intent: "describe SCM actions without creating branches, commits, or change requests",
+      capabilities: SCM_PROVIDER_CAPABILITIES,
       createsBranch: false,
       opensChangeRequest: false,
     },

--- a/src/protocol/run-request.ts
+++ b/src/protocol/run-request.ts
@@ -1,3 +1,8 @@
+import {
+  AGENT_PROVIDER_CAPABILITIES,
+  SCM_PROVIDER_CAPABILITIES,
+} from "../core/index.js";
+
 export interface RunRequestSource {
   readonly sourceId: string;
   readonly sourceType: string;
@@ -96,10 +101,12 @@ export interface RunRequestExecutionPlan {
   };
   readonly agentProvider: {
     readonly intent: string;
+    readonly capabilities: typeof AGENT_PROVIDER_CAPABILITIES;
     readonly invokesProvider: false;
   };
   readonly scmProvider: {
     readonly intent: string;
+    readonly capabilities: typeof SCM_PROVIDER_CAPABILITIES;
     readonly createsBranch: false;
     readonly opensChangeRequest: false;
   };
@@ -263,10 +270,12 @@ export function createRunRequestExecutionPlan(request: RunRequest): RunRequestEx
     laneWorkspace: createLaneWorkspacePlan(request),
     agentProvider: {
       intent: "normalize agent intent without invoking a provider",
+      capabilities: AGENT_PROVIDER_CAPABILITIES,
       invokesProvider: false,
     },
     scmProvider: {
       intent: "normalize repository intent without creating branches, commits, or change requests",
+      capabilities: SCM_PROVIDER_CAPABILITIES,
       createsBranch: false,
       opensChangeRequest: false,
     },

--- a/src/scm/index.ts
+++ b/src/scm/index.ts
@@ -1,1 +1,6 @@
-export type { ChangeRequest, ScmProvider } from "../core/index.js";
+export {
+  SCM_PROVIDER_CAPABILITIES,
+  type ChangeRequest,
+  type ScmProvider,
+  type ScmProviderCapability,
+} from "../core/index.js";

--- a/test/dry-run-cli.test.ts
+++ b/test/dry-run-cli.test.ts
@@ -3,6 +3,11 @@ import { execFile } from "node:child_process";
 import test from "node:test";
 import { promisify } from "node:util";
 
+import {
+  AGENT_PROVIDER_CAPABILITIES,
+  SCM_PROVIDER_CAPABILITIES,
+} from "../src/core/index.js";
+
 const execFileAsync = promisify(execFile);
 
 test("dry-run sample emits a normalized execution plan", async () => {
@@ -29,10 +34,12 @@ test("dry-run sample emits a normalized execution plan", async () => {
     };
     agentProvider: {
       intent: string;
+      capabilities: readonly string[];
       invokesProvider: boolean;
     };
     scmProvider: {
       intent: string;
+      capabilities: readonly string[];
       createsBranch: boolean;
       opensChangeRequest: boolean;
     };
@@ -61,10 +68,12 @@ test("dry-run sample emits a normalized execution plan", async () => {
   });
   assert.deepEqual(plan.agentProvider, {
     intent: "describe agent selection without invoking an agent provider",
+    capabilities: AGENT_PROVIDER_CAPABILITIES,
     invokesProvider: false,
   });
   assert.deepEqual(plan.scmProvider, {
     intent: "describe SCM actions without creating branches, commits, or change requests",
+    capabilities: SCM_PROVIDER_CAPABILITIES,
     createsBranch: false,
     opensChangeRequest: false,
   });

--- a/test/eip-conformance-fixtures.test.ts
+++ b/test/eip-conformance-fixtures.test.ts
@@ -4,6 +4,8 @@ import path from "node:path";
 import test from "node:test";
 
 import {
+  AGENT_PROVIDER_CAPABILITIES,
+  SCM_PROVIDER_CAPABILITIES,
   createRunRequestExecutionPlan,
   createRunResult,
   createRunStatusSnapshot,
@@ -175,10 +177,12 @@ test(`${protocolLabel} dry-run consumer and producer outputs stay fixture-compat
     },
     agentProvider: {
       intent: "normalize agent intent without invoking a provider",
+      capabilities: AGENT_PROVIDER_CAPABILITIES,
       invokesProvider: false,
     },
     scmProvider: {
       intent: "normalize repository intent without creating branches, commits, or change requests",
+      capabilities: SCM_PROVIDER_CAPABILITIES,
       createsBranch: false,
       opensChangeRequest: false,
     },

--- a/test/provider-capability-boundary.test.ts
+++ b/test/provider-capability-boundary.test.ts
@@ -1,0 +1,57 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+import {
+  AGENT_PROVIDER_CAPABILITIES,
+  SCM_PROVIDER_CAPABILITIES,
+  type AgentProvider,
+  type ScmProvider,
+} from "../src/core/index.js";
+
+test("defines provider-neutral SCM and agent capability vocabulary", () => {
+  assert.deepEqual(SCM_PROVIDER_CAPABILITIES, [
+    "work-item-pickup",
+    "lane-branch-intent",
+    "lane-worktree-intent",
+    "change-request-intent",
+    "status-reporting",
+  ]);
+  assert.deepEqual(AGENT_PROVIDER_CAPABILITIES, [
+    "dry-run-intent",
+    "execute-intent",
+  ]);
+
+  const scmProvider: ScmProvider = {
+    id: "initial-scm-adapter",
+    displayName: "Initial SCM adapter",
+    capabilities: SCM_PROVIDER_CAPABILITIES,
+  };
+  const agentProvider: AgentProvider = {
+    id: "initial-agent-adapter",
+    displayName: "Initial agent adapter",
+    capabilities: AGENT_PROVIDER_CAPABILITIES,
+  };
+
+  assert.equal(scmProvider.capabilities.includes("status-reporting"), true);
+  assert.equal(agentProvider.capabilities.includes("execute-intent"), true);
+  assert.doesNotMatch(JSON.stringify({ scmProvider, agentProvider }), /\b(GitHub|Codex|gh)\b/i);
+});
+
+test("documents Phase 4 provider boundaries without making initial adapters core concepts", async () => {
+  const providerDocs = await readFile("docs/architecture/provider-capabilities.md", "utf8");
+
+  for (const capability of SCM_PROVIDER_CAPABILITIES) {
+    assert.match(providerDocs, new RegExp(`\\b${capability}\\b`));
+  }
+  for (const capability of AGENT_PROVIDER_CAPABILITIES) {
+    assert.match(providerDocs, new RegExp(`\\b${capability}\\b`));
+  }
+
+  assert.match(providerDocs, /GitHub adapter/i);
+  assert.match(providerDocs, /Codex adapter/i);
+  assert.match(providerDocs, /GitLab/i);
+  assert.match(providerDocs, /OpenCode/i);
+  assert.match(providerDocs, /Claude Code/i);
+  assert.doesNotMatch(providerDocs, /Ensen-flow checkout|Ensen-flow service|Ensen-flow package/i);
+});

--- a/test/run-request-execution-plan.test.ts
+++ b/test/run-request-execution-plan.test.ts
@@ -4,6 +4,10 @@ import path from "node:path";
 import test from "node:test";
 
 import {
+  AGENT_PROVIDER_CAPABILITIES,
+  SCM_PROVIDER_CAPABILITIES,
+} from "../src/core/index.js";
+import {
   createRunRequestExecutionPlan,
   parseRunRequest,
 } from "../src/protocol/index.js";
@@ -107,10 +111,12 @@ test("maps an issue-like RunRequest into a bounded execution plan", async () => 
     },
     agentProvider: {
       intent: "normalize agent intent without invoking a provider",
+      capabilities: AGENT_PROVIDER_CAPABILITIES,
       invokesProvider: false,
     },
     scmProvider: {
       intent: "normalize repository intent without creating branches, commits, or change requests",
+      capabilities: SCM_PROVIDER_CAPABILITIES,
       createsBranch: false,
       opensChangeRequest: false,
     },


### PR DESCRIPTION
## Summary
- define provider-neutral SCMProvider and AgentProvider capability constants and typed provider surfaces
- expose those capability requirements in dry-run and RunRequest execution plans
- document Phase 4 dogfood adapter boundaries while keeping GitHub/Codex out of core concepts

## Verification
- npm ci
- npm run typecheck
- npm run build && node --test dist/test/provider-capability-boundary.test.js
- npm test

Part of #54
Closes #55

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added architecture documentation defining provider capability boundaries and clarifying separation between core logic and adapter responsibilities.

* **New Features**
  * Provider capabilities are now formally defined and tracked within execution plans.
  * Execution plans now include capability metadata for both agent and SCM providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->