### PR TITLE
[codex] Add Codex agent adapter boundary

### DIFF
--- a/docs/architecture/provider-capabilities.md
+++ b/docs/architecture/provider-capabilities.md
@@ -30,6 +30,26 @@ Core lane logic may decide that a Lane Run needs dry-run or execute capability.
 It must not start provider sessions, shell out to provider commands, or encode
 provider-specific command arguments as core model vocabulary.
 
+## Codex AgentProvider Boundary
+
+The Phase 4 Codex adapter boundary publishes operation-level capability evidence
+against protocol `v0.2.0` before any operation is treated as available:
+
+| Operation | Support level | Boundary behavior |
+| --- | --- | --- |
+| `submit` | `supported` | May be planned as the execute-capable boundary only after explicit execute posture, repo-relative workspace, owner-controlled scope, and idempotency binding are present. |
+| `status` | `partial` | Must fail closed for authoritative status polling; partial Codex observations are diagnostics, not RunStatusSnapshot truth. |
+| `cancel` | `unsupported` | Must fail closed and must not mark a lane run cancelled without an authoritative cancellation boundary. |
+| `fetchEvidence` | `partial` | May describe references or diagnostics, but must not claim durable evidence fetch support. |
+| `polling` | `partial` | Must not fabricate polling support or infer lifecycle state from Codex naming or operator text. |
+| `evidenceReferences` | `supported` | May publish sanitized evidence-reference facts without raw evidence bodies, secrets, or host-local absolute paths. |
+| `idempotency` | `supported` | Required for execute intent before `submit` can be considered ready. |
+
+Dry-run remains the default Codex intent. It describes the adapter invocation and
+records capability evidence without starting a Codex session. Execute intent is a
+separate guarded fact surface; it is still represented without starting a
+provider session until a later invocation layer owns that side effect.
+
 ## Dogfood Adapter Positions
 
 The first dogfood slice can use a GitHub adapter for SCMProvider behavior and a

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -3,3 +3,225 @@ export {
   type AgentProvider,
   type AgentProviderCapability,
 } from "../core/index.js";
+
+export type CodexProviderOperation =
+  | "submit"
+  | "status"
+  | "cancel"
+  | "fetchEvidence"
+  | "polling"
+  | "evidenceReferences"
+  | "idempotency";
+
+export type CodexProviderSupportLevel = "supported" | "partial" | "unsupported";
+
+export interface CodexAgentProviderCapabilityEvidence {
+  readonly protocolVersion: "0.2.0";
+  readonly operations: Readonly<Record<CodexProviderOperation, CodexProviderSupportLevel>>;
+}
+
+export type CodexAgentInvocationMode = "dry-run" | "execute";
+
+export interface CodexAgentWorkspaceFact {
+  readonly kind: "repo-relative";
+  readonly path: string;
+}
+
+export interface CodexAgentScopeBinding {
+  readonly owner: string;
+  readonly repository: string;
+  readonly issueNumber: number;
+}
+
+export interface CodexAgentIdempotencyBinding {
+  readonly key: string;
+  readonly scopeFingerprint: string;
+}
+
+export interface CreateCodexAgentInvocationIntentInput {
+  readonly mode?: CodexAgentInvocationMode;
+  readonly capabilityEvidence: CodexAgentProviderCapabilityEvidence;
+  readonly workspace?: CodexAgentWorkspaceFact;
+  readonly allowedExecutionPosture?: "dry-run-only" | "execute-enabled";
+  readonly scope?: CodexAgentScopeBinding;
+  readonly idempotencyBinding?: CodexAgentIdempotencyBinding;
+}
+
+export interface CodexAgentInvocationIntent {
+  readonly ok: boolean;
+  readonly provider: "codex";
+  readonly mode: CodexAgentInvocationMode;
+  readonly capabilityEvidence: CodexAgentProviderCapabilityEvidence;
+  readonly invocation: {
+    readonly intent: "describe-codex-invocation" | "execute-codex-invocation";
+    readonly startsProviderSession: false;
+    readonly operation: "submit";
+  };
+  readonly outcome: "planned" | "ready-to-invoke" | "blocked";
+  readonly diagnostics: readonly string[];
+}
+
+export interface CodexProviderOperationAvailable {
+  readonly ok: true;
+}
+
+export interface CodexProviderOperationUnavailable {
+  readonly ok: false;
+  readonly diagnostic: string;
+}
+
+export type CodexProviderOperationAvailability =
+  | CodexProviderOperationAvailable
+  | CodexProviderOperationUnavailable;
+
+const repoRelativeWorkspacePattern = /^(?:\.|[A-Za-z0-9._-][A-Za-z0-9._/-]*)$/;
+const idempotencyKeyPattern = /^[A-Za-z0-9][A-Za-z0-9._:-]{11,159}$/;
+
+export const CODEX_AGENT_PROVIDER_CAPABILITY_EVIDENCE: CodexAgentProviderCapabilityEvidence =
+  Object.freeze({
+    protocolVersion: "0.2.0",
+    operations: Object.freeze({
+      submit: "supported",
+      status: "partial",
+      cancel: "unsupported",
+      fetchEvidence: "partial",
+      polling: "partial",
+      evidenceReferences: "supported",
+      idempotency: "supported",
+    } as const),
+  });
+
+export function createCodexAgentInvocationIntent(
+  input: CreateCodexAgentInvocationIntentInput,
+): CodexAgentInvocationIntent {
+  const mode = input.mode ?? "dry-run";
+  const diagnostics = validateCommonBoundary(input);
+
+  if (mode === "execute") {
+    diagnostics.push(...validateExecuteBoundary(input));
+  }
+
+  const ok = diagnostics.length === 0;
+
+  return {
+    ok,
+    provider: "codex",
+    mode,
+    capabilityEvidence: input.capabilityEvidence,
+    invocation: {
+      intent: mode === "execute" ? "execute-codex-invocation" : "describe-codex-invocation",
+      startsProviderSession: false,
+      operation: "submit",
+    },
+    outcome: ok ? (mode === "execute" ? "ready-to-invoke" : "planned") : "blocked",
+    diagnostics,
+  };
+}
+
+export function requireCodexProviderOperation(
+  evidence: CodexAgentProviderCapabilityEvidence,
+  operation: CodexProviderOperation,
+): CodexProviderOperationAvailability {
+  const supportLevel = evidence.operations[operation];
+
+  if (supportLevel === "supported") {
+    return { ok: true };
+  }
+
+  return {
+    ok: false,
+    diagnostic: `Codex provider operation ${operation} is ${supportLevel}, not supported.`,
+  };
+}
+
+function validateCommonBoundary(input: CreateCodexAgentInvocationIntentInput): string[] {
+  const diagnostics: string[] = [];
+
+  if (input.capabilityEvidence.protocolVersion !== "0.2.0") {
+    diagnostics.push("Codex adapter capability evidence must target protocol v0.2.0.");
+  }
+
+  for (const operation of requiredOperations) {
+    const supportLevel = input.capabilityEvidence.operations[operation];
+
+    if (!isSupportLevel(supportLevel)) {
+      diagnostics.push(`Codex provider operation ${operation} is missing capability evidence.`);
+    }
+  }
+
+  if (input.workspace === undefined) {
+    diagnostics.push("Codex adapter workspace is required.");
+  } else if (
+    input.workspace.kind !== "repo-relative" ||
+    !repoRelativeWorkspacePattern.test(input.workspace.path) ||
+    input.workspace.path.includes("..")
+  ) {
+    diagnostics.push("Codex adapter workspace must be a repo-relative path without traversal.");
+  }
+
+  return diagnostics;
+}
+
+function validateExecuteBoundary(input: CreateCodexAgentInvocationIntentInput): string[] {
+  const diagnostics: string[] = [];
+
+  if (input.allowedExecutionPosture !== "execute-enabled") {
+    diagnostics.push("Codex execute posture is not enabled by explicit local configuration.");
+  }
+
+  if (!isSafeScope(input.scope)) {
+    diagnostics.push("Codex execute intent requires owner-controlled scope binding.");
+  }
+
+  if (!isSafeIdempotencyBinding(input.idempotencyBinding)) {
+    diagnostics.push("Codex execute intent requires idempotency binding.");
+  }
+
+  const submitAvailability = requireCodexProviderOperation(input.capabilityEvidence, "submit");
+
+  if (!submitAvailability.ok) {
+    diagnostics.push(submitAvailability.diagnostic);
+  }
+
+  const idempotencyAvailability = requireCodexProviderOperation(input.capabilityEvidence, "idempotency");
+
+  if (!idempotencyAvailability.ok) {
+    diagnostics.push(idempotencyAvailability.diagnostic);
+  }
+
+  return diagnostics;
+}
+
+function isSafeScope(scope: CodexAgentScopeBinding | undefined): scope is CodexAgentScopeBinding {
+  return (
+    scope !== undefined &&
+    /^[A-Za-z0-9_.-]{1,100}$/.test(scope.owner) &&
+    /^[A-Za-z0-9_.-]{1,100}$/.test(scope.repository) &&
+    Number.isSafeInteger(scope.issueNumber) &&
+    scope.issueNumber > 0
+  );
+}
+
+function isSafeIdempotencyBinding(
+  binding: CodexAgentIdempotencyBinding | undefined,
+): binding is CodexAgentIdempotencyBinding {
+  return (
+    binding !== undefined &&
+    idempotencyKeyPattern.test(binding.key) &&
+    /^[A-Za-z0-9._:-]{12,160}$/.test(binding.scopeFingerprint)
+  );
+}
+
+function isSupportLevel(value: unknown): value is CodexProviderSupportLevel {
+  return value === "supported" || value === "partial" || value === "unsupported";
+}
+
+const requiredOperations = Object.freeze([
+  "submit",
+  "status",
+  "cancel",
+  "fetchEvidence",
+  "polling",
+  "evidenceReferences",
+  "idempotency",
+] as const satisfies readonly CodexProviderOperation[]);

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -154,7 +154,7 @@ function validateCommonBoundary(input: CreateCodexAgentInvocationIntentInput): s
   } else if (
     input.workspace.kind !== "repo-relative" ||
     !repoRelativeWorkspacePattern.test(input.workspace.path) ||
-    input.workspace.path.includes("..")
+    input.workspace.path.split("/").some((segment) => segment === "..")
   ) {
     diagnostics.push("Codex adapter workspace must be a repo-relative path without traversal.");
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ export function describeProduct(): string {
 }
 
 export * from "./core/index.js";
+export * from "./agent/index.js";
 export * from "./executor/index.js";
 export * from "./lane/index.js";
 export * from "./protocol/index.js";

--- a/test/codex-agent-adapter.test.ts
+++ b/test/codex-agent-adapter.test.ts
@@ -1,0 +1,137 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  CODEX_AGENT_PROVIDER_CAPABILITY_EVIDENCE,
+  createCodexAgentInvocationIntent,
+  requireCodexProviderOperation,
+} from "../src/agent/index.js";
+
+const capabilityEvidence = CODEX_AGENT_PROVIDER_CAPABILITY_EVIDENCE;
+
+test("represents Codex dry-run intent without starting a provider session", () => {
+  const intent = createCodexAgentInvocationIntent({
+    capabilityEvidence,
+    workspace: {
+      kind: "repo-relative",
+      path: ".",
+    },
+  });
+
+  assert.equal(intent.ok, true);
+  assert.equal(intent.mode, "dry-run");
+  assert.equal(intent.invocation.startsProviderSession, false);
+  assert.equal(intent.invocation.intent, "describe-codex-invocation");
+  assert.equal(intent.outcome, "planned");
+  assert.deepEqual(intent.capabilityEvidence.operations, capabilityEvidence.operations);
+});
+
+test("fails closed before Codex execute intent when scope, posture, or idempotency binding is missing", () => {
+  const intent = createCodexAgentInvocationIntent({
+    mode: "execute",
+    capabilityEvidence,
+    workspace: {
+      kind: "repo-relative",
+      path: ".",
+    },
+    allowedExecutionPosture: "dry-run-only",
+  });
+
+  assert.equal(intent.ok, false);
+  assert.equal(intent.mode, "execute");
+  assert.equal(intent.invocation.startsProviderSession, false);
+  assert.equal(intent.outcome, "blocked");
+  assert.match(intent.diagnostics.join("\n"), /execute posture is not enabled/i);
+  assert.match(intent.diagnostics.join("\n"), /owner-controlled scope/i);
+  assert.match(intent.diagnostics.join("\n"), /idempotency binding/i);
+});
+
+test("separates guarded Codex execute intent from dry-run preview", () => {
+  const intent = createCodexAgentInvocationIntent({
+    mode: "execute",
+    capabilityEvidence,
+    workspace: {
+      kind: "repo-relative",
+      path: ".",
+    },
+    allowedExecutionPosture: "execute-enabled",
+    scope: {
+      owner: "TommyKammy",
+      repository: "Ensen-loop",
+      issueNumber: 59,
+    },
+    idempotencyBinding: {
+      key: "issue-59-codex-submit",
+      scopeFingerprint: "TommyKammy-Ensen-loop-59",
+    },
+  });
+
+  assert.equal(intent.ok, true);
+  assert.equal(intent.mode, "execute");
+  assert.equal(intent.invocation.intent, "execute-codex-invocation");
+  assert.equal(intent.invocation.startsProviderSession, false);
+  assert.equal(intent.outcome, "ready-to-invoke");
+  assert.deepEqual(intent.diagnostics, []);
+});
+
+test("requires authoritative capability support before status or cancellation operations", () => {
+  assert.deepEqual(requireCodexProviderOperation(capabilityEvidence, "status"), {
+    ok: false,
+    diagnostic: "Codex provider operation status is partial, not supported.",
+  });
+
+  assert.deepEqual(requireCodexProviderOperation(capabilityEvidence, "cancel"), {
+    ok: false,
+    diagnostic: "Codex provider operation cancel is unsupported, not supported.",
+  });
+
+  assert.deepEqual(requireCodexProviderOperation(capabilityEvidence, "submit"), {
+    ok: true,
+  });
+});
+
+test("sanitizes Codex boundary diagnostics instead of echoing unsafe local inputs", () => {
+  const intent = createCodexAgentInvocationIntent({
+    mode: "execute",
+    capabilityEvidence,
+    workspace: {
+      kind: "repo-relative",
+      path: "/Users/example/project",
+    },
+    allowedExecutionPosture: "execute-enabled",
+    scope: {
+      owner: "TommyKammy",
+      repository: "Ensen-loop",
+      issueNumber: 59,
+    },
+    idempotencyBinding: {
+      key: "TODO",
+      scopeFingerprint: "unsafe",
+    },
+  });
+
+  const diagnostics = intent.diagnostics.join("\n");
+
+  assert.equal(intent.ok, false);
+  assert.doesNotMatch(diagnostics, /\/Users\/example\/project/);
+  assert.doesNotMatch(diagnostics, /\bTODO\b/);
+  assert.match(diagnostics, /repo-relative path without traversal/i);
+  assert.match(diagnostics, /idempotency binding/i);
+});
+
+test("publishes frozen Codex provider capability evidence for protocol v0.2.0 operations", () => {
+  assert.equal(Object.isFrozen(CODEX_AGENT_PROVIDER_CAPABILITY_EVIDENCE), true);
+  assert.equal(Object.isFrozen(CODEX_AGENT_PROVIDER_CAPABILITY_EVIDENCE.operations), true);
+  assert.deepEqual(CODEX_AGENT_PROVIDER_CAPABILITY_EVIDENCE, {
+    protocolVersion: "0.2.0",
+    operations: {
+      submit: "supported",
+      status: "partial",
+      cancel: "unsupported",
+      fetchEvidence: "partial",
+      polling: "partial",
+      evidenceReferences: "supported",
+      idempotency: "supported",
+    },
+  });
+});

--- a/test/codex-agent-adapter.test.ts
+++ b/test/codex-agent-adapter.test.ts
@@ -74,6 +74,19 @@ test("separates guarded Codex execute intent from dry-run preview", () => {
   assert.deepEqual(intent.diagnostics, []);
 });
 
+test("allows repo-relative workspace names that contain literal double-dot text", () => {
+  const intent = createCodexAgentInvocationIntent({
+    capabilityEvidence,
+    workspace: {
+      kind: "repo-relative",
+      path: "fixtures/v1..legacy",
+    },
+  });
+
+  assert.equal(intent.ok, true);
+  assert.deepEqual(intent.diagnostics, []);
+});
+
 test("requires authoritative capability support before status or cancellation operations", () => {
   assert.deepEqual(requireCodexProviderOperation(capabilityEvidence, "status"), {
     ok: false,
@@ -96,7 +109,7 @@ test("sanitizes Codex boundary diagnostics instead of echoing unsafe local input
     capabilityEvidence,
     workspace: {
       kind: "repo-relative",
-      path: "/Users/example/project",
+      path: "../secret/../../etc/passwd",
     },
     allowedExecutionPosture: "execute-enabled",
     scope: {
@@ -113,7 +126,7 @@ test("sanitizes Codex boundary diagnostics instead of echoing unsafe local input
   const diagnostics = intent.diagnostics.join("\n");
 
   assert.equal(intent.ok, false);
-  assert.doesNotMatch(diagnostics, /\/Users\/example\/project/);
+  assert.doesNotMatch(diagnostics, /\.\.\/secret/);
   assert.doesNotMatch(diagnostics, /\bTODO\b/);
   assert.match(diagnostics, /repo-relative path without traversal/i);
   assert.match(diagnostics, /idempotency binding/i);


### PR DESCRIPTION
## Summary
- add a pure Codex AgentProvider adapter boundary with dry-run default and guarded execute intent
- publish frozen protocol v0.2.0 operation support evidence for submit, status, cancel, fetchEvidence, polling, evidence references, and idempotency
- document partial/unsupported operation behavior and add focused regression coverage for fail-closed diagnostics

## Verification
- npm run typecheck
- npm run build && node --test dist/test/codex-agent-adapter.test.js && npm test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Codex agent provider capability support with operation-level boundaries, protocol v0.2.0 validation, and intent modes (dry-run vs execute).  
  * Exposed the agent capability API at the package root.

* **Documentation**
  * Documented provider operation support levels, boundary behaviors, and intent/execute constraints.

* **Tests**
  * Added tests for invocation intent creation, availability validation, diagnostics sanitization, and protocol conformance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->