### PR TITLE
LOOP-031: Add GitHub WorkItem pickup

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ The Ensen-loop mission and development charter alignment are summarized in [docs
 
 The Phase 1 local Work Item validation skeleton is documented in [docs/reference/work-item-contract.md](docs/reference/work-item-contract.md).
 
+GitHub issue pickup is documented in [docs/reference/github-work-item-pickup.md](docs/reference/github-work-item-pickup.md). It is an owner-controlled, allowlisted, read-only SCMProvider `work-item-pickup` boundary that maps already-loaded GitHub issue facts into provider-neutral Work Item facts without mutating GitHub state or starting execution.
+
 The copied Ensen-protocol v0.1.0 schema and conformance fixture snapshot is documented in [protocol-snapshots/ensen-protocol/v0.1.0/README.md](protocol-snapshots/ensen-protocol/v0.1.0/README.md). It is repo-owned fixture data, not a mutable shared runtime dependency.
 
 ## Commands

--- a/docs/reference/github-work-item-pickup.md
+++ b/docs/reference/github-work-item-pickup.md
@@ -1,0 +1,58 @@
+# GitHub WorkItem Pickup
+
+GitHub issue pickup is an SCMProvider adapter boundary for `work-item-pickup`.
+It normalizes already-loaded GitHub issue facts into provider-neutral Work Item
+facts and sanitized scope/provenance facts. It is pre-executor input
+collection only.
+
+The pickup boundary is read-only. It must not edit issues, labels, branches,
+comments, pull requests, commits, checks, or any other GitHub state. It also
+must not start a Codex session or advertise executor capabilities such as
+`submit`, `status`, `cancel`, or `fetchEvidence`.
+
+Repositories are blocked unless an operator-owned allowlist explicitly marks
+the exact repository as owner-controlled:
+
+```json
+{
+  "allowlist": [
+    {
+      "owner": "TommyKammy",
+      "name": "Ensen-loop",
+      "ownerControlled": true
+    }
+  ],
+  "issue": {
+    "repository": {
+      "owner": "TommyKammy",
+      "name": "Ensen-loop",
+      "htmlUrl": "https://github.com/TommyKammy/Ensen-loop"
+    },
+    "issue": {
+      "number": 56,
+      "title": "LOOP-031: Add GitHub WorkItem pickup for owner-controlled repos",
+      "state": "open",
+      "htmlUrl": "https://github.com/TommyKammy/Ensen-loop/issues/56"
+    },
+    "requester": {
+      "login": "owner-maintainer"
+    }
+  }
+}
+```
+
+Successful pickup returns a Work Item with `source: "github-issue"` plus
+sanitized scope facts: provider, repository, issue number, issue URL,
+repository URL, requester login, and `ownerControlled: true`. These facts are
+authoritative input for later lane submission and idempotency binding, but they
+do not mean execution has started.
+
+Malformed issue references, missing requester provenance, missing repository
+URL facts, secret-like input fields, and repositories that are not explicitly
+allowlisted as owner-controlled fail closed with field-specific diagnostics.
+GitHub-authored issue text remains untrusted context and does not grant
+operator permission by itself.
+
+Protocol `v0.2.0` remains copied/vendored contract evidence only. GitHub pickup
+does not import Ensen-protocol runtime code and does not implement protocol
+`submit`, `status`, `cancel`, or `fetchEvidence`.

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,4 +20,5 @@ export * from "./core/index.js";
 export * from "./executor/index.js";
 export * from "./lane/index.js";
 export * from "./protocol/index.js";
+export * from "./scm/index.js";
 export * from "./work-item/index.js";

--- a/src/scm/github-work-item-pickup.ts
+++ b/src/scm/github-work-item-pickup.ts
@@ -89,8 +89,21 @@ const githubPickupBoundary: GithubPickupBoundary = Object.freeze({
 });
 
 export function pickupGithubIssueWorkItem(
-  input: GithubIssuePickupInput,
+  input: GithubIssuePickupInput | null | undefined,
 ): GithubWorkItemPickupResult {
+  if (input === null || input === undefined) {
+    return {
+      ok: false,
+      issues: [
+        {
+          path: "input",
+          message: "GitHub pickup input is required.",
+        },
+      ],
+      boundary: githubPickupBoundary,
+    };
+  }
+
   const issues = collectGithubIssuePickupIssues(input);
 
   if (issues.length > 0) {
@@ -120,7 +133,7 @@ export function pickupGithubIssueWorkItem(
   return {
     ok: true,
     workItem: {
-      id: `github-${repository.owner}-${repository.name}-${issue.number}`,
+      id: `github:${repository.owner}/${repository.name}#${issue.number}`,
       title: issue.title,
       source: "github-issue",
       status: issue.state === "open" ? "ready" : "blocked",
@@ -281,6 +294,14 @@ function validateAllowlist(
   let hasOwnerControlledMatch = false;
 
   allowlist.forEach((entry, index) => {
+    if (typeof entry !== "object" || entry === null) {
+      issues.push({
+        path: `allowlist[${index}]`,
+        message: "Owner-controlled repository allowlist entries must be objects.",
+      });
+      return;
+    }
+
     if (entry.ownerControlled !== true) {
       issues.push({
         path: `allowlist[${index}].ownerControlled`,

--- a/src/scm/github-work-item-pickup.ts
+++ b/src/scm/github-work-item-pickup.ts
@@ -1,0 +1,314 @@
+import type { WorkItem } from "../core/index.js";
+
+export interface GithubOwnerControlledRepository {
+  readonly owner: string;
+  readonly name: string;
+  readonly ownerControlled?: boolean;
+}
+
+export interface GithubIssueRepositoryFacts {
+  readonly owner?: unknown;
+  readonly name?: unknown;
+  readonly htmlUrl?: unknown;
+}
+
+export interface GithubIssueFacts {
+  readonly number?: unknown;
+  readonly title?: unknown;
+  readonly state?: unknown;
+  readonly htmlUrl?: unknown;
+}
+
+export interface GithubRequesterFacts {
+  readonly login?: unknown;
+}
+
+export interface GithubIssuePickupInput {
+  readonly allowlist: readonly GithubOwnerControlledRepository[];
+  readonly issue: {
+    readonly repository: GithubIssueRepositoryFacts;
+    readonly issue: GithubIssueFacts;
+    readonly requester: GithubRequesterFacts;
+  };
+}
+
+export interface GithubWorkItemScope {
+  readonly provider: "github";
+  readonly repository: string;
+  readonly issueNumber: number;
+  readonly issueUrl: string;
+  readonly repositoryUrl: string;
+  readonly requester: string;
+  readonly ownerControlled: true;
+}
+
+export interface GithubPickupBoundary {
+  readonly capability: "work-item-pickup";
+  readonly readOnly: true;
+  readonly mutatesProvider: false;
+  readonly startsExecution: false;
+  readonly executorCapabilitiesAdvertised: readonly string[];
+  readonly protocolRuntimeImported: false;
+}
+
+export interface GithubWorkItemPickupIssue {
+  readonly path: string;
+  readonly message: string;
+}
+
+export interface GithubWorkItemPickupSuccess {
+  readonly ok: true;
+  readonly workItem: WorkItem;
+  readonly scope: GithubWorkItemScope;
+  readonly boundary: GithubPickupBoundary;
+}
+
+export interface GithubWorkItemPickupFailure {
+  readonly ok: false;
+  readonly issues: readonly GithubWorkItemPickupIssue[];
+  readonly boundary: GithubPickupBoundary;
+}
+
+export type GithubWorkItemPickupResult =
+  | GithubWorkItemPickupSuccess
+  | GithubWorkItemPickupFailure;
+
+const githubOwnerPattern = /^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?$/;
+const githubRepositoryPattern = /^[A-Za-z0-9._-]+$/;
+const secretLikeTopLevelKeys = new Set(["token", "authorization", "password", "secret"]);
+
+const githubPickupBoundary: GithubPickupBoundary = Object.freeze({
+  capability: "work-item-pickup",
+  readOnly: true,
+  mutatesProvider: false,
+  startsExecution: false,
+  executorCapabilitiesAdvertised: [],
+  protocolRuntimeImported: false,
+});
+
+export function pickupGithubIssueWorkItem(
+  input: GithubIssuePickupInput,
+): GithubWorkItemPickupResult {
+  const issues = collectGithubIssuePickupIssues(input);
+
+  if (issues.length > 0) {
+    return {
+      ok: false,
+      issues,
+      boundary: githubPickupBoundary,
+    };
+  }
+
+  const repository = input.issue.repository as {
+    readonly owner: string;
+    readonly name: string;
+    readonly htmlUrl: string;
+  };
+  const issue = input.issue.issue as {
+    readonly number: number;
+    readonly title: string;
+    readonly state: "open" | "closed";
+    readonly htmlUrl: string;
+  };
+  const requester = input.issue.requester as {
+    readonly login: string;
+  };
+  const repositoryName = `${repository.owner}/${repository.name}`;
+
+  return {
+    ok: true,
+    workItem: {
+      id: `github-${repository.owner}-${repository.name}-${issue.number}`,
+      title: issue.title,
+      source: "github-issue",
+      status: issue.state === "open" ? "ready" : "blocked",
+    },
+    scope: {
+      provider: "github",
+      repository: repositoryName,
+      issueNumber: issue.number,
+      issueUrl: issue.htmlUrl,
+      repositoryUrl: repository.htmlUrl,
+      requester: requester.login,
+      ownerControlled: true,
+    },
+    boundary: githubPickupBoundary,
+  };
+}
+
+function collectGithubIssuePickupIssues(
+  input: GithubIssuePickupInput,
+): readonly GithubWorkItemPickupIssue[] {
+  const issues: GithubWorkItemPickupIssue[] = [];
+  const repository = input.issue?.repository;
+  const issue = input.issue?.issue;
+  const requester = input.issue?.requester;
+
+  for (const key of Object.keys(input as unknown as Record<string, unknown>)) {
+    if (secretLikeTopLevelKeys.has(key.toLowerCase())) {
+      issues.push({
+        path: key,
+        message: "GitHub pickup input must not include credentials or secret-like fields.",
+      });
+    }
+  }
+
+  validateRepositoryFacts(repository, issues);
+  validateIssueFacts(repository, issue, issues);
+  validateRequesterFacts(requester, issues);
+  validateAllowlist(input.allowlist, repository, issues);
+
+  return issues;
+}
+
+function validateRepositoryFacts(
+  repository: GithubIssueRepositoryFacts | undefined,
+  issues: GithubWorkItemPickupIssue[],
+): void {
+  if (repository === undefined) {
+    issues.push({
+      path: "repository",
+      message: "GitHub repository facts are required.",
+    });
+    return;
+  }
+
+  if (!isGithubOwner(repository.owner)) {
+    issues.push({
+      path: "repository.owner",
+      message: "GitHub repository owner is required and must be a valid owner name.",
+    });
+  }
+
+  if (!isGithubRepositoryName(repository.name)) {
+    issues.push({
+      path: "repository.name",
+      message: "GitHub repository name is required and must be a valid repository name.",
+    });
+  }
+}
+
+function validateIssueFacts(
+  repository: GithubIssueRepositoryFacts | undefined,
+  issue: GithubIssueFacts | undefined,
+  issues: GithubWorkItemPickupIssue[],
+): void {
+  if (issue === undefined) {
+    issues.push({
+      path: "issue",
+      message: "GitHub issue facts are required.",
+    });
+    return;
+  }
+
+  if (
+    typeof issue.number !== "number" ||
+    !Number.isSafeInteger(issue.number) ||
+    issue.number <= 0
+  ) {
+    issues.push({
+      path: "issue.number",
+      message: "GitHub issue number must be a positive safe integer.",
+    });
+  }
+
+  if (typeof issue.title !== "string" || issue.title.trim().length === 0) {
+    issues.push({
+      path: "issue.title",
+      message: "GitHub issue title is required and must contain non-whitespace text.",
+    });
+  }
+
+  if (issue.state !== "open" && issue.state !== "closed") {
+    issues.push({
+      path: "issue.state",
+      message: "GitHub issue state must be open or closed.",
+    });
+  }
+
+  if (
+    typeof issue.htmlUrl !== "string" ||
+    (repository !== undefined &&
+      typeof issue.number === "number" &&
+      Number.isSafeInteger(issue.number) &&
+      issue.number > 0 &&
+      issue.htmlUrl !== expectedIssueUrl(repository, issue.number))
+  ) {
+    issues.push({
+      path: "issue.htmlUrl",
+      message: "GitHub issue URL is required and must match the repository and issue number.",
+    });
+  }
+
+  if (
+    repository !== undefined &&
+    repository.htmlUrl !== expectedRepositoryUrl(repository)
+  ) {
+    issues.push({
+      path: "repository.htmlUrl",
+      message: "GitHub repository URL is required and must match the repository owner/name.",
+    });
+  }
+}
+
+function validateRequesterFacts(
+  requester: GithubRequesterFacts | undefined,
+  issues: GithubWorkItemPickupIssue[],
+): void {
+  if (typeof requester?.login !== "string" || requester.login.trim().length === 0) {
+    issues.push({
+      path: "requester.login",
+      message: "GitHub requester login is required as provenance for later lane submission.",
+    });
+  }
+}
+
+function validateAllowlist(
+  allowlist: readonly GithubOwnerControlledRepository[],
+  repository: GithubIssueRepositoryFacts | undefined,
+  issues: GithubWorkItemPickupIssue[],
+): void {
+  let hasOwnerControlledMatch = false;
+
+  allowlist.forEach((entry, index) => {
+    if (entry.ownerControlled !== true) {
+      issues.push({
+        path: `allowlist[${index}].ownerControlled`,
+        message:
+          "Owner-controlled repository allowlist entries must explicitly set ownerControlled: true.",
+      });
+    }
+
+    if (
+      repository !== undefined &&
+      entry.owner === repository.owner &&
+      entry.name === repository.name &&
+      entry.ownerControlled === true
+    ) {
+      hasOwnerControlledMatch = true;
+    }
+  });
+
+  if (!hasOwnerControlledMatch) {
+    issues.push({
+      path: "repository",
+      message: "GitHub repository must be explicitly allowlisted as owner-controlled.",
+    });
+  }
+}
+
+function expectedRepositoryUrl(repository: GithubIssueRepositoryFacts): string {
+  return `https://github.com/${repository.owner}/${repository.name}`;
+}
+
+function expectedIssueUrl(repository: GithubIssueRepositoryFacts, issueNumber: number): string {
+  return `${expectedRepositoryUrl(repository)}/issues/${issueNumber}`;
+}
+
+function isGithubOwner(value: unknown): value is string {
+  return typeof value === "string" && githubOwnerPattern.test(value);
+}
+
+function isGithubRepositoryName(value: unknown): value is string {
+  return typeof value === "string" && githubRepositoryPattern.test(value);
+}

--- a/src/scm/github-work-item-pickup.ts
+++ b/src/scm/github-work-item-pickup.ts
@@ -77,12 +77,14 @@ const githubOwnerPattern = /^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?$/;
 const githubRepositoryPattern = /^[A-Za-z0-9._-]+$/;
 const secretLikeTopLevelKeys = new Set(["token", "authorization", "password", "secret"]);
 
+const executorCapabilitiesAdvertised = Object.freeze([] as readonly string[]);
+
 const githubPickupBoundary: GithubPickupBoundary = Object.freeze({
   capability: "work-item-pickup",
   readOnly: true,
   mutatesProvider: false,
   startsExecution: false,
-  executorCapabilitiesAdvertised: [],
+  executorCapabilitiesAdvertised,
   protocolRuntimeImported: false,
 });
 
@@ -264,10 +266,18 @@ function validateRequesterFacts(
 }
 
 function validateAllowlist(
-  allowlist: readonly GithubOwnerControlledRepository[],
+  allowlist: unknown,
   repository: GithubIssueRepositoryFacts | undefined,
   issues: GithubWorkItemPickupIssue[],
 ): void {
+  if (!Array.isArray(allowlist)) {
+    issues.push({
+      path: "allowlist",
+      message: "Owner-controlled repository allowlist is required and must be an array.",
+    });
+    return;
+  }
+
   let hasOwnerControlledMatch = false;
 
   allowlist.forEach((entry, index) => {

--- a/src/scm/index.ts
+++ b/src/scm/index.ts
@@ -4,3 +4,17 @@ export {
   type ScmProvider,
   type ScmProviderCapability,
 } from "../core/index.js";
+export {
+  pickupGithubIssueWorkItem,
+  type GithubIssueFacts,
+  type GithubIssuePickupInput,
+  type GithubIssueRepositoryFacts,
+  type GithubOwnerControlledRepository,
+  type GithubPickupBoundary,
+  type GithubRequesterFacts,
+  type GithubWorkItemPickupFailure,
+  type GithubWorkItemPickupIssue,
+  type GithubWorkItemPickupResult,
+  type GithubWorkItemPickupSuccess,
+  type GithubWorkItemScope,
+} from "./github-work-item-pickup.js";

--- a/test/github-work-item-pickup.test.ts
+++ b/test/github-work-item-pickup.test.ts
@@ -1,0 +1,172 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+import {
+  pickupGithubIssueWorkItem,
+} from "../src/scm/index.js";
+
+const allowedIssue = {
+  repository: {
+    owner: "TommyKammy",
+    name: "Ensen-loop",
+    htmlUrl: "https://github.com/TommyKammy/Ensen-loop",
+  },
+  issue: {
+    number: 56,
+    title: "LOOP-031: Add GitHub WorkItem pickup for owner-controlled repos",
+    state: "open",
+    htmlUrl: "https://github.com/TommyKammy/Ensen-loop/issues/56",
+  },
+  requester: {
+    login: "owner-maintainer",
+  },
+};
+
+const allowlist = [
+  {
+    owner: "TommyKammy",
+    name: "Ensen-loop",
+    ownerControlled: true,
+  },
+] as const;
+
+test("maps an allowed GitHub issue into provider-neutral WorkItem pickup facts", () => {
+  const result = pickupGithubIssueWorkItem({
+    allowlist,
+    issue: allowedIssue,
+  });
+
+  assert.equal(result.ok, true);
+  assert.deepEqual(result.workItem, {
+    id: "github-TommyKammy-Ensen-loop-56",
+    title: "LOOP-031: Add GitHub WorkItem pickup for owner-controlled repos",
+    source: "github-issue",
+    status: "ready",
+  });
+  assert.deepEqual(result.scope, {
+    provider: "github",
+    repository: "TommyKammy/Ensen-loop",
+    issueNumber: 56,
+    issueUrl: "https://github.com/TommyKammy/Ensen-loop/issues/56",
+    repositoryUrl: "https://github.com/TommyKammy/Ensen-loop",
+    requester: "owner-maintainer",
+    ownerControlled: true,
+  });
+  assert.deepEqual(result.boundary, {
+    capability: "work-item-pickup",
+    readOnly: true,
+    mutatesProvider: false,
+    startsExecution: false,
+    executorCapabilitiesAdvertised: [],
+    protocolRuntimeImported: false,
+  });
+});
+
+test("fails closed when the GitHub repository is not owner-controlled allowed scope", () => {
+  const result = pickupGithubIssueWorkItem({
+    allowlist,
+    issue: {
+      ...allowedIssue,
+      repository: {
+        ...allowedIssue.repository,
+        name: "other-repo",
+        htmlUrl: "https://github.com/TommyKammy/other-repo",
+      },
+      issue: {
+        ...allowedIssue.issue,
+        htmlUrl: "https://github.com/TommyKammy/other-repo/issues/56",
+      },
+    },
+  });
+
+  assert.equal(result.ok, false);
+  assert.deepEqual(result.issues, [
+    {
+      path: "repository",
+      message: "GitHub repository must be explicitly allowlisted as owner-controlled.",
+    },
+  ]);
+});
+
+test("fails closed for malformed issue references and missing GitHub facts", () => {
+  const result = pickupGithubIssueWorkItem({
+    allowlist,
+    issue: {
+      repository: {
+        owner: "TommyKammy",
+        name: "Ensen-loop",
+      },
+      issue: {
+        number: 0,
+        title: " ",
+        state: "triaged",
+      },
+      requester: {},
+    },
+  });
+
+  assert.equal(result.ok, false);
+  assert.deepEqual(result.issues, [
+    {
+      path: "issue.number",
+      message: "GitHub issue number must be a positive safe integer.",
+    },
+    {
+      path: "issue.title",
+      message: "GitHub issue title is required and must contain non-whitespace text.",
+    },
+    {
+      path: "issue.state",
+      message: "GitHub issue state must be open or closed.",
+    },
+    {
+      path: "issue.htmlUrl",
+      message: "GitHub issue URL is required and must match the repository and issue number.",
+    },
+    {
+      path: "repository.htmlUrl",
+      message: "GitHub repository URL is required and must match the repository owner/name.",
+    },
+    {
+      path: "requester.login",
+      message: "GitHub requester login is required as provenance for later lane submission.",
+    },
+  ]);
+});
+
+test("fails closed when owner-controlled scope is missing from the allowlist entry", () => {
+  const result = pickupGithubIssueWorkItem({
+    allowlist: [
+      {
+        owner: "TommyKammy",
+        name: "Ensen-loop",
+      },
+    ],
+    issue: allowedIssue,
+  });
+
+  assert.equal(result.ok, false);
+  assert.deepEqual(result.issues, [
+    {
+      path: "allowlist[0].ownerControlled",
+      message: "Owner-controlled repository allowlist entries must explicitly set ownerControlled: true.",
+    },
+    {
+      path: "repository",
+      message: "GitHub repository must be explicitly allowlisted as owner-controlled.",
+    },
+  ]);
+});
+
+test("documents GitHub pickup as read-only input collection without executor protocol claims", async () => {
+  const docs = await readFile("docs/reference/github-work-item-pickup.md", "utf8");
+
+  assert.match(docs, /ownerControlled: true/);
+  assert.match(docs, /read-only/i);
+  assert.match(docs, /must not edit issues, labels, branches,\s+comments, pull requests, commits/i);
+  assert.match(docs, /must not start a Codex session/i);
+  assert.match(docs, /does not implement protocol\s+`submit`, `status`, `cancel`, or `fetchEvidence`/i);
+  assert.match(docs, /Protocol `v0\.2\.0` remains copied\/vendored contract evidence only/);
+  assert.doesNotMatch(docs, /Ensen-protocol runtime code is required/i);
+});

--- a/test/github-work-item-pickup.test.ts
+++ b/test/github-work-item-pickup.test.ts
@@ -63,6 +63,20 @@ test("maps an allowed GitHub issue into provider-neutral WorkItem pickup facts",
   });
 });
 
+test("keeps advertised executor capabilities immutable at runtime", () => {
+  const result = pickupGithubIssueWorkItem({
+    allowlist,
+    issue: allowedIssue,
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(Object.isFrozen(result.boundary.executorCapabilitiesAdvertised), true);
+  assert.throws(() => {
+    (result.boundary.executorCapabilitiesAdvertised as unknown as string[]).push("submit");
+  }, TypeError);
+  assert.deepEqual(result.boundary.executorCapabilitiesAdvertised, []);
+});
+
 test("fails closed when the GitHub repository is not owner-controlled allowed scope", () => {
   const result = pickupGithubIssueWorkItem({
     allowlist,
@@ -157,6 +171,27 @@ test("fails closed when owner-controlled scope is missing from the allowlist ent
       message: "GitHub repository must be explicitly allowlisted as owner-controlled.",
     },
   ]);
+});
+
+test("fails closed when allowlist scope is missing or malformed", () => {
+  const missingResult = pickupGithubIssueWorkItem({
+    allowlist: undefined,
+    issue: allowedIssue,
+  } as unknown as Parameters<typeof pickupGithubIssueWorkItem>[0]);
+  const malformedResult = pickupGithubIssueWorkItem({
+    allowlist: {},
+    issue: allowedIssue,
+  } as unknown as Parameters<typeof pickupGithubIssueWorkItem>[0]);
+
+  assert.equal(missingResult.ok, false);
+  assert.deepEqual(missingResult.issues, [
+    {
+      path: "allowlist",
+      message: "Owner-controlled repository allowlist is required and must be an array.",
+    },
+  ]);
+  assert.equal(malformedResult.ok, false);
+  assert.deepEqual(malformedResult.issues, missingResult.issues);
 });
 
 test("documents GitHub pickup as read-only input collection without executor protocol claims", async () => {

--- a/test/github-work-item-pickup.test.ts
+++ b/test/github-work-item-pickup.test.ts
@@ -39,7 +39,7 @@ test("maps an allowed GitHub issue into provider-neutral WorkItem pickup facts",
 
   assert.equal(result.ok, true);
   assert.deepEqual(result.workItem, {
-    id: "github-TommyKammy-Ensen-loop-56",
+    id: "github:TommyKammy/Ensen-loop#56",
     title: "LOOP-031: Add GitHub WorkItem pickup for owner-controlled repos",
     source: "github-issue",
     status: "ready",
@@ -173,6 +173,18 @@ test("fails closed when owner-controlled scope is missing from the allowlist ent
   ]);
 });
 
+test("fails closed when top-level pickup input is missing", () => {
+  const result = pickupGithubIssueWorkItem(undefined);
+
+  assert.equal(result.ok, false);
+  assert.deepEqual(result.issues, [
+    {
+      path: "input",
+      message: "GitHub pickup input is required.",
+    },
+  ]);
+});
+
 test("fails closed when allowlist scope is missing or malformed", () => {
   const missingResult = pickupGithubIssueWorkItem({
     allowlist: undefined,
@@ -180,6 +192,10 @@ test("fails closed when allowlist scope is missing or malformed", () => {
   } as unknown as Parameters<typeof pickupGithubIssueWorkItem>[0]);
   const malformedResult = pickupGithubIssueWorkItem({
     allowlist: {},
+    issue: allowedIssue,
+  } as unknown as Parameters<typeof pickupGithubIssueWorkItem>[0]);
+  const malformedEntryResult = pickupGithubIssueWorkItem({
+    allowlist: [null],
     issue: allowedIssue,
   } as unknown as Parameters<typeof pickupGithubIssueWorkItem>[0]);
 
@@ -192,6 +208,17 @@ test("fails closed when allowlist scope is missing or malformed", () => {
   ]);
   assert.equal(malformedResult.ok, false);
   assert.deepEqual(malformedResult.issues, missingResult.issues);
+  assert.equal(malformedEntryResult.ok, false);
+  assert.deepEqual(malformedEntryResult.issues, [
+    {
+      path: "allowlist[0]",
+      message: "Owner-controlled repository allowlist entries must be objects.",
+    },
+    {
+      path: "repository",
+      message: "GitHub repository must be explicitly allowlisted as owner-controlled.",
+    },
+  ]);
 });
 
 test("documents GitHub pickup as read-only input collection without executor protocol claims", async () => {


### PR DESCRIPTION
## Summary
- add a read-only GitHub issue WorkItem pickup boundary under SCMProvider
- require explicit owner-controlled repository allowlist scope before pickup succeeds
- document the safe fixture shape and no executor/protocol-runtime claims

## Verification
- npm run typecheck
- npm run build
- node --test dist/test/github-work-item-pickup.test.js
- npm test

Part of #54
Closes #56

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added GitHub issue work-item pickup: read-only normalization of GitHub issues into provider-neutral work items with validation and owner-controlled allowlist security.

* **Documentation**
  * Added reference docs describing the pickup boundary, validation rules, success/failure semantics, and security constraints (owner-controlled allowlist).

* **Tests**
  * Added comprehensive tests covering success cases, validation failures, allowlist enforcement, and boundary immutability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->