### PR TITLE
LOOP-036: Freeze provider capability vocabularies

### DIFF
--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -27,20 +27,20 @@ export const MODULE_BOUNDARIES = [
 
 export type ModuleBoundary = (typeof MODULE_BOUNDARIES)[number];
 
-export const SCM_PROVIDER_CAPABILITIES = [
+export const SCM_PROVIDER_CAPABILITIES = Object.freeze([
   "work-item-pickup",
   "lane-branch-intent",
   "lane-worktree-intent",
   "change-request-intent",
   "status-reporting",
-] as const;
+] as const);
 
 export type ScmProviderCapability = (typeof SCM_PROVIDER_CAPABILITIES)[number];
 
-export const AGENT_PROVIDER_CAPABILITIES = [
+export const AGENT_PROVIDER_CAPABILITIES = Object.freeze([
   "dry-run-intent",
   "execute-intent",
-] as const;
+] as const);
 
 export type AgentProviderCapability = (typeof AGENT_PROVIDER_CAPABILITIES)[number];
 

--- a/test/provider-capability-boundary.test.ts
+++ b/test/provider-capability-boundary.test.ts
@@ -8,19 +8,28 @@ import {
   type AgentProvider,
   type ScmProvider,
 } from "../src/core/index.js";
+import { createSampleDryRunExecutionPlan } from "../src/lane/index.js";
+import {
+  createRunRequestExecutionPlan,
+  parseRunRequest,
+} from "../src/protocol/index.js";
+
+const expectedScmProviderCapabilities = [
+  "work-item-pickup",
+  "lane-branch-intent",
+  "lane-worktree-intent",
+  "change-request-intent",
+  "status-reporting",
+] as const;
+
+const expectedAgentProviderCapabilities = [
+  "dry-run-intent",
+  "execute-intent",
+] as const;
 
 test("defines provider-neutral SCM and agent capability vocabulary", () => {
-  assert.deepEqual(SCM_PROVIDER_CAPABILITIES, [
-    "work-item-pickup",
-    "lane-branch-intent",
-    "lane-worktree-intent",
-    "change-request-intent",
-    "status-reporting",
-  ]);
-  assert.deepEqual(AGENT_PROVIDER_CAPABILITIES, [
-    "dry-run-intent",
-    "execute-intent",
-  ]);
+  assert.deepEqual(SCM_PROVIDER_CAPABILITIES, expectedScmProviderCapabilities);
+  assert.deepEqual(AGENT_PROVIDER_CAPABILITIES, expectedAgentProviderCapabilities);
 
   const scmProvider: ScmProvider = {
     id: "initial-scm-adapter",
@@ -36,6 +45,47 @@ test("defines provider-neutral SCM and agent capability vocabulary", () => {
   assert.equal(scmProvider.capabilities.includes("status-reporting"), true);
   assert.equal(agentProvider.capabilities.includes("execute-intent"), true);
   assert.doesNotMatch(JSON.stringify({ scmProvider, agentProvider }), /\b(GitHub|Codex|gh)\b/i);
+});
+
+test("keeps lane and run-request capability output stable after attempted vocabulary mutation", async () => {
+  const request = parseRunRequest(
+    JSON.parse(
+      await readFile(
+        "protocol-snapshots/ensen-protocol/v0.1.0/fixtures/run-request/v1/valid/github-issue-request.json",
+        "utf8",
+      ),
+    ) as unknown,
+  );
+  const mutableScmCapabilities = SCM_PROVIDER_CAPABILITIES as unknown as string[];
+  const mutableAgentCapabilities = AGENT_PROVIDER_CAPABILITIES as unknown as string[];
+
+  try {
+    try {
+      mutableScmCapabilities.push("runtime-mutated-scm-capability");
+    } catch (error) {
+      assert.ok(error instanceof TypeError);
+    }
+    try {
+      mutableAgentCapabilities.push("runtime-mutated-agent-capability");
+    } catch (error) {
+      assert.ok(error instanceof TypeError);
+    }
+
+    const dryRunPlan = createSampleDryRunExecutionPlan();
+    const runRequestPlan = createRunRequestExecutionPlan(request);
+
+    assert.deepEqual(dryRunPlan.scmProvider.capabilities, expectedScmProviderCapabilities);
+    assert.deepEqual(dryRunPlan.agentProvider.capabilities, expectedAgentProviderCapabilities);
+    assert.deepEqual(runRequestPlan.scmProvider.capabilities, expectedScmProviderCapabilities);
+    assert.deepEqual(runRequestPlan.agentProvider.capabilities, expectedAgentProviderCapabilities);
+  } finally {
+    if (mutableScmCapabilities.length > expectedScmProviderCapabilities.length) {
+      mutableScmCapabilities.splice(expectedScmProviderCapabilities.length);
+    }
+    if (mutableAgentCapabilities.length > expectedAgentProviderCapabilities.length) {
+      mutableAgentCapabilities.splice(expectedAgentProviderCapabilities.length);
+    }
+  }
 });
 
 test("documents Phase 4 provider boundaries without making initial adapters core concepts", async () => {


### PR DESCRIPTION
## Summary
- freeze exported SCM and agent provider capability vocabularies at runtime
- add a focused regression test proving attempted importer mutation cannot change dry-run or RunRequest plan capability output

## Verification
- npm ci
- npm run build && node --test dist/test/provider-capability-boundary.test.js
- npm run typecheck
- npm run build
- npm test

Closes #62

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced runtime immutability protections for provider capability definitions.

* **Tests**
  * Expanded test coverage to verify stability of capability lists across various execution scenarios and safeguard against accidental modifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->