### PR TITLE
LOOP-032 add issue readiness evaluation

### DIFF
--- a/docs/reference/issue-readiness.md
+++ b/docs/reference/issue-readiness.md
@@ -1,0 +1,47 @@
+# Issue Readiness Evaluation
+
+Issue readiness evaluation is a pre-execution diagnostic boundary for deciding
+whether a mapped WorkItem is bounded enough to become a lane run input. It reads
+provider-neutral WorkItem facts, owner-controlled scope facts, and observable
+issue structure supplied by a pickup adapter.
+
+The boundary returns one of three parseable states:
+
+| State | Meaning |
+| --- | --- |
+| `runnable` | The WorkItem is ready, scope is owner-controlled, and the issue describes one bounded behavior delta with acceptance criteria. |
+| `blocked` | A fail-closed prerequisite is missing or unsafe, such as owner-controlled scope, supported capability, supported EIP major version, trusted evidence, or an unambiguous open state. |
+| `needs-human-refinement` | The issue is not unsafe, but it needs explicit human cleanup before a lane run, such as acceptance criteria or exactly one observable behavior delta. |
+
+## Lint Signals
+
+The `1 issue = 1 behavior delta` lint is based on observable issue structure
+after pickup maps provider input into neutral facts. A runnable issue must expose
+exactly one behavior delta. Multiple deltas are blocked because the lane could
+otherwise perform unrelated changes under one WorkItem. Missing deltas require
+human refinement because the intended behavior change is underspecified.
+
+Readiness diagnostics are safe for public artifacts. They identify fields and
+categories without echoing raw secrets, credentials, or workstation-local
+absolute paths.
+
+## Protocol Boundary
+
+Readiness is not execution. It does not create a worktree, start an agent,
+submit a protocol request, emit status snapshots, cancel a run, fetch evidence,
+synthesize RunResult output, or make merge decisions.
+
+Protocol `v0.2.0` guidance is reflected as fail-closed diagnostic categories for
+validation failure, unsupported capability, provider rejection before run
+binding, unavailable evidence, unknown failure, and unsupported EIP major
+versions. These diagnostics are advisory inputs for a later lane boundary; they
+are not protocol terminal artifacts.
+
+## Non-Goals
+
+- No automatic issue rewriting.
+- No compliance claims.
+- No protocol terminal artifact synthesis.
+- No automatic product, execution, or merge authority.
+- No dependency on Ensen-flow approval or workflow state.
+

--- a/src/work-item/index.ts
+++ b/src/work-item/index.ts
@@ -89,7 +89,7 @@ const localWorkItemStatuses = new Set<unknown>([
 const defaultReadinessCapabilities = Object.freeze(["work-item-readiness"] as const);
 const defaultSupportedEipMajorVersions = Object.freeze([2] as const);
 const workstationLocalPathPattern =
-  /(?:\/Users\/[^/\s]+|\/home\/[^/\s]+|[A-Za-z]:\\Users\\[^\\\s]+)/;
+  /(?:^|[\s([{"'`:=<])(?:\/(?!\/)\S+|[A-Za-z]:[\\/]\S+|\\\\\S+)/;
 const secretLikeTextPattern =
   /\b(?:token|secret|password|authorization|api[_-]?key)\b\s*[:=]\s*\S+/i;
 
@@ -435,7 +435,7 @@ function validateTerminalState(
   issue: IssueReadinessFacts,
   diagnostics: IssueReadinessDiagnostic[],
 ): void {
-  if (issue.terminalState !== undefined && issue.terminalState !== "open") {
+  if (issue.terminalState !== "open") {
     diagnostics.push({
       category: "unknown_failure",
       path: "issue.terminalState",

--- a/src/work-item/index.ts
+++ b/src/work-item/index.ts
@@ -19,6 +19,65 @@ export interface WorkItemValidationFailure {
 
 export type WorkItemValidationResult = WorkItemValidationSuccess | WorkItemValidationFailure;
 
+export type IssueReadinessStatus = "runnable" | "blocked" | "needs-human-refinement";
+
+export type IssueReadinessDiagnosticCategory =
+  | "validation_failure"
+  | "unsupported_capability"
+  | "provider_rejection_before_run_binding"
+  | "evidence_unavailable"
+  | "unknown_failure"
+  | "unsupported_eip_major_version"
+  | "behavior_delta_violation";
+
+export type IssueReadinessDiagnosticSeverity = "info" | "human" | "blocker";
+
+export interface IssueReadinessDiagnostic {
+  readonly category: IssueReadinessDiagnosticCategory;
+  readonly path: string;
+  readonly message: string;
+  readonly severity: IssueReadinessDiagnosticSeverity;
+}
+
+export interface IssueReadinessBoundary {
+  readonly capability: "work-item-readiness";
+  readonly startsExecution: false;
+  readonly emitsProtocolTerminalArtifact: false;
+  readonly protocolRuntimeImported: false;
+  readonly providerNeutral: true;
+}
+
+export interface IssueReadinessScope {
+  readonly ownerControlled?: boolean;
+}
+
+export interface IssueReadinessFacts {
+  readonly acceptanceCriteria?: readonly string[];
+  readonly behaviorDeltas?: readonly string[];
+  readonly scopeItems?: readonly string[];
+  readonly requestedCapabilities?: readonly string[];
+  readonly eipMajorVersion?: number;
+  readonly terminalState?: "open" | "closed" | "unknown";
+  readonly bodyText?: string;
+  readonly unsafeInputs?: readonly string[];
+}
+
+export interface IssueReadinessInput {
+  readonly workItem: WorkItem;
+  readonly scope?: IssueReadinessScope;
+  readonly issue?: IssueReadinessFacts;
+  readonly supportedCapabilities?: readonly string[];
+  readonly supportedEipMajorVersions?: readonly number[];
+}
+
+export interface IssueReadinessResult {
+  readonly status: IssueReadinessStatus;
+  readonly runnable: boolean;
+  readonly workItem: WorkItem;
+  readonly diagnostics: readonly IssueReadinessDiagnostic[];
+  readonly boundary: IssueReadinessBoundary;
+}
+
 const localWorkItemIdPattern = /^[A-Za-z0-9][A-Za-z0-9._-]*$/;
 const localWorkItemStatuses = new Set<unknown>([
   "ready",
@@ -27,6 +86,20 @@ const localWorkItemStatuses = new Set<unknown>([
   "completed",
   "failed",
 ]);
+const defaultReadinessCapabilities = Object.freeze(["work-item-readiness"] as const);
+const defaultSupportedEipMajorVersions = Object.freeze([2] as const);
+const workstationLocalPathPattern =
+  /(?:\/Users\/[^/\s]+|\/home\/[^/\s]+|[A-Za-z]:\\Users\\[^\\\s]+)/;
+const secretLikeTextPattern =
+  /\b(?:token|secret|password|authorization|api[_-]?key)\b\s*[:=]\s*\S+/i;
+
+const issueReadinessBoundary: IssueReadinessBoundary = Object.freeze({
+  capability: "work-item-readiness",
+  startsExecution: false,
+  emitsProtocolTerminalArtifact: false,
+  protocolRuntimeImported: false,
+  providerNeutral: true,
+});
 
 export class WorkItemValidationError extends Error {
   readonly issues: readonly WorkItemValidationIssue[];
@@ -73,6 +146,105 @@ export function parseLocalWorkItem(value: unknown): WorkItem {
   }
 
   return result.workItem;
+}
+
+export function evaluateIssueReadiness(input: IssueReadinessInput): IssueReadinessResult {
+  const diagnostics: IssueReadinessDiagnostic[] = [];
+  const workItemValidationIssues = collectCoreWorkItemReadinessIssues(input.workItem);
+  const issue = input.issue ?? {};
+  const supportedCapabilities = input.supportedCapabilities ?? defaultReadinessCapabilities;
+  const supportedEipMajorVersions =
+    input.supportedEipMajorVersions ?? defaultSupportedEipMajorVersions;
+
+  for (const issue of workItemValidationIssues) {
+    diagnostics.push({
+      category: "validation_failure",
+      path: `workItem.${issue.path}`,
+      message: issue.message,
+      severity: "blocker",
+    });
+  }
+
+  if (input.workItem.status !== "ready") {
+    diagnostics.push({
+      category: "unknown_failure",
+      path: "workItem.status",
+      message: "Issue readiness requires a ready WorkItem lifecycle state.",
+      severity: "blocker",
+    });
+  }
+
+  if (input.scope?.ownerControlled !== true) {
+    diagnostics.push({
+      category: "provider_rejection_before_run_binding",
+      path: "scope.ownerControlled",
+      message: "Issue scope must be explicitly owner-controlled before lane execution.",
+      severity: "blocker",
+    });
+  }
+
+  validateAcceptanceCriteria(issue, diagnostics);
+  validateBehaviorDeltas(issue, diagnostics);
+  validateScopeItems(issue, diagnostics);
+  validateCapabilities(issue, supportedCapabilities, diagnostics);
+  validateEipMajorVersion(issue, supportedEipMajorVersions, diagnostics);
+  validateTerminalState(issue, diagnostics);
+  validateUnsafeInputs(issue, diagnostics);
+
+  const hasBlocker = diagnostics.some((diagnostic) => diagnostic.severity === "blocker");
+  const hasHumanRefinement = diagnostics.some((diagnostic) => diagnostic.severity === "human");
+  const status: IssueReadinessStatus = hasBlocker
+    ? "blocked"
+    : hasHumanRefinement
+      ? "needs-human-refinement"
+      : "runnable";
+
+  if (status === "runnable") {
+    diagnostics.push({
+      category: "validation_failure",
+      path: "issue.behaviorDeltas",
+      message: "Issue has one observable behavior delta.",
+      severity: "info",
+    });
+  }
+
+  return {
+    status,
+    runnable: status === "runnable",
+    workItem: input.workItem,
+    diagnostics,
+    boundary: issueReadinessBoundary,
+  };
+}
+
+function collectCoreWorkItemReadinessIssues(
+  workItem: WorkItem,
+): readonly WorkItemValidationIssue[] {
+  const issues: WorkItemValidationIssue[] = [];
+
+  const idIssue = validateLocalWorkItemTextField("id", workItem.id);
+  if (idIssue !== undefined) {
+    issues.push(idIssue);
+  }
+
+  const titleIssue = validateLocalWorkItemTextField("title", workItem.title);
+  if (titleIssue !== undefined) {
+    issues.push(titleIssue);
+  }
+
+  const sourceIssue = validateLocalWorkItemTextField("source", workItem.source);
+  if (sourceIssue !== undefined) {
+    issues.push(sourceIssue);
+  }
+
+  if (!localWorkItemStatuses.has(workItem.status)) {
+    issues.push({
+      path: "status",
+      message: "status must be one of: ready, blocked, running, completed, failed.",
+    });
+  }
+
+  return issues;
 }
 
 function collectLocalWorkItemIssues(value: unknown): readonly WorkItemValidationIssue[] {
@@ -125,8 +297,197 @@ function collectLocalWorkItemIssues(value: unknown): readonly WorkItemValidation
   return issues;
 }
 
+function validateAcceptanceCriteria(
+  issue: IssueReadinessFacts,
+  diagnostics: IssueReadinessDiagnostic[],
+): void {
+  const acceptanceCriteria = issue.acceptanceCriteria ?? [];
+
+  if (acceptanceCriteria.length === 0) {
+    diagnostics.push({
+      category: "validation_failure",
+      path: "issue.acceptanceCriteria",
+      message: "Issue needs explicit acceptance criteria before lane execution.",
+      severity: "human",
+    });
+    return;
+  }
+
+  if (!allNonBlankStrings(acceptanceCriteria)) {
+    diagnostics.push({
+      category: "validation_failure",
+      path: "issue.acceptanceCriteria",
+      message: "Issue acceptance criteria must contain only non-empty public text.",
+      severity: "blocker",
+    });
+  }
+
+  if (acceptanceCriteria.length > 12) {
+    diagnostics.push({
+      category: "validation_failure",
+      path: "issue.acceptanceCriteria",
+      message: "Issue acceptance criteria are too broad for one lane run.",
+      severity: "blocker",
+    });
+  }
+}
+
+function validateBehaviorDeltas(
+  issue: IssueReadinessFacts,
+  diagnostics: IssueReadinessDiagnostic[],
+): void {
+  const behaviorDeltas = issue.behaviorDeltas ?? [];
+
+  if (behaviorDeltas.length === 0) {
+    diagnostics.push({
+      category: "behavior_delta_violation",
+      path: "issue.behaviorDeltas",
+      message: "Issue needs exactly one observable behavior delta.",
+      severity: "human",
+    });
+    return;
+  }
+
+  if (behaviorDeltas.length !== 1 || !allNonBlankStrings(behaviorDeltas)) {
+    diagnostics.push({
+      category: "behavior_delta_violation",
+      path: "issue.behaviorDeltas",
+      message: "Issue must describe exactly one observable behavior delta.",
+      severity: "blocker",
+    });
+  }
+}
+
+function validateScopeItems(
+  issue: IssueReadinessFacts,
+  diagnostics: IssueReadinessDiagnostic[],
+): void {
+  const scopeItems = issue.scopeItems ?? [];
+
+  if (scopeItems.length === 0) {
+    diagnostics.push({
+      category: "validation_failure",
+      path: "issue.scopeItems",
+      message: "Issue needs explicit bounded scope before lane execution.",
+      severity: "human",
+    });
+    return;
+  }
+
+  if (!allNonBlankStrings(scopeItems)) {
+    diagnostics.push({
+      category: "validation_failure",
+      path: "issue.scopeItems",
+      message: "Issue scope must contain only non-empty public text.",
+      severity: "blocker",
+    });
+  }
+
+  if (scopeItems.length > 8) {
+    diagnostics.push({
+      category: "validation_failure",
+      path: "issue.scopeItems",
+      message: "Issue scope is too broad for one lane run.",
+      severity: "blocker",
+    });
+  }
+}
+
+function validateCapabilities(
+  issue: IssueReadinessFacts,
+  supportedCapabilities: readonly string[],
+  diagnostics: IssueReadinessDiagnostic[],
+): void {
+  const requestedCapabilities = issue.requestedCapabilities ?? [];
+
+  requestedCapabilities.forEach((capability, index) => {
+    if (typeof capability !== "string" || !supportedCapabilities.includes(capability)) {
+      diagnostics.push({
+        category: "unsupported_capability",
+        path: `issue.requestedCapabilities[${index}]`,
+        message: "Issue requests an unsupported pre-execution capability.",
+        severity: "blocker",
+      });
+    }
+  });
+}
+
+function validateEipMajorVersion(
+  issue: IssueReadinessFacts,
+  supportedEipMajorVersions: readonly number[],
+  diagnostics: IssueReadinessDiagnostic[],
+): void {
+  if (
+    issue.eipMajorVersion !== undefined &&
+    (!Number.isSafeInteger(issue.eipMajorVersion) ||
+      !supportedEipMajorVersions.includes(issue.eipMajorVersion))
+  ) {
+    diagnostics.push({
+      category: "unsupported_eip_major_version",
+      path: "issue.eipMajorVersion",
+      message: "Issue references an unsupported EIP major version.",
+      severity: "blocker",
+    });
+  }
+}
+
+function validateTerminalState(
+  issue: IssueReadinessFacts,
+  diagnostics: IssueReadinessDiagnostic[],
+): void {
+  if (issue.terminalState !== undefined && issue.terminalState !== "open") {
+    diagnostics.push({
+      category: "unknown_failure",
+      path: "issue.terminalState",
+      message: "Issue terminal state is ambiguous or not open for readiness evaluation.",
+      severity: "blocker",
+    });
+  }
+}
+
+function validateUnsafeInputs(
+  issue: IssueReadinessFacts,
+  diagnostics: IssueReadinessDiagnostic[],
+): void {
+  issue.unsafeInputs?.forEach((_unsafeInput, index) => {
+    diagnostics.push({
+      category: "evidence_unavailable",
+      path: `issue.unsafeInputs[${index}]`,
+      message: "Issue readiness input contains unsafe or secret-like evidence.",
+      severity: "blocker",
+    });
+  });
+
+  const publicTextFields: readonly (readonly [string, string | undefined])[] = [
+    ["issue.bodyText", issue.bodyText],
+    ...(issue.acceptanceCriteria ?? []).map(
+      (value, index) => [`issue.acceptanceCriteria[${index}]`, value] as const,
+    ),
+    ...(issue.behaviorDeltas ?? []).map(
+      (value, index) => [`issue.behaviorDeltas[${index}]`, value] as const,
+    ),
+    ...(issue.scopeItems ?? []).map(
+      (value, index) => [`issue.scopeItems[${index}]`, value] as const,
+    ),
+  ];
+
+  for (const [path, value] of publicTextFields) {
+    if (
+      typeof value === "string" &&
+      (workstationLocalPathPattern.test(value) || secretLikeTextPattern.test(value))
+    ) {
+      diagnostics.push({
+        category: "evidence_unavailable",
+        path,
+        message: "Issue readiness input contains unsafe or secret-like evidence.",
+        severity: "blocker",
+      });
+    }
+  }
+}
+
 function validateLocalWorkItemTextField(
-  path: "title" | "source",
+  path: "id" | "title" | "source",
   value: unknown,
 ): WorkItemValidationIssue | undefined {
   if (typeof value !== "string" || value.length === 0) {
@@ -148,6 +509,10 @@ function validateLocalWorkItemTextField(
 
 function isLocalWorkItemId(value: unknown): value is string {
   return typeof value === "string" && localWorkItemIdPattern.test(value);
+}
+
+function allNonBlankStrings(values: readonly unknown[]): boolean {
+  return values.every((value) => typeof value === "string" && value.trim().length > 0);
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/test/issue-readiness.test.ts
+++ b/test/issue-readiness.test.ts
@@ -1,0 +1,210 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+import {
+  evaluateIssueReadiness,
+  type IssueReadinessInput,
+} from "../src/work-item/index.js";
+
+const runnableInput: IssueReadinessInput = {
+  workItem: {
+    id: "github:TommyKammy/Ensen-loop#57",
+    title: "LOOP-032: Add issue readiness evaluation",
+    source: "github-issue",
+    status: "ready",
+  },
+  scope: {
+    ownerControlled: true,
+  },
+  issue: {
+    acceptanceCriteria: [
+      "Readiness evaluation returns a parseable runnable result.",
+      "Readiness diagnostics remain pre-execution only.",
+    ],
+    behaviorDeltas: ["Add issue readiness evaluation before lane execution."],
+    scopeItems: ["Evaluate mapped WorkItem facts before worktree creation."],
+    requestedCapabilities: ["work-item-readiness"],
+    eipMajorVersion: 2,
+  },
+};
+
+test("returns a runnable readiness result for a bounded owner-controlled issue", () => {
+  const result = evaluateIssueReadiness(runnableInput);
+
+  assert.equal(result.status, "runnable");
+  assert.equal(result.runnable, true);
+  assert.equal(result.workItem.id, runnableInput.workItem.id);
+  assert.equal(result.workItem.title, runnableInput.workItem.title);
+  assert.deepEqual(result.diagnostics, [
+    {
+      category: "validation_failure",
+      path: "issue.behaviorDeltas",
+      message: "Issue has one observable behavior delta.",
+      severity: "info",
+    },
+  ]);
+  assert.deepEqual(result.boundary, {
+    capability: "work-item-readiness",
+    startsExecution: false,
+    emitsProtocolTerminalArtifact: false,
+    protocolRuntimeImported: false,
+    providerNeutral: true,
+  });
+});
+
+test("blocks multi-delta issues before lane execution", () => {
+  const result = evaluateIssueReadiness({
+    ...runnableInput,
+    issue: {
+      ...runnableInput.issue,
+      behaviorDeltas: [
+        "Add issue readiness evaluation.",
+        "Start lane execution from readiness.",
+      ],
+    },
+  });
+
+  assert.equal(result.status, "blocked");
+  assert.equal(result.runnable, false);
+  assert.deepEqual(result.diagnostics, [
+    {
+      category: "behavior_delta_violation",
+      path: "issue.behaviorDeltas",
+      message: "Issue must describe exactly one observable behavior delta.",
+      severity: "blocker",
+    },
+  ]);
+});
+
+test("blocks missing owner-controlled scope and unsafe issue inputs", () => {
+  const result = evaluateIssueReadiness({
+    ...runnableInput,
+    scope: {
+      ownerControlled: false,
+    },
+    issue: {
+      ...runnableInput.issue,
+      unsafeInputs: ["placeholder-token"],
+    },
+  });
+
+  assert.equal(result.status, "blocked");
+  assert.equal(result.runnable, false);
+  assert.deepEqual(result.diagnostics, [
+    {
+      category: "provider_rejection_before_run_binding",
+      path: "scope.ownerControlled",
+      message: "Issue scope must be explicitly owner-controlled before lane execution.",
+      severity: "blocker",
+    },
+    {
+      category: "evidence_unavailable",
+      path: "issue.unsafeInputs[0]",
+      message: "Issue readiness input contains unsafe or secret-like evidence.",
+      severity: "blocker",
+    },
+  ]);
+});
+
+test("blocks unsupported EIP major versions without producing terminal protocol output", () => {
+  const result = evaluateIssueReadiness({
+    ...runnableInput,
+    issue: {
+      ...runnableInput.issue,
+      eipMajorVersion: 3,
+    },
+  });
+
+  assert.equal(result.status, "blocked");
+  assert.equal(result.runnable, false);
+  assert.deepEqual(result.diagnostics, [
+    {
+      category: "unsupported_eip_major_version",
+      path: "issue.eipMajorVersion",
+      message: "Issue references an unsupported EIP major version.",
+      severity: "blocker",
+    },
+  ]);
+  assert.equal(result.boundary.emitsProtocolTerminalArtifact, false);
+});
+
+test("blocks oversized, unsupported-capability, and ambiguous terminal-state inputs", () => {
+  const result = evaluateIssueReadiness({
+    ...runnableInput,
+    issue: {
+      ...runnableInput.issue,
+      acceptanceCriteria: Array.from(
+        { length: 13 },
+        (_value, index) => `Criterion ${index + 1}`,
+      ),
+      requestedCapabilities: ["work-item-readiness", "submit"],
+      terminalState: "unknown",
+    },
+  });
+
+  assert.equal(result.status, "blocked");
+  assert.equal(result.runnable, false);
+  assert.deepEqual(result.diagnostics, [
+    {
+      category: "validation_failure",
+      path: "issue.acceptanceCriteria",
+      message: "Issue acceptance criteria are too broad for one lane run.",
+      severity: "blocker",
+    },
+    {
+      category: "unsupported_capability",
+      path: "issue.requestedCapabilities[1]",
+      message: "Issue requests an unsupported pre-execution capability.",
+      severity: "blocker",
+    },
+    {
+      category: "unknown_failure",
+      path: "issue.terminalState",
+      message: "Issue terminal state is ambiguous or not open for readiness evaluation.",
+      severity: "blocker",
+    },
+  ]);
+});
+
+test("routes ambiguous or underspecified issues to human refinement", () => {
+  const result = evaluateIssueReadiness({
+    ...runnableInput,
+    issue: {
+      ...runnableInput.issue,
+      acceptanceCriteria: [],
+      behaviorDeltas: [],
+      scopeItems: ["Clarify what should change."],
+    },
+  });
+
+  assert.equal(result.status, "needs-human-refinement");
+  assert.equal(result.runnable, false);
+  assert.deepEqual(result.diagnostics, [
+    {
+      category: "validation_failure",
+      path: "issue.acceptanceCriteria",
+      message: "Issue needs explicit acceptance criteria before lane execution.",
+      severity: "human",
+    },
+    {
+      category: "behavior_delta_violation",
+      path: "issue.behaviorDeltas",
+      message: "Issue needs exactly one observable behavior delta.",
+      severity: "human",
+    },
+  ]);
+});
+
+test("documents readiness as provider-neutral diagnostics without terminal protocol output", async () => {
+  const docs = await readFile("docs/reference/issue-readiness.md", "utf8");
+
+  assert.match(docs, /pre-execution diagnostic boundary/);
+  assert.match(docs, /provider-neutral WorkItem facts/);
+  assert.match(docs, /1 issue = 1 behavior delta/);
+  assert.match(docs, /does not create a worktree, start an agent/);
+  assert.match(docs, /not protocol terminal artifacts/);
+  assert.match(docs, /No dependency on Ensen-flow approval or workflow state/);
+  assert.doesNotMatch(docs, /\/Users\/[^/\s]+/);
+  assert.doesNotMatch(docs, /[A-Za-z]:\\Users\\/);
+});

--- a/test/issue-readiness.test.ts
+++ b/test/issue-readiness.test.ts
@@ -26,6 +26,7 @@ const runnableInput: IssueReadinessInput = {
     scopeItems: ["Evaluate mapped WorkItem facts before worktree creation."],
     requestedCapabilities: ["work-item-readiness"],
     eipMajorVersion: 2,
+    terminalState: "open",
   },
 };
 
@@ -167,6 +168,65 @@ test("blocks oversized, unsupported-capability, and ambiguous terminal-state inp
   ]);
 });
 
+test("blocks missing terminal state before readiness can become runnable", () => {
+  const result = evaluateIssueReadiness({
+    ...runnableInput,
+    issue: {
+      acceptanceCriteria: runnableInput.issue?.acceptanceCriteria,
+      behaviorDeltas: runnableInput.issue?.behaviorDeltas,
+      scopeItems: runnableInput.issue?.scopeItems,
+      requestedCapabilities: runnableInput.issue?.requestedCapabilities,
+      eipMajorVersion: runnableInput.issue?.eipMajorVersion,
+    },
+  });
+
+  assert.equal(result.status, "blocked");
+  assert.equal(result.runnable, false);
+  assert.deepEqual(result.diagnostics, [
+    {
+      category: "unknown_failure",
+      path: "issue.terminalState",
+      message: "Issue terminal state is ambiguous or not open for readiness evaluation.",
+      severity: "blocker",
+    },
+  ]);
+});
+
+test("blocks generic absolute local paths in public issue text without echoing them", () => {
+  const posixPath = ["", "tmp", "build", "output.log"].join("/");
+  const windowsDrivePath = ["D:", "agent", "work", "repo"].join("\\");
+  const uncPath = ["", "", "agent-share", "work", "repo"].join("\\");
+  const result = evaluateIssueReadiness({
+    ...runnableInput,
+    issue: {
+      ...runnableInput.issue,
+      bodyText: [
+        "Collect output from",
+        posixPath,
+        windowsDrivePath,
+        uncPath,
+        "before starting the lane.",
+      ].join(" "),
+    },
+  });
+
+  assert.equal(result.status, "blocked");
+  assert.equal(result.runnable, false);
+  assert.deepEqual(result.diagnostics, [
+    {
+      category: "evidence_unavailable",
+      path: "issue.bodyText",
+      message: "Issue readiness input contains unsafe or secret-like evidence.",
+      severity: "blocker",
+    },
+  ]);
+
+  const diagnosticText = JSON.stringify(result.diagnostics);
+  assert.doesNotMatch(diagnosticText, new RegExp(escapeRegExp(posixPath)));
+  assert.doesNotMatch(diagnosticText, new RegExp(escapeRegExp(windowsDrivePath)));
+  assert.doesNotMatch(diagnosticText, new RegExp(escapeRegExp(uncPath)));
+});
+
 test("routes ambiguous or underspecified issues to human refinement", () => {
   const result = evaluateIssueReadiness({
     ...runnableInput,
@@ -208,3 +268,7 @@ test("documents readiness as provider-neutral diagnostics without terminal proto
   assert.doesNotMatch(docs, /\/Users\/[^/\s]+/);
   assert.doesNotMatch(docs, /[A-Za-z]:\\Users\\/);
 });
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}


### PR DESCRIPTION
## Summary
- add provider-neutral issue readiness evaluation for WorkItem facts
- add 1 issue = 1 behavior delta lint and fail-closed readiness diagnostics
- document readiness as pre-execution diagnostics without protocol terminal artifacts

## Verification
- npm run typecheck -- --pretty false
- npm run build
- npm test

Closes #57

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an issue readiness evaluation that validates work items before execution and reports runnable / blocked / needs-human-refinement statuses with actionable diagnostics.

* **Documentation**
  * Added a reference guide describing readiness states, diagnostic categories/severities, lint signals, safety expectations (no secrets/local paths), and explicit non-goals.

* **Tests**
  * Added comprehensive tests covering readiness outcomes, diagnostic rules, evidence-safety checks, capability/version constraints, and boundary behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->