### PR TITLE
LOOP-033: Add worktree and branch lane run skeleton

### DIFF
--- a/docs/architecture/local-lane-execution.md
+++ b/docs/architecture/local-lane-execution.md
@@ -85,6 +85,24 @@ not start an agent, create SCM state, mutate GitHub, or delete unrelated files.
 Examples should use placeholders such as `<workspace-root>`, `<state-root>`,
 `<run-request-json-file>`, and `<supervisor-config-path>`.
 
+`planBranchLaneRunSkeleton()` is the dry-run-first Phase 3 helper for
+branch/worktree lane intent. It accepts one ready Work Item, one lane run id, one
+idempotency key, explicit `<repository-root>`, `<worktree-root>`, and
+`<state-root>` paths, an owner-controlled branch name, and an authoritative
+repository scope record. The default mode describes the intended branch,
+worktree path, state file path, idempotency fact, and provider non-actions
+without creating branch, worktree, change request, agent session, or local
+provider state.
+
+Prepare mode is explicit. It creates only the Ensen-loop local lane workspace
+and state directories, writes a queued LaneRunState, and records branch intent,
+repository scope, idempotency, and cleanup facts in the Lane Journal. It still
+does not call Git, create a branch, create a Git worktree, open a change request,
+or start an agent. If state persistence fails after local preparation, the
+helper removes the prepared lane workspace and state directory for that lane id
+and leaves unrelated files untouched. Later cleanup can use the journal cleanup
+fact and the lane id to remove the prepared local workspace and state directory.
+
 ## State Transitions
 
 LaneRunState is the authoritative lifecycle record for local lane execution.

--- a/src/lane/index.ts
+++ b/src/lane/index.ts
@@ -394,8 +394,12 @@ export async function planBranchLaneRunSkeleton(
   try {
     laneRunStatePath = await writeLaneRunState(stateRoot.inputPath, state);
   } catch (error) {
-    await rm(localSkeleton.workspacePath, { recursive: true, force: true });
-    await rm(localSkeleton.statePath, { recursive: true, force: true });
+    if (localSkeleton.created.workspace) {
+      await rm(localSkeleton.workspacePath, { recursive: true, force: true });
+    }
+    if (localSkeleton.created.state) {
+      await rm(localSkeleton.statePath, { recursive: true, force: true });
+    }
     throw error;
   }
 

--- a/src/lane/index.ts
+++ b/src/lane/index.ts
@@ -88,11 +88,79 @@ export interface PreparedLocalLaneWorkspace {
   };
 }
 
+export type BranchLaneRunSkeletonMode = "dry-run" | "prepare";
+
+export interface AuthoritativeLaneRunScope {
+  readonly ownerControlled: true;
+  readonly repositoryId: string;
+  readonly repositorySlug: string;
+  readonly repositoryRoot: string;
+}
+
+export interface PlanBranchLaneRunSkeletonInput {
+  readonly mode?: BranchLaneRunSkeletonMode;
+  readonly workItem: WorkItem;
+  readonly laneRunId: string;
+  readonly idempotencyKey: string;
+  readonly repositoryRoot: string;
+  readonly worktreeRoot: string;
+  readonly stateRoot: string;
+  readonly branchName: string;
+  readonly baseBranch?: string;
+  readonly authoritativeScope?: AuthoritativeLaneRunScope;
+  readonly allowedRepositoryRoots?: readonly string[];
+  readonly recordedAt?: string;
+}
+
+export interface BranchLaneRunSkeleton {
+  readonly mode: BranchLaneRunSkeletonMode;
+  readonly mutatesFilesystem: boolean;
+  readonly startsAgentExecution: false;
+  readonly createsBranch: false;
+  readonly opensChangeRequest: false;
+  readonly laneRunId: string;
+  readonly workItem: WorkItem;
+  readonly repository: {
+    readonly id: string;
+    readonly slug: string;
+  };
+  readonly branch: {
+    readonly name: string;
+    readonly base: string;
+  };
+  readonly worktree: {
+    readonly path: string;
+  };
+  readonly state: {
+    readonly root: string;
+    readonly stateDirectory: string;
+    readonly stateFile: string;
+  };
+  readonly idempotency: {
+    readonly key: string;
+    readonly intent: string;
+  };
+  readonly providerState: {
+    readonly agentProviderSessionCreated: false;
+    readonly scmBranchCreated: false;
+    readonly scmWorktreeCreated: false;
+    readonly changeRequestCreated: false;
+  };
+  readonly cleanup: {
+    readonly intent: string;
+  };
+  readonly localSkeleton?: PreparedLocalLaneWorkspace;
+  readonly laneRunStatePath?: string;
+}
+
 export const preparedLocalLaneMarkerFilename = ".ensen-loop-prepared.json";
 export const preparedLocalLaneMarkerSchemaVersion = "ensen.local-lane-prepared.v1";
 
 const laneRunIdPattern = /^[A-Za-z0-9][A-Za-z0-9._-]*$/;
 const localLaneDirectoryNamePattern = /^[A-Za-z0-9._-]{1,128}$/;
+const branchNamePattern = /^[A-Za-z0-9][A-Za-z0-9._/-]{0,159}$/;
+const repositorySlugPattern = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
+const idempotencyIntentPattern = /^[A-Za-z0-9][A-Za-z0-9._:-]{11,159}$/;
 const isoDateTimePattern =
   /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.\d+)?(Z|[+-]\d{2}:\d{2})$/;
 const laneRunStatuses = new Set<unknown>([
@@ -184,6 +252,158 @@ export async function prepareLocalLaneWorkspace(
 
     throw error;
   }
+}
+
+export async function planBranchLaneRunSkeleton(
+  input: PlanBranchLaneRunSkeletonInput,
+): Promise<BranchLaneRunSkeleton> {
+  const mode = input.mode ?? "dry-run";
+
+  if (mode !== "dry-run" && mode !== "prepare") {
+    throw new Error("Lane skeleton mode must be dry-run or prepare.");
+  }
+
+  assertReadyWorkItem(input.workItem);
+  assertSafeBranchName(input.branchName);
+  assertSafeBranchName(input.baseBranch ?? "main");
+  assertSafeIdempotencyKey(input.idempotencyKey);
+
+  const laneRunId = resolveLocalLaneDirectoryName({
+    laneRunId: input.laneRunId,
+    workItemId: input.workItem.id,
+  });
+  const scope = input.authoritativeScope;
+
+  if (scope === undefined) {
+    throw new Error("An authoritative repository scope is required before lane skeleton planning.");
+  }
+
+  validateAuthoritativeLaneRunScope(scope);
+
+  const repositoryRoot = await resolveCanonicalRepositoryRoot(input.repositoryRoot);
+  const scopedRepositoryRoot = await resolveCanonicalRepositoryRoot(scope.repositoryRoot);
+
+  if (repositoryRoot.realPath !== scopedRepositoryRoot.realPath) {
+    throw new Error("Repository root must match the authoritative repository scope.");
+  }
+
+  if (input.allowedRepositoryRoots !== undefined) {
+    await assertRepositoryRootAllowlisted(repositoryRoot.realPath, input.allowedRepositoryRoots);
+  }
+
+  const worktreeRoot = await resolveCanonicalLocalLaneRoot("workspace", input.worktreeRoot);
+  const stateRoot = await resolveCanonicalLocalLaneRoot("state", input.stateRoot);
+
+  if (worktreeRoot.realPath === stateRoot.realPath) {
+    throw new Error("Local lane worktree root and state root must be separate directories.");
+  }
+
+  const stateFile = resolveLaneRunStatePath(stateRoot.inputPath, laneRunId);
+  const stateDirectory = path.join(stateRoot.inputPath, "lane-runs", laneRunId);
+  const skeletonBase = {
+    mode,
+    mutatesFilesystem: mode === "prepare",
+    startsAgentExecution: false,
+    createsBranch: false,
+    opensChangeRequest: false,
+    laneRunId,
+    workItem: { ...input.workItem },
+    repository: {
+      id: scope.repositoryId,
+      slug: scope.repositorySlug,
+    },
+    branch: {
+      name: input.branchName,
+      base: input.baseBranch ?? "main",
+    },
+    worktree: {
+      path: path.join(worktreeRoot.inputPath, "lane-runs", laneRunId),
+    },
+    state: {
+      root: stateRoot.inputPath,
+      stateDirectory,
+      stateFile,
+    },
+    idempotency: {
+      key: input.idempotencyKey,
+      intent: "deduplicate later provider submit binding without starting execution",
+    },
+    providerState: {
+      agentProviderSessionCreated: false,
+      scmBranchCreated: false,
+      scmWorktreeCreated: false,
+      changeRequestCreated: false,
+    },
+    cleanup: {
+      intent: `cleanup: remove prepared local lane workspace and state directory for ${laneRunId}`,
+    },
+  } satisfies Omit<BranchLaneRunSkeleton, "localSkeleton" | "laneRunStatePath">;
+
+  if (mode === "dry-run") {
+    return skeletonBase;
+  }
+
+  const localSkeleton = await prepareLocalLaneWorkspace({
+    workspaceRoot: worktreeRoot.inputPath,
+    stateRoot: stateRoot.inputPath,
+    laneRunId,
+    workItemId: input.workItem.id,
+  });
+  const recordedAt = input.recordedAt ?? new Date().toISOString();
+  const state = createLaneRunState({
+    id: laneRunId,
+    workItemId: input.workItem.id,
+    status: "queued",
+    revision: 1,
+    createdAt: recordedAt,
+    updatedAt: recordedAt,
+    journal: createLaneJournal({
+      id: `journal-${laneRunId}`,
+      laneRunId,
+      workItemId: input.workItem.id,
+      entries: [
+        {
+          id: `${laneRunId}-scope`,
+          recordedAt,
+          kind: "hypothesis",
+          message: `authoritative scope: ${scope.repositorySlug} ${scope.repositoryId}`,
+        },
+        {
+          id: `${laneRunId}-branch`,
+          recordedAt,
+          kind: "change",
+          message: `branch intent: ${input.branchName} from ${input.baseBranch ?? "main"}`,
+        },
+        {
+          id: `${laneRunId}-idempotency`,
+          recordedAt,
+          kind: "change",
+          message: `idempotency key: ${input.idempotencyKey}`,
+        },
+        {
+          id: `${laneRunId}-cleanup`,
+          recordedAt,
+          kind: "next-action",
+          message: skeletonBase.cleanup.intent,
+        },
+      ],
+    }),
+  });
+  let laneRunStatePath: string | undefined;
+
+  try {
+    laneRunStatePath = await writeLaneRunState(stateRoot.inputPath, state);
+  } catch (error) {
+    await rm(localSkeleton.workspacePath, { recursive: true, force: true });
+    await rm(localSkeleton.statePath, { recursive: true, force: true });
+    throw error;
+  }
+
+  return {
+    ...skeletonBase,
+    localSkeleton,
+    laneRunStatePath,
+  };
 }
 
 export function serializeLaneRunState(state: LaneRunState): string {
@@ -315,6 +535,89 @@ interface PreparedLocalLanePath {
 interface CanonicalLocalLaneRoot {
   readonly inputPath: string;
   readonly realPath: string;
+}
+
+function assertReadyWorkItem(workItem: WorkItem): void {
+  if (!isNonEmptyString(workItem.id) || !isNonEmptyString(workItem.title) || !isNonEmptyString(workItem.source)) {
+    throw new Error("WorkItem scope is malformed.");
+  }
+
+  if (workItem.status !== "ready") {
+    throw new Error("WorkItem must be ready before lane skeleton planning.");
+  }
+}
+
+function assertSafeIdempotencyKey(idempotencyKey: string): void {
+  if (!idempotencyIntentPattern.test(idempotencyKey)) {
+    throw new Error("Idempotency key is unsafe for lane skeleton planning.");
+  }
+}
+
+function assertSafeBranchName(branchName: string): void {
+  if (
+    !branchNamePattern.test(branchName) ||
+    branchName.includes("..") ||
+    branchName.includes("//") ||
+    branchName.includes("@{") ||
+    branchName.includes("\\") ||
+    branchName.endsWith("/") ||
+    branchName.endsWith(".") ||
+    branchName.endsWith(".lock") ||
+    branchName.startsWith(".") ||
+    branchName.includes(" ")
+  ) {
+    throw new Error("Branch name is unsafe for lane skeleton planning.");
+  }
+}
+
+function validateAuthoritativeLaneRunScope(scope: AuthoritativeLaneRunScope): void {
+  if (
+    scope.ownerControlled !== true ||
+    !isNonEmptyString(scope.repositoryId) ||
+    !repositorySlugPattern.test(scope.repositorySlug) ||
+    !isNonEmptyString(scope.repositoryRoot)
+  ) {
+    throw new Error("Authoritative repository scope is malformed.");
+  }
+}
+
+async function assertRepositoryRootAllowlisted(
+  repositoryRealPath: string,
+  allowedRepositoryRoots: readonly string[],
+): Promise<void> {
+  for (const allowedRoot of allowedRepositoryRoots) {
+    const allowed = await resolveCanonicalRepositoryRoot(allowedRoot);
+
+    if (allowed.realPath === repositoryRealPath) {
+      return;
+    }
+  }
+
+  throw new Error("Repository root is not allowlisted for lane skeleton planning.");
+}
+
+async function resolveCanonicalRepositoryRoot(rootPath: string): Promise<CanonicalLocalLaneRoot> {
+  if (!path.isAbsolute(rootPath)) {
+    throw new Error("Repository root must be an absolute path.");
+  }
+
+  const resolvedRoot = path.resolve(rootPath);
+  const stats = await lstat(resolvedRoot).catch((error: unknown) => {
+    if (isNodeError(error) && error.code === "ENOENT") {
+      throw new Error("Repository root must exist before lane skeleton planning.");
+    }
+
+    throw error;
+  });
+
+  if (stats.isSymbolicLink() || !stats.isDirectory()) {
+    throw new Error("Repository root must be a real directory.");
+  }
+
+  return {
+    inputPath: resolvedRoot,
+    realPath: await realpath(resolvedRoot),
+  };
 }
 
 async function resolveCanonicalLocalLaneRoot(

--- a/test/lane-run-skeleton.test.ts
+++ b/test/lane-run-skeleton.test.ts
@@ -1,0 +1,239 @@
+import assert from "node:assert/strict";
+import { access, lstat, mkdir, mkdtemp, readFile, rm, symlink } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import {
+  planBranchLaneRunSkeleton,
+  readLaneRunState,
+} from "../src/lane/index.js";
+import type { WorkItem } from "../src/work-item/index.js";
+
+const readyWorkItem: WorkItem = {
+  id: "workitem_01HV7Y8M8F2KQ5W3P9R6T4N258",
+  title: "Add worktree and branch lane run skeleton",
+  source: "github-issue",
+  status: "ready",
+};
+
+test("dry-runs a deterministic branch/worktree lane skeleton without filesystem mutation", async () => {
+  const roots = await createSkeletonRoots();
+
+  try {
+    const skeleton = await planBranchLaneRunSkeleton({
+      workItem: readyWorkItem,
+      laneRunId: "run_01HV7Y8M8F2KQ5W3P9R6T4N258",
+      idempotencyKey: "issue-58-lane-skeleton-001",
+      repositoryRoot: roots.repositoryRoot,
+      worktreeRoot: roots.worktreeRoot,
+      stateRoot: roots.stateRoot,
+      branchName: "codex/issue-58",
+      authoritativeScope: {
+        ownerControlled: true,
+        repositoryId: "repo_01HV7Y8M8F2KQ5W3P9R6T4N2LOOP",
+        repositorySlug: "TommyKammy/Ensen-loop",
+        repositoryRoot: roots.repositoryRoot,
+      },
+    });
+
+    assert.equal(skeleton.mode, "dry-run");
+    assert.equal(skeleton.mutatesFilesystem, false);
+    assert.equal(skeleton.startsAgentExecution, false);
+    assert.equal(skeleton.createsBranch, false);
+    assert.equal(skeleton.opensChangeRequest, false);
+    assert.equal(skeleton.laneRunId, "run_01HV7Y8M8F2KQ5W3P9R6T4N258");
+    assert.equal(skeleton.workItem.id, readyWorkItem.id);
+    assert.equal(skeleton.branch.name, "codex/issue-58");
+    assert.equal(skeleton.worktree.path, path.join(roots.worktreeRoot, "lane-runs", skeleton.laneRunId));
+    assert.equal(skeleton.state.stateFile, path.join(roots.stateRoot, "lane-runs", `${skeleton.laneRunId}.json`));
+    assert.equal(skeleton.idempotency.key, "issue-58-lane-skeleton-001");
+    assert.deepEqual(skeleton.providerState, {
+      agentProviderSessionCreated: false,
+      scmBranchCreated: false,
+      scmWorktreeCreated: false,
+      changeRequestCreated: false,
+    });
+
+    await assert.rejects(() => access(path.join(roots.worktreeRoot, "lane-runs")), /ENOENT/);
+    await assert.rejects(() => access(path.join(roots.stateRoot, "lane-runs")), /ENOENT/);
+  } finally {
+    await roots.cleanup();
+  }
+});
+
+test("prepares a local skeleton tied to lane id, branch intent, scope, and restart facts", async () => {
+  const roots = await createSkeletonRoots();
+
+  try {
+    const skeleton = await planBranchLaneRunSkeleton({
+      mode: "prepare",
+      workItem: readyWorkItem,
+      laneRunId: "run_01HV7Y8M8F2KQ5W3P9R6T4N2RESTART",
+      idempotencyKey: "issue-58-lane-skeleton-restart",
+      repositoryRoot: roots.repositoryRoot,
+      worktreeRoot: roots.worktreeRoot,
+      stateRoot: roots.stateRoot,
+      branchName: "codex/issue-58-restart",
+      baseBranch: "main",
+      authoritativeScope: {
+        ownerControlled: true,
+        repositoryId: "repo_01HV7Y8M8F2KQ5W3P9R6T4N2LOOP",
+        repositorySlug: "TommyKammy/Ensen-loop",
+        repositoryRoot: roots.repositoryRoot,
+      },
+    });
+
+    assert.equal(skeleton.mode, "prepare");
+    assert.equal(skeleton.mutatesFilesystem, true);
+    assert.equal(skeleton.localSkeleton?.created.workspace, true);
+    assert.equal(skeleton.localSkeleton?.created.state, true);
+    assert.equal(skeleton.startsAgentExecution, false);
+    assert.equal(skeleton.createsBranch, false);
+    assert.equal(skeleton.opensChangeRequest, false);
+
+    const state = await readLaneRunState(roots.stateRoot, skeleton.laneRunId);
+    assert.equal(state.id, skeleton.laneRunId);
+    assert.equal(state.workItemId, readyWorkItem.id);
+    assert.equal(state.status, "queued");
+    assert.equal(state.startsAgentExecution, false);
+
+    const journalText = state.journal.entries.map((entry) => entry.message).join("\n");
+    assert.match(journalText, /branch intent: codex\/issue-58-restart from main/);
+    assert.match(journalText, /authoritative scope: TommyKammy\/Ensen-loop repo_01HV7Y8M8F2KQ5W3P9R6T4N2LOOP/);
+    assert.match(journalText, /idempotency key: issue-58-lane-skeleton-restart/);
+    assert.match(journalText, /cleanup: remove prepared local lane workspace and state directory for run_01HV7Y8M8F2KQ5W3P9R6T4N2RESTART/);
+    assert.equal(JSON.stringify(state).includes(roots.repositoryRoot), false);
+    assert.equal(JSON.stringify(state).includes(roots.worktreeRoot), false);
+
+    assert.equal(
+      await readFile(path.join(skeleton.localSkeleton!.workspacePath, ".ensen-loop-prepared.json"), "utf8")
+        .then((value) => JSON.parse(value).laneRunId),
+      skeleton.laneRunId,
+    );
+  } finally {
+    await roots.cleanup();
+  }
+});
+
+test("fails closed before mutation for unsafe branch, missing scope, symlink root, and disallowed repository", async () => {
+  const roots = await createSkeletonRoots();
+  const outsideRoot = await mkdtemp(path.join(os.tmpdir(), "ensen-loop-outside-repo-"));
+  const symlinkRoot = path.join(os.tmpdir(), `ensen-loop-repo-link-${process.pid}`);
+
+  try {
+    await symlink(roots.repositoryRoot, symlinkRoot, "dir");
+
+    await assert.rejects(
+      () =>
+        planBranchLaneRunSkeleton({
+          mode: "prepare",
+          workItem: readyWorkItem,
+          laneRunId: "run_unsafe_branch",
+          idempotencyKey: "issue-58-lane-skeleton-unsafe",
+          repositoryRoot: roots.repositoryRoot,
+          worktreeRoot: roots.worktreeRoot,
+          stateRoot: roots.stateRoot,
+          branchName: "../escape",
+          authoritativeScope: {
+            ownerControlled: true,
+            repositoryId: "repo_allowed",
+            repositorySlug: "TommyKammy/Ensen-loop",
+            repositoryRoot: roots.repositoryRoot,
+          },
+        }),
+      /Branch name is unsafe/,
+    );
+    await assert.rejects(() => access(path.join(roots.worktreeRoot, "lane-runs")), /ENOENT/);
+
+    await assert.rejects(
+      () =>
+        planBranchLaneRunSkeleton({
+          mode: "prepare",
+          workItem: readyWorkItem,
+          laneRunId: "run_missing_scope",
+          idempotencyKey: "issue-58-lane-skeleton-missing-scope",
+          repositoryRoot: roots.repositoryRoot,
+          worktreeRoot: roots.worktreeRoot,
+          stateRoot: roots.stateRoot,
+          branchName: "codex/issue-58",
+        }),
+      /authoritative repository scope is required/,
+    );
+
+    await assert.rejects(
+      () =>
+        planBranchLaneRunSkeleton({
+          mode: "prepare",
+          workItem: readyWorkItem,
+          laneRunId: "run_symlink_root",
+          idempotencyKey: "issue-58-lane-skeleton-symlink-root",
+          repositoryRoot: symlinkRoot,
+          worktreeRoot: roots.worktreeRoot,
+          stateRoot: roots.stateRoot,
+          branchName: "codex/issue-58",
+          authoritativeScope: {
+            ownerControlled: true,
+            repositoryId: "repo_allowed",
+            repositorySlug: "TommyKammy/Ensen-loop",
+            repositoryRoot: symlinkRoot,
+          },
+        }),
+      /Repository root must be a real directory/,
+    );
+
+    await assert.rejects(
+      () =>
+        planBranchLaneRunSkeleton({
+          mode: "prepare",
+          workItem: readyWorkItem,
+          laneRunId: "run_disallowed_repo",
+          idempotencyKey: "issue-58-lane-skeleton-disallowed",
+          repositoryRoot: outsideRoot,
+          worktreeRoot: roots.worktreeRoot,
+          stateRoot: roots.stateRoot,
+          branchName: "codex/issue-58",
+          allowedRepositoryRoots: [roots.repositoryRoot],
+          authoritativeScope: {
+            ownerControlled: true,
+            repositoryId: "repo_disallowed",
+            repositorySlug: "TommyKammy/Other",
+            repositoryRoot: outsideRoot,
+          },
+        }),
+      /Repository root is not allowlisted/,
+    );
+
+    await assert.rejects(() => access(path.join(roots.worktreeRoot, "lane-runs")), /ENOENT/);
+    await assert.rejects(() => access(path.join(roots.stateRoot, "lane-runs")), /ENOENT/);
+  } finally {
+    await roots.cleanup();
+    await rm(outsideRoot, { recursive: true, force: true });
+    await rm(symlinkRoot, { force: true });
+  }
+});
+
+async function createSkeletonRoots(): Promise<{
+  readonly repositoryRoot: string;
+  readonly worktreeRoot: string;
+  readonly stateRoot: string;
+  readonly cleanup: () => Promise<void>;
+}> {
+  const root = await mkdtemp(path.join(os.tmpdir(), "ensen-loop-skeleton-"));
+  const repositoryRoot = path.join(root, "repo");
+  const worktreeRoot = path.join(root, "worktrees");
+  const stateRoot = path.join(root, "state");
+
+  await mkdir(repositoryRoot);
+  await mkdir(worktreeRoot);
+  await mkdir(stateRoot);
+
+  return {
+    repositoryRoot,
+    worktreeRoot,
+    stateRoot,
+    cleanup: async () => {
+      await rm(root, { recursive: true, force: true });
+    },
+  };
+}

--- a/test/lane-run-skeleton.test.ts
+++ b/test/lane-run-skeleton.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { access, lstat, mkdir, mkdtemp, readFile, rm, symlink } from "node:fs/promises";
+import { access, lstat, mkdir, mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -119,7 +119,7 @@ test("prepares a local skeleton tied to lane id, branch intent, scope, and resta
 test("fails closed before mutation for unsafe branch, missing scope, symlink root, and disallowed repository", async () => {
   const roots = await createSkeletonRoots();
   const outsideRoot = await mkdtemp(path.join(os.tmpdir(), "ensen-loop-outside-repo-"));
-  const symlinkRoot = path.join(os.tmpdir(), `ensen-loop-repo-link-${process.pid}`);
+  const symlinkRoot = path.join(outsideRoot, "repo-symlink");
 
   try {
     await symlink(roots.repositoryRoot, symlinkRoot, "dir");
@@ -210,6 +210,50 @@ test("fails closed before mutation for unsafe branch, missing scope, symlink roo
     await roots.cleanup();
     await rm(outsideRoot, { recursive: true, force: true });
     await rm(symlinkRoot, { force: true });
+  }
+});
+
+test("preserves pre-existing local skeleton directories when state persistence fails", async () => {
+  const roots = await createSkeletonRoots();
+  const laneRunId = "run_existing_local_skeleton";
+  const existingWorkspacePath = path.join(roots.worktreeRoot, "lane-runs", laneRunId);
+  const existingStatePath = path.join(roots.stateRoot, "lane-runs", laneRunId);
+  const blockedStateFilePath = path.join(roots.stateRoot, "lane-runs", `${laneRunId}.json`);
+
+  try {
+    await mkdir(existingWorkspacePath, { recursive: true });
+    await mkdir(existingStatePath, { recursive: true });
+    await mkdir(blockedStateFilePath, { recursive: true });
+    await writeFile(path.join(existingWorkspacePath, "pre-existing.txt"), "keep workspace\n", "utf8");
+    await writeFile(path.join(existingStatePath, "pre-existing.txt"), "keep state\n", "utf8");
+
+    await assert.rejects(
+      () =>
+        planBranchLaneRunSkeleton({
+          mode: "prepare",
+          workItem: readyWorkItem,
+          laneRunId,
+          idempotencyKey: "issue-58-lane-skeleton-existing-fail",
+          repositoryRoot: roots.repositoryRoot,
+          worktreeRoot: roots.worktreeRoot,
+          stateRoot: roots.stateRoot,
+          branchName: "codex/issue-58-existing-fail",
+          authoritativeScope: {
+            ownerControlled: true,
+            repositoryId: "repo_01HV7Y8M8F2KQ5W3P9R6T4N2LOOP",
+            repositorySlug: "TommyKammy/Ensen-loop",
+            repositoryRoot: roots.repositoryRoot,
+          },
+        }),
+      /Lane run state file path must be a regular file/,
+    );
+
+    assert.equal((await lstat(existingWorkspacePath)).isDirectory(), true);
+    assert.equal((await lstat(existingStatePath)).isDirectory(), true);
+    assert.equal(await readFile(path.join(existingWorkspacePath, "pre-existing.txt"), "utf8"), "keep workspace\n");
+    assert.equal(await readFile(path.join(existingStatePath, "pre-existing.txt"), "utf8"), "keep state\n");
+  } finally {
+    await roots.cleanup();
   }
 });
 


### PR DESCRIPTION
## Summary
- Add dry-run-first branch/worktree lane skeleton planning from a ready WorkItem
- Validate repository scope, branch names, roots, and allowlisted repositories before prepare-mode mutation
- Persist queued LaneRunState with branch, scope, idempotency, and cleanup journal facts in explicit prepare mode

## Verification
- npm run typecheck
- npm run build
- npm test

Closes #58

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added branch lane skeleton planning with dry-run and prepare modes for initializing lane runs, with enhanced validation, idempotency, and repository/worktree/state safety.

* **Tests**
  * Added tests covering dry-run results, prepare-mode persistence, fail-safe behavior when state persistence fails, and safety/allowlist rejection scenarios.

* **Documentation**
  * Added architecture docs describing skeleton planning inputs, prepare-mode behavior, and safety/cleanup guarantees.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->