### PR TITLE
LOOP-035: Add patch and PR draft artifact output

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ The Phase 1 local Work Item validation skeleton is documented in [docs/reference
 
 GitHub issue pickup is documented in [docs/reference/github-work-item-pickup.md](docs/reference/github-work-item-pickup.md). It is an owner-controlled, allowlisted, read-only SCMProvider `work-item-pickup` boundary that maps already-loaded GitHub issue facts into provider-neutral Work Item facts without mutating GitHub state or starting execution.
 
+Phase 4 patch and PR draft artifact output is documented in [docs/reference/lane-artifact-output.md](docs/reference/lane-artifact-output.md). It emits reviewable metadata for completed lane runs without embedding evidence payloads, opening pull requests, claiming merge readiness, or bypassing human review.
+
 The copied Ensen-protocol v0.1.0 schema and conformance fixture snapshot is documented in [protocol-snapshots/ensen-protocol/v0.1.0/README.md](protocol-snapshots/ensen-protocol/v0.1.0/README.md). It is repo-owned fixture data, not a mutable shared runtime dependency.
 
 ## Commands

--- a/docs/reference/lane-artifact-output.md
+++ b/docs/reference/lane-artifact-output.md
@@ -1,0 +1,44 @@
+# Lane Artifact Output
+
+Phase 4 lane artifact output is a review surface for completed local lane runs.
+It can describe a patch artifact reference or a PR draft intent, but it does not
+create pull requests, merge branches, declare production readiness, or replace
+human review.
+
+## Artifact Boundary
+
+Artifact metadata is tied to the authoritative Lane Run state, Work Item,
+branch facts, repo-relative worktree facts, AgentProvider outcome,
+verification-intent commands, provider capability evidence, and evidence
+references. A lane run must be completed before artifact output is emitted.
+Status snapshots, provider prose, retries, timeout summaries, or operator text
+must not be used to synthesize a terminal artifact.
+
+Artifact paths are public review metadata. They must stay repo-relative under
+`artifacts/`, avoid traversal, and avoid raw secrets or workstation-local
+absolute paths. Public artifact output must not embed raw evidence bodies,
+customer data, repository mutation payloads, credentials, or local machine
+paths.
+
+## Protocol v0.2.0 Evidence Boundary
+
+Protocol `v0.2.0` capability evidence keeps terminal result facts separate from
+EvidenceBundleRef-compatible metadata. Lane artifact output may reference
+evidence with sanitized bundle identifiers and safe URIs, but it must not embed
+the evidence payload itself.
+
+`fetchEvidence` support is explicit. `partial` support is reported as partial,
+and `unsupported` evidence retrieval fails closed for artifact references instead
+of inventing retrievable evidence.
+
+## PR Draft Intent
+
+PR draft intent is only an intent artifact. It requires owner-controlled
+repository facts and change-request intent support. The artifact records a draft
+review boundary and keeps these fields false:
+
+- pull request creation
+- merge readiness
+- automatic merge authority
+
+The merge decision remains human-only.

--- a/src/artifact/index.ts
+++ b/src/artifact/index.ts
@@ -1,0 +1,538 @@
+import type {
+  CodexAgentInvocationIntent,
+  CodexAgentProviderCapabilityEvidence,
+  CodexProviderSupportLevel,
+} from "../agent/index.js";
+import type { WorkItem } from "../core/index.js";
+import type { LaneRunState } from "../lane/index.js";
+import {
+  type EvidenceBundleRef,
+  validateEvidenceBundleRef,
+} from "../protocol/index.js";
+
+export type LaneArtifactOutputKind = "patch" | "pr-draft-intent";
+
+export interface LaneArtifactRefInput {
+  readonly uri: string;
+  readonly mediaType: "text/x-diff" | "application/json" | "text/markdown";
+}
+
+export interface LaneArtifactBranchFacts {
+  readonly name: string;
+  readonly base: string;
+}
+
+export interface LaneArtifactWorktreeFacts {
+  readonly kind: "repo-relative";
+  readonly path: string;
+}
+
+export interface LaneArtifactVerificationIntent {
+  readonly commands: readonly string[];
+}
+
+export interface LaneArtifactOwnerControlledRepository {
+  readonly provider: "github";
+  readonly repositorySlug: string;
+  readonly changeRequestIntentSupported: boolean;
+}
+
+export interface CreateLaneArtifactOutputInput {
+  readonly kind: LaneArtifactOutputKind;
+  readonly laneRunState: LaneRunState;
+  readonly workItem: WorkItem;
+  readonly branch: LaneArtifactBranchFacts;
+  readonly worktree: LaneArtifactWorktreeFacts;
+  readonly artifactRef: LaneArtifactRefInput;
+  readonly agentOutcome: CodexAgentInvocationIntent;
+  readonly verificationIntent: LaneArtifactVerificationIntent;
+  readonly capabilityEvidence: CodexAgentProviderCapabilityEvidence;
+  readonly evidenceRefs?: readonly EvidenceBundleRef[];
+  readonly ownerControlledRepository?: LaneArtifactOwnerControlledRepository;
+}
+
+export interface LaneArtifactEvidenceReference {
+  readonly evidenceBundleId: string;
+  readonly uri: string;
+  readonly fetchEvidence: Exclude<CodexProviderSupportLevel, "unsupported">;
+}
+
+export interface LaneArtifactOutput {
+  readonly schemaVersion: "ensen.loop.lane-artifact-output.v1";
+  readonly kind: LaneArtifactOutputKind;
+  readonly laneRun: {
+    readonly id: string;
+    readonly status: "completed";
+    readonly revision: number;
+  };
+  readonly workItem: WorkItem;
+  readonly branch: LaneArtifactBranchFacts;
+  readonly worktree: LaneArtifactWorktreeFacts;
+  readonly artifact: LaneArtifactRefInput;
+  readonly agentProvider: {
+    readonly provider: CodexAgentInvocationIntent["provider"];
+    readonly mode: CodexAgentInvocationIntent["mode"];
+    readonly outcome: CodexAgentInvocationIntent["outcome"];
+    readonly startsProviderSession: false;
+  };
+  readonly verificationIntent: LaneArtifactVerificationIntent;
+  readonly capabilityEvidence: CodexAgentProviderCapabilityEvidence;
+  readonly evidence: {
+    readonly embedsEvidencePayload: false;
+    readonly fetchEvidence: CodexProviderSupportLevel;
+    readonly references: readonly LaneArtifactEvidenceReference[];
+  };
+  readonly createsPullRequest: false;
+  readonly changeRequestIntent: {
+    readonly status: "draft" | "not-requested";
+    readonly humanReviewBoundary: true;
+  };
+  readonly humanReview: {
+    readonly required: true;
+    readonly mergeAuthority: "human-only";
+  };
+  readonly mergeReady: false;
+  readonly autoMerge: false;
+}
+
+export interface LaneArtifactOutputValidationIssue {
+  readonly path: string;
+  readonly message: string;
+}
+
+export interface LaneArtifactOutputValidationSuccess {
+  readonly ok: true;
+  readonly artifact: LaneArtifactOutput;
+}
+
+export interface LaneArtifactOutputValidationFailure {
+  readonly ok: false;
+  readonly issues: readonly LaneArtifactOutputValidationIssue[];
+}
+
+export type LaneArtifactOutputValidationResult =
+  | LaneArtifactOutputValidationSuccess
+  | LaneArtifactOutputValidationFailure;
+
+const branchNamePattern = /^[A-Za-z0-9][A-Za-z0-9._/-]{0,159}$/;
+const repoRelativePathPattern = /^(?:\.|[A-Za-z0-9._-][A-Za-z0-9._/-]*)$/;
+const artifactPathPattern = /^artifacts\/[A-Za-z0-9._~@/-]+$/;
+const mediaTypes = new Set<unknown>(["text/x-diff", "application/json", "text/markdown"]);
+const repositorySlugPattern = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
+const secretPattern =
+  /(?:password|passwd|token|secret|credential|api[_-]?key)\s*[:=]\s*[^\s"'`<>]+/i;
+const workstationLocalPathPattern =
+  /(?:^|[\s"'([{<>=])(?:\/Users\/[^/\s"'`<>]+|\/home\/[^/\s"'`<>]+|~(?:[/\\]|\s|$)|\$HOME(?:[/\\]|\s|$)|%USERPROFILE%(?:[/\\]|\s|$)|[A-Za-z]:\\Users\\[^\\\s"'`<>]+)/i;
+
+export function createLaneArtifactOutput(input: CreateLaneArtifactOutputInput): LaneArtifactOutput {
+  const issues = collectCreateLaneArtifactOutputIssues(input);
+
+  if (issues.length > 0) {
+    throw new Error(issues[0]?.message ?? "Lane artifact output is malformed.");
+  }
+
+  const fetchEvidence = input.capabilityEvidence.operations.fetchEvidence;
+  const referenceFetchEvidence = toReferenceFetchEvidence(fetchEvidence);
+  const evidenceRefs = input.evidenceRefs ?? [];
+  const artifact: LaneArtifactOutput = {
+    schemaVersion: "ensen.loop.lane-artifact-output.v1",
+    kind: input.kind,
+    laneRun: {
+      id: input.laneRunState.id,
+      status: "completed",
+      revision: input.laneRunState.revision,
+    },
+    workItem: { ...input.workItem },
+    branch: { ...input.branch },
+    worktree: { ...input.worktree },
+    artifact: { ...input.artifactRef },
+    agentProvider: {
+      provider: input.agentOutcome.provider,
+      mode: input.agentOutcome.mode,
+      outcome: input.agentOutcome.outcome,
+      startsProviderSession: input.agentOutcome.invocation.startsProviderSession,
+    },
+    verificationIntent: {
+      commands: [...input.verificationIntent.commands],
+    },
+    capabilityEvidence: input.capabilityEvidence,
+    evidence: {
+      embedsEvidencePayload: false,
+      fetchEvidence,
+      references: evidenceRefs.map((evidenceRef) => ({
+        evidenceBundleId: evidenceRef.id,
+        uri: evidenceRef.uri,
+        fetchEvidence: referenceFetchEvidence,
+      })),
+    },
+    createsPullRequest: false,
+    changeRequestIntent: {
+      status: input.kind === "pr-draft-intent" ? "draft" : "not-requested",
+      humanReviewBoundary: true,
+    },
+    humanReview: {
+      required: true,
+      mergeAuthority: "human-only",
+    },
+    mergeReady: false,
+    autoMerge: false,
+  };
+  const validation = validateLaneArtifactOutput(artifact);
+
+  if (!validation.ok) {
+    throw new Error(validation.issues[0]?.message ?? "Lane artifact output is malformed.");
+  }
+
+  return artifact;
+}
+
+export function validateLaneArtifactOutput(value: unknown): LaneArtifactOutputValidationResult {
+  const issues = collectLaneArtifactOutputIssues(value);
+
+  if (issues.length > 0) {
+    return {
+      ok: false,
+      issues,
+    };
+  }
+
+  return {
+    ok: true,
+    artifact: value as LaneArtifactOutput,
+  };
+}
+
+function collectCreateLaneArtifactOutputIssues(
+  input: CreateLaneArtifactOutputInput,
+): readonly LaneArtifactOutputValidationIssue[] {
+  const issues: LaneArtifactOutputValidationIssue[] = [];
+
+  if (input.laneRunState.status !== "completed") {
+    issues.push({
+      path: "laneRunState.status",
+      message: "Artifact output requires a completed lane state.",
+    });
+  }
+
+  if (
+    input.laneRunState.id !== input.laneRunState.journal.laneRunId ||
+    input.laneRunState.workItemId !== input.laneRunState.journal.workItemId ||
+    input.workItem.id !== input.laneRunState.workItemId
+  ) {
+    issues.push({
+      path: "laneRunState",
+      message: "Artifact output requires WorkItem and lane state identifiers to match.",
+    });
+  }
+
+  collectBranchIssues(issues, input.branch, "branch");
+  collectWorktreeIssues(issues, input.worktree, "worktree");
+  collectArtifactRefIssues(issues, input.artifactRef, "artifactRef");
+  collectVerificationIntentIssues(issues, input.verificationIntent, "verificationIntent");
+
+  if (!input.agentOutcome.ok || input.agentOutcome.invocation.startsProviderSession !== false) {
+    issues.push({
+      path: "agentOutcome",
+      message: "Artifact output requires a successful provider outcome fact that does not start a session.",
+    });
+  }
+
+  if (input.capabilityEvidence.protocolVersion !== "0.2.0") {
+    issues.push({
+      path: "capabilityEvidence.protocolVersion",
+      message: "Artifact output requires protocol v0.2.0 capability evidence.",
+    });
+  }
+
+  if (input.capabilityEvidence.operations.evidenceReferences !== "supported") {
+    issues.push({
+      path: "capabilityEvidence.operations.evidenceReferences",
+      message: "Artifact output requires supported evidenceReferences capability.",
+    });
+  }
+
+  if (input.capabilityEvidence.operations.fetchEvidence === "unsupported" && (input.evidenceRefs?.length ?? 0) > 0) {
+    issues.push({
+      path: "capabilityEvidence.operations.fetchEvidence",
+      message: "Artifact evidence references fail closed when fetchEvidence is unsupported.",
+    });
+  }
+
+  if (input.kind === "pr-draft-intent") {
+    collectPrDraftScopeIssues(issues, input.ownerControlledRepository);
+  }
+
+  collectEvidenceRefIssues(issues, input.laneRunState, input.evidenceRefs ?? []);
+
+  return issues;
+}
+
+function collectLaneArtifactOutputIssues(value: unknown): readonly LaneArtifactOutputValidationIssue[] {
+  const issues: LaneArtifactOutputValidationIssue[] = [];
+
+  if (!isRecord(value)) {
+    return [
+      {
+        path: "$",
+        message: "Lane artifact output must be a JSON object.",
+      },
+    ];
+  }
+
+  if (value.schemaVersion !== "ensen.loop.lane-artifact-output.v1") {
+    issues.push({
+      path: "schemaVersion",
+      message: "Lane artifact output schemaVersion is unsupported.",
+    });
+  }
+
+  if (value.kind !== "patch" && value.kind !== "pr-draft-intent") {
+    issues.push({
+      path: "kind",
+      message: "Lane artifact output kind must be patch or pr-draft-intent.",
+    });
+  }
+
+  if (!isRecord(value.laneRun) || value.laneRun.status !== "completed") {
+    issues.push({
+      path: "laneRun.status",
+      message: "Lane artifact output must be tied to completed lane state.",
+    });
+  }
+
+  if (value.createsPullRequest !== false || value.mergeReady !== false || value.autoMerge !== false) {
+    issues.push({
+      path: "humanReview",
+      message: "Lane artifact output must not imply pull request creation, merge readiness, or auto merge.",
+    });
+  }
+
+  if (
+    !isRecord(value.humanReview) ||
+    value.humanReview.required !== true ||
+    value.humanReview.mergeAuthority !== "human-only"
+  ) {
+    issues.push({
+      path: "humanReview",
+      message: "Lane artifact output must preserve the human review boundary.",
+    });
+  }
+
+  if (
+    !isRecord(value.evidence) ||
+    value.evidence.embedsEvidencePayload !== false ||
+    !isSupportLevel(value.evidence.fetchEvidence) ||
+    !Array.isArray(value.evidence.references)
+  ) {
+    issues.push({
+      path: "evidence",
+      message: "Lane artifact output must expose evidence references without embedding evidence payloads.",
+    });
+  } else {
+    for (const [index, reference] of value.evidence.references.entries()) {
+      if (
+        !isRecord(reference) ||
+        typeof reference.evidenceBundleId !== "string" ||
+        typeof reference.uri !== "string" ||
+        reference.fetchEvidence === "unsupported" ||
+        !isSupportLevel(reference.fetchEvidence)
+      ) {
+        issues.push({
+          path: `evidence.references[${index}]`,
+          message: "Lane artifact evidence references must identify safe referenced evidence and fetch support.",
+        });
+      }
+    }
+  }
+
+  if (containsUnsafePublicText(value)) {
+    issues.push({
+      path: "$",
+      message: "Lane artifact output must not contain raw secrets or workstation-local absolute paths.",
+    });
+  }
+
+  return issues;
+}
+
+function collectBranchIssues(
+  issues: LaneArtifactOutputValidationIssue[],
+  branch: LaneArtifactBranchFacts,
+  pathPrefix: string,
+): void {
+  if (!isSafeBranchName(branch.name) || !isSafeBranchName(branch.base)) {
+    issues.push({
+      path: pathPrefix,
+      message: "Artifact output requires safe branch facts.",
+    });
+  }
+}
+
+function collectWorktreeIssues(
+  issues: LaneArtifactOutputValidationIssue[],
+  worktree: LaneArtifactWorktreeFacts,
+  pathPrefix: string,
+): void {
+  if (
+    worktree.kind !== "repo-relative" ||
+    !repoRelativePathPattern.test(worktree.path) ||
+    worktree.path.split("/").some((segment) => segment === "..")
+  ) {
+    issues.push({
+      path: pathPrefix,
+      message: "Artifact output worktree path must be repo-relative and traversal-free.",
+    });
+  }
+}
+
+function collectArtifactRefIssues(
+  issues: LaneArtifactOutputValidationIssue[],
+  artifactRef: LaneArtifactRefInput,
+  pathPrefix: string,
+): void {
+  if (
+    typeof artifactRef.uri !== "string" ||
+    !artifactPathPattern.test(artifactRef.uri) ||
+    artifactRef.uri.includes("..") ||
+    artifactRef.uri.includes("//") ||
+    workstationLocalPathPattern.test(artifactRef.uri) ||
+    secretPattern.test(artifactRef.uri)
+  ) {
+    issues.push({
+      path: `${pathPrefix}.uri`,
+      message: "Artifact path must be repo-relative under artifacts/ without traversal, secrets, or workstation-local paths.",
+    });
+  }
+
+  if (!mediaTypes.has(artifactRef.mediaType)) {
+    issues.push({
+      path: `${pathPrefix}.mediaType`,
+      message: "Artifact media type is unsupported.",
+    });
+  }
+}
+
+function collectVerificationIntentIssues(
+  issues: LaneArtifactOutputValidationIssue[],
+  verificationIntent: LaneArtifactVerificationIntent,
+  pathPrefix: string,
+): void {
+  if (
+    !Array.isArray(verificationIntent.commands) ||
+    verificationIntent.commands.length === 0 ||
+    verificationIntent.commands.some(
+      (command) =>
+        typeof command !== "string" ||
+        command.length === 0 ||
+        workstationLocalPathPattern.test(command) ||
+        secretPattern.test(command),
+    )
+  ) {
+    issues.push({
+      path: `${pathPrefix}.commands`,
+      message: "Artifact output requires safe verification-intent commands.",
+    });
+  }
+}
+
+function collectPrDraftScopeIssues(
+  issues: LaneArtifactOutputValidationIssue[],
+  repository: LaneArtifactOwnerControlledRepository | undefined,
+): void {
+  if (
+    repository === undefined ||
+    repository.provider !== "github" ||
+    !repositorySlugPattern.test(repository.repositorySlug) ||
+    repository.changeRequestIntentSupported !== true
+  ) {
+    issues.push({
+      path: "ownerControlledRepository",
+      message: "PR draft intent requires an owner-controlled repository with change-request intent support.",
+    });
+  }
+}
+
+function collectEvidenceRefIssues(
+  issues: LaneArtifactOutputValidationIssue[],
+  laneRunState: LaneRunState,
+  evidenceRefs: readonly EvidenceBundleRef[],
+): void {
+  const stateRefs = new Set(laneRunState.evidence.bundleRefs);
+
+  if (stateRefs.size > 0 && evidenceRefs.length === 0) {
+    issues.push({
+      path: "evidenceRefs",
+      message: "Artifact output requires matching EvidenceBundleRef metadata for lane evidence references.",
+    });
+    return;
+  }
+
+  for (const [index, evidenceRef] of evidenceRefs.entries()) {
+    const validation = validateEvidenceBundleRef(evidenceRef);
+
+    if (!validation.ok) {
+      issues.push({
+        path: `evidenceRefs[${index}]`,
+        message: "Artifact output evidence references must be EvidenceBundleRef-compatible.",
+      });
+      continue;
+    }
+
+    if (!stateRefs.has(evidenceRef.uri)) {
+      issues.push({
+        path: `evidenceRefs[${index}].uri`,
+        message: "Artifact output evidence references must match persisted lane state evidence refs.",
+      });
+    }
+
+    if (containsUnsafePublicText(evidenceRef)) {
+      issues.push({
+        path: `evidenceRefs[${index}]`,
+        message: "Artifact output evidence references must not contain raw secrets or workstation-local paths.",
+      });
+    }
+  }
+}
+
+function isSafeBranchName(branchName: string): boolean {
+  return (
+    branchNamePattern.test(branchName) &&
+    !branchName.includes("..") &&
+    !branchName.includes("//") &&
+    !branchName.includes("@{") &&
+    !branchName.includes("\\") &&
+    !branchName.endsWith("/") &&
+    !branchName.endsWith(".") &&
+    !branchName.endsWith(".lock") &&
+    !branchName.startsWith(".") &&
+    !branchName.includes(" ")
+  );
+}
+
+function containsUnsafePublicText(value: unknown): boolean {
+  return JSON.stringify(value, (_key, child) => {
+    if (typeof child === "string" && (secretPattern.test(child) || workstationLocalPathPattern.test(child))) {
+      return "[UNSAFE]";
+    }
+
+    return child;
+  }).includes("[UNSAFE]");
+}
+
+function isSupportLevel(value: unknown): value is CodexProviderSupportLevel {
+  return value === "supported" || value === "partial" || value === "unsupported";
+}
+
+function toReferenceFetchEvidence(
+  supportLevel: CodexProviderSupportLevel,
+): Exclude<CodexProviderSupportLevel, "unsupported"> {
+  if (supportLevel === "unsupported") {
+    throw new Error("Artifact evidence references fail closed when fetchEvidence is unsupported.");
+  }
+
+  return supportLevel;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/src/artifact/index.ts
+++ b/src/artifact/index.ts
@@ -132,7 +132,6 @@ export function createLaneArtifactOutput(input: CreateLaneArtifactOutputInput): 
   }
 
   const fetchEvidence = input.capabilityEvidence.operations.fetchEvidence;
-  const referenceFetchEvidence = toReferenceFetchEvidence(fetchEvidence);
   const evidenceRefs = input.evidenceRefs ?? [];
   const artifact: LaneArtifactOutput = {
     schemaVersion: "ensen.loop.lane-artifact-output.v1",
@@ -162,7 +161,7 @@ export function createLaneArtifactOutput(input: CreateLaneArtifactOutputInput): 
       references: evidenceRefs.map((evidenceRef) => ({
         evidenceBundleId: evidenceRef.id,
         uri: evidenceRef.uri,
-        fetchEvidence: referenceFetchEvidence,
+        fetchEvidence: toReferenceFetchEvidence(fetchEvidence),
       })),
     },
     createsPullRequest: false,
@@ -279,6 +278,11 @@ function collectLaneArtifactOutputIssues(value: unknown): readonly LaneArtifactO
     ];
   }
 
+  collectBranchIssues(issues, value.branch, "branch");
+  collectWorktreeIssues(issues, value.worktree, "worktree");
+  collectArtifactRefIssues(issues, value.artifact, "artifact");
+  collectVerificationIntentIssues(issues, value.verificationIntent, "verificationIntent");
+
   if (value.schemaVersion !== "ensen.loop.lane-artifact-output.v1") {
     issues.push({
       path: "schemaVersion",
@@ -357,10 +361,14 @@ function collectLaneArtifactOutputIssues(value: unknown): readonly LaneArtifactO
 
 function collectBranchIssues(
   issues: LaneArtifactOutputValidationIssue[],
-  branch: LaneArtifactBranchFacts,
+  branch: unknown,
   pathPrefix: string,
 ): void {
-  if (!isSafeBranchName(branch.name) || !isSafeBranchName(branch.base)) {
+  if (
+    !isRecord(branch) ||
+    !isSafeBranchName(branch.name) ||
+    !isSafeBranchName(branch.base)
+  ) {
     issues.push({
       path: pathPrefix,
       message: "Artifact output requires safe branch facts.",
@@ -370,11 +378,13 @@ function collectBranchIssues(
 
 function collectWorktreeIssues(
   issues: LaneArtifactOutputValidationIssue[],
-  worktree: LaneArtifactWorktreeFacts,
+  worktree: unknown,
   pathPrefix: string,
 ): void {
   if (
+    !isRecord(worktree) ||
     worktree.kind !== "repo-relative" ||
+    typeof worktree.path !== "string" ||
     !repoRelativePathPattern.test(worktree.path) ||
     worktree.path.split("/").some((segment) => segment === "..")
   ) {
@@ -387,9 +397,17 @@ function collectWorktreeIssues(
 
 function collectArtifactRefIssues(
   issues: LaneArtifactOutputValidationIssue[],
-  artifactRef: LaneArtifactRefInput,
+  artifactRef: unknown,
   pathPrefix: string,
 ): void {
+  if (!isRecord(artifactRef)) {
+    issues.push({
+      path: pathPrefix,
+      message: "Artifact output requires an artifact reference.",
+    });
+    return;
+  }
+
   if (
     typeof artifactRef.uri !== "string" ||
     !artifactPathPattern.test(artifactRef.uri) ||
@@ -414,10 +432,11 @@ function collectArtifactRefIssues(
 
 function collectVerificationIntentIssues(
   issues: LaneArtifactOutputValidationIssue[],
-  verificationIntent: LaneArtifactVerificationIntent,
+  verificationIntent: unknown,
   pathPrefix: string,
 ): void {
   if (
+    !isRecord(verificationIntent) ||
     !Array.isArray(verificationIntent.commands) ||
     verificationIntent.commands.length === 0 ||
     verificationIntent.commands.some(
@@ -494,8 +513,9 @@ function collectEvidenceRefIssues(
   }
 }
 
-function isSafeBranchName(branchName: string): boolean {
+function isSafeBranchName(branchName: unknown): boolean {
   return (
+    typeof branchName === "string" &&
     branchNamePattern.test(branchName) &&
     !branchName.includes("..") &&
     !branchName.includes("//") &&
@@ -510,13 +530,19 @@ function isSafeBranchName(branchName: string): boolean {
 }
 
 function containsUnsafePublicText(value: unknown): boolean {
-  return JSON.stringify(value, (_key, child) => {
-    if (typeof child === "string" && (secretPattern.test(child) || workstationLocalPathPattern.test(child))) {
-      return "[UNSAFE]";
-    }
+  try {
+    const serialized = JSON.stringify(value, (_key, child) => {
+      if (typeof child === "string" && (secretPattern.test(child) || workstationLocalPathPattern.test(child))) {
+        return "[UNSAFE]";
+      }
 
-    return child;
-  }).includes("[UNSAFE]");
+      return child;
+    });
+
+    return typeof serialized === "string" && serialized.includes("[UNSAFE]");
+  } catch {
+    return true;
+  }
 }
 
 function isSupportLevel(value: unknown): value is CodexProviderSupportLevel {

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,7 @@ export function describeProduct(): string {
 
 export * from "./core/index.js";
 export * from "./agent/index.js";
+export * from "./artifact/index.js";
 export * from "./executor/index.js";
 export * from "./lane/index.js";
 export * from "./protocol/index.js";

--- a/test/lane-artifact-output.test.ts
+++ b/test/lane-artifact-output.test.ts
@@ -1,0 +1,306 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  CODEX_AGENT_PROVIDER_CAPABILITY_EVIDENCE,
+  createCodexAgentInvocationIntent,
+} from "../src/agent/index.js";
+import {
+  createLaneArtifactOutput,
+  validateLaneArtifactOutput,
+} from "../src/artifact/index.js";
+import {
+  createLaneJournal,
+  createLaneRunState,
+} from "../src/lane/index.js";
+import type { EvidenceBundleRef } from "../src/protocol/index.js";
+
+const completedState = createLaneRunState({
+  id: "run_issue60Patch01",
+  workItemId: "workitem_issue60Patch01",
+  status: "completed",
+  revision: 3,
+  createdAt: "2026-05-02T00:00:00.000Z",
+  updatedAt: "2026-05-02T00:05:00.000Z",
+  journal: createLaneJournal({
+    id: "journal-issue60Patch01",
+    laneRunId: "run_issue60Patch01",
+    workItemId: "workitem_issue60Patch01",
+    entries: [],
+  }),
+  evidence: {
+    bundleRefs: ["artifacts/evidence/issue-60/bundle-ref.json"],
+  },
+});
+
+const safeEvidenceRef: EvidenceBundleRef = {
+  schemaVersion: "eip.evidence-bundle-ref.v1",
+  id: "evb_issue60PatchEvidence01",
+  correlationId: "corr_issue60PatchEvidence01",
+  type: "local_path",
+  uri: "artifacts/evidence/issue-60/bundle-ref.json",
+  createdAt: "2026-05-02T00:05:00Z",
+  contentType: "application/json",
+  metadata: {
+    producer: "ensen-loop",
+    artifactKind: "phase4ArtifactEvidenceReference",
+    embedsEvidencePayload: false,
+  },
+};
+
+const agentOutcome = createCodexAgentInvocationIntent({
+  mode: "execute",
+  capabilityEvidence: CODEX_AGENT_PROVIDER_CAPABILITY_EVIDENCE,
+  workspace: {
+    kind: "repo-relative",
+    path: ".",
+  },
+  allowedExecutionPosture: "execute-enabled",
+  scope: {
+    owner: "TommyKammy",
+    repository: "Ensen-loop",
+    issueNumber: 60,
+  },
+  idempotencyBinding: {
+    key: "issue-60-codex-submit",
+    scopeFingerprint: "TommyKammy-Ensen-loop-60",
+  },
+});
+
+test("emits patch artifact metadata tied to completed lane state without raw evidence", () => {
+  const artifact = createLaneArtifactOutput({
+    kind: "patch",
+    laneRunState: completedState,
+    workItem: {
+      id: "workitem_issue60Patch01",
+      title: "LOOP-035: Add patch or PR draft artifact output",
+      source: "github-issue-60",
+      status: "completed",
+    },
+    branch: {
+      name: "codex/issue-60",
+      base: "main",
+    },
+    worktree: {
+      kind: "repo-relative",
+      path: ".",
+    },
+    artifactRef: {
+      uri: "artifacts/patches/issue-60.patch",
+      mediaType: "text/x-diff",
+    },
+    agentOutcome,
+    verificationIntent: {
+      commands: ["npm run typecheck", "npm run build", "npm test"],
+    },
+    capabilityEvidence: CODEX_AGENT_PROVIDER_CAPABILITY_EVIDENCE,
+    evidenceRefs: [safeEvidenceRef],
+  });
+
+  assert.equal(validateLaneArtifactOutput(artifact).ok, true);
+  assert.equal(artifact.kind, "patch");
+  assert.equal(artifact.laneRun.id, completedState.id);
+  assert.equal(artifact.workItem.id, completedState.workItemId);
+  assert.equal(artifact.humanReview.required, true);
+  assert.equal(artifact.humanReview.mergeAuthority, "human-only");
+  assert.equal(artifact.createsPullRequest, false);
+  assert.equal(artifact.mergeReady, false);
+  assert.deepEqual(artifact.evidence.references, [
+    {
+      evidenceBundleId: safeEvidenceRef.id,
+      uri: safeEvidenceRef.uri,
+      fetchEvidence: "partial",
+    },
+  ]);
+  assert.doesNotMatch(JSON.stringify(artifact), /rawEvidence|customer data|token=/i);
+});
+
+test("emits guarded PR draft intent without implying automatic merge authority", () => {
+  const artifact = createLaneArtifactOutput({
+    kind: "pr-draft-intent",
+    laneRunState: completedState,
+    workItem: {
+      id: "workitem_issue60Patch01",
+      title: "LOOP-035: Add patch or PR draft artifact output",
+      source: "github-issue-60",
+      status: "completed",
+    },
+    branch: {
+      name: "codex/issue-60",
+      base: "main",
+    },
+    worktree: {
+      kind: "repo-relative",
+      path: ".",
+    },
+    artifactRef: {
+      uri: "artifacts/pr-drafts/issue-60.json",
+      mediaType: "application/json",
+    },
+    agentOutcome,
+    verificationIntent: {
+      commands: ["npm run typecheck"],
+    },
+    capabilityEvidence: CODEX_AGENT_PROVIDER_CAPABILITY_EVIDENCE,
+    ownerControlledRepository: {
+      provider: "github",
+      repositorySlug: "TommyKammy/Ensen-loop",
+      changeRequestIntentSupported: true,
+    },
+    evidenceRefs: [safeEvidenceRef],
+  });
+
+  assert.equal(artifact.kind, "pr-draft-intent");
+  assert.equal(artifact.createsPullRequest, false);
+  assert.equal(artifact.changeRequestIntent.status, "draft");
+  assert.equal(artifact.changeRequestIntent.humanReviewBoundary, true);
+  assert.equal(artifact.mergeReady, false);
+  assert.equal(artifact.autoMerge, false);
+});
+
+test("fails closed for unsafe paths, unsupported evidence fetch, and unsupported PR draft scope", () => {
+  assert.throws(
+    () =>
+      createLaneArtifactOutput({
+        kind: "patch",
+        laneRunState: completedState,
+        workItem: {
+          id: "workitem_issue60Patch01",
+          title: "LOOP-035: Add patch or PR draft artifact output",
+          source: "github-issue-60",
+          status: "completed",
+        },
+        branch: {
+          name: "codex/issue-60",
+          base: "main",
+        },
+        worktree: {
+          kind: "repo-relative",
+          path: ".",
+        },
+        artifactRef: {
+          uri: "/Users/example/secret.patch",
+          mediaType: "text/x-diff",
+        },
+        agentOutcome,
+        verificationIntent: {
+          commands: ["npm test"],
+        },
+        capabilityEvidence: CODEX_AGENT_PROVIDER_CAPABILITY_EVIDENCE,
+      }),
+    /artifact path must be repo-relative/i,
+  );
+
+  assert.throws(
+    () =>
+      createLaneArtifactOutput({
+        kind: "patch",
+        laneRunState: completedState,
+        workItem: {
+          id: "workitem_issue60Patch01",
+          title: "LOOP-035: Add patch or PR draft artifact output",
+          source: "github-issue-60",
+          status: "completed",
+        },
+        branch: {
+          name: "codex/issue-60",
+          base: "main",
+        },
+        worktree: {
+          kind: "repo-relative",
+          path: ".",
+        },
+        artifactRef: {
+          uri: "artifacts/patches/issue-60.patch",
+          mediaType: "text/x-diff",
+        },
+        agentOutcome,
+        verificationIntent: {
+          commands: ["npm test"],
+        },
+        capabilityEvidence: {
+          ...CODEX_AGENT_PROVIDER_CAPABILITY_EVIDENCE,
+          operations: {
+            ...CODEX_AGENT_PROVIDER_CAPABILITY_EVIDENCE.operations,
+            fetchEvidence: "unsupported",
+          },
+        },
+        evidenceRefs: [safeEvidenceRef],
+      }),
+    /fetchEvidence is unsupported/i,
+  );
+
+  assert.throws(
+    () =>
+      createLaneArtifactOutput({
+        kind: "pr-draft-intent",
+        laneRunState: completedState,
+        workItem: {
+          id: "workitem_issue60Patch01",
+          title: "LOOP-035: Add patch or PR draft artifact output",
+          source: "github-issue-60",
+          status: "completed",
+        },
+        branch: {
+          name: "codex/issue-60",
+          base: "main",
+        },
+        worktree: {
+          kind: "repo-relative",
+          path: ".",
+        },
+        artifactRef: {
+          uri: "artifacts/pr-drafts/issue-60.json",
+          mediaType: "application/json",
+        },
+        agentOutcome,
+        verificationIntent: {
+          commands: ["npm test"],
+        },
+        capabilityEvidence: CODEX_AGENT_PROVIDER_CAPABILITY_EVIDENCE,
+        ownerControlledRepository: {
+          provider: "github",
+          repositorySlug: "TommyKammy/Ensen-loop",
+          changeRequestIntentSupported: false,
+        },
+      }),
+    /owner-controlled repository with change-request intent support/i,
+  );
+});
+
+test("refuses artifact output before an authoritative terminal lane state exists", () => {
+  assert.throws(
+    () =>
+      createLaneArtifactOutput({
+        kind: "patch",
+        laneRunState: {
+          ...completedState,
+          status: "running",
+        },
+        workItem: {
+          id: "workitem_issue60Patch01",
+          title: "LOOP-035: Add patch or PR draft artifact output",
+          source: "github-issue-60",
+          status: "running",
+        },
+        branch: {
+          name: "codex/issue-60",
+          base: "main",
+        },
+        worktree: {
+          kind: "repo-relative",
+          path: ".",
+        },
+        artifactRef: {
+          uri: "artifacts/patches/issue-60.patch",
+          mediaType: "text/x-diff",
+        },
+        agentOutcome,
+        verificationIntent: {
+          commands: ["npm test"],
+        },
+        capabilityEvidence: CODEX_AGENT_PROVIDER_CAPABILITY_EVIDENCE,
+      }),
+    /completed lane state/i,
+  );
+});

--- a/test/lane-artifact-output.test.ts
+++ b/test/lane-artifact-output.test.ts
@@ -33,6 +33,24 @@ const completedState = createLaneRunState({
   },
 });
 
+const completedStateWithoutEvidence = createLaneRunState({
+  id: "run_issue60PatchNoEvidence01",
+  workItemId: "workitem_issue60Patch01",
+  status: "completed",
+  revision: 4,
+  createdAt: "2026-05-02T00:00:00.000Z",
+  updatedAt: "2026-05-02T00:06:00.000Z",
+  journal: createLaneJournal({
+    id: "journal-issue60PatchNoEvidence01",
+    laneRunId: "run_issue60PatchNoEvidence01",
+    workItemId: "workitem_issue60Patch01",
+    entries: [],
+  }),
+  evidence: {
+    bundleRefs: [],
+  },
+});
+
 const safeEvidenceRef: EvidenceBundleRef = {
   schemaVersion: "eip.evidence-bundle-ref.v1",
   id: "evb_issue60PatchEvidence01",
@@ -158,6 +176,46 @@ test("emits guarded PR draft intent without implying automatic merge authority",
   assert.equal(artifact.autoMerge, false);
 });
 
+test("emits explicit unsupported fetchEvidence only when no evidence references are present", () => {
+  const artifact = createLaneArtifactOutput({
+    kind: "patch",
+    laneRunState: completedStateWithoutEvidence,
+    workItem: {
+      id: "workitem_issue60Patch01",
+      title: "LOOP-035: Add patch or PR draft artifact output",
+      source: "github-issue-60",
+      status: "completed",
+    },
+    branch: {
+      name: "codex/issue-60",
+      base: "main",
+    },
+    worktree: {
+      kind: "repo-relative",
+      path: ".",
+    },
+    artifactRef: {
+      uri: "artifacts/patches/issue-60.patch",
+      mediaType: "text/x-diff",
+    },
+    agentOutcome,
+    verificationIntent: {
+      commands: ["npm test"],
+    },
+    capabilityEvidence: {
+      ...CODEX_AGENT_PROVIDER_CAPABILITY_EVIDENCE,
+      operations: {
+        ...CODEX_AGENT_PROVIDER_CAPABILITY_EVIDENCE.operations,
+        fetchEvidence: "unsupported",
+      },
+    },
+  });
+
+  assert.equal(artifact.evidence.fetchEvidence, "unsupported");
+  assert.deepEqual(artifact.evidence.references, []);
+  assert.equal(validateLaneArtifactOutput(artifact).ok, true);
+});
+
 test("fails closed for unsafe paths, unsupported evidence fetch, and unsupported PR draft scope", () => {
   assert.throws(
     () =>
@@ -179,7 +237,7 @@ test("fails closed for unsafe paths, unsupported evidence fetch, and unsupported
           path: ".",
         },
         artifactRef: {
-          uri: "/Users/example/secret.patch",
+          uri: "/tmp/unsafe.patch",
           mediaType: "text/x-diff",
         },
         agentOutcome,
@@ -265,6 +323,79 @@ test("fails closed for unsafe paths, unsupported evidence fetch, and unsupported
         },
       }),
     /owner-controlled repository with change-request intent support/i,
+  );
+});
+
+test("validates nested public artifact fields and fails closed on unsafe serialization", () => {
+  const artifact = createLaneArtifactOutput({
+    kind: "patch",
+    laneRunState: completedState,
+    workItem: {
+      id: "workitem_issue60Patch01",
+      title: "LOOP-035: Add patch or PR draft artifact output",
+      source: "github-issue-60",
+      status: "completed",
+    },
+    branch: {
+      name: "codex/issue-60",
+      base: "main",
+    },
+    worktree: {
+      kind: "repo-relative",
+      path: ".",
+    },
+    artifactRef: {
+      uri: "artifacts/patches/issue-60.patch",
+      mediaType: "text/x-diff",
+    },
+    agentOutcome,
+    verificationIntent: {
+      commands: ["npm test"],
+    },
+    capabilityEvidence: CODEX_AGENT_PROVIDER_CAPABILITY_EVIDENCE,
+    evidenceRefs: [safeEvidenceRef],
+  });
+
+  const malformedNestedFields = validateLaneArtifactOutput({
+    ...artifact,
+    branch: {
+      name: "../escape",
+      base: "main",
+    },
+    worktree: {
+      kind: "repo-relative",
+      path: "../escape",
+    },
+    artifact: {
+      uri: "patches/issue-60.patch",
+      mediaType: "text/plain",
+    },
+    verificationIntent: {
+      commands: [""],
+    },
+  });
+
+  assert.equal(malformedNestedFields.ok, false);
+  assert.deepEqual(
+    malformedNestedFields.ok ? [] : malformedNestedFields.issues.map((issue) => issue.path),
+    [
+      "branch",
+      "worktree",
+      "artifact.uri",
+      "artifact.mediaType",
+      "verificationIntent.commands",
+    ],
+  );
+
+  const circularArtifact: Record<string, unknown> = { ...artifact };
+  circularArtifact.self = circularArtifact;
+
+  const circularValidation = validateLaneArtifactOutput(circularArtifact);
+
+  assert.equal(circularValidation.ok, false);
+  assert.match(
+    circularValidation.ok ? "" : circularValidation.issues.map((issue) => issue.message).join("\n"),
+    /raw secrets or workstation-local absolute paths/i,
   );
 });
 


### PR DESCRIPTION
## Summary
- add a Phase 4 lane artifact output boundary for patch refs and PR draft intent
- tie artifact metadata to completed lane state, WorkItem, branch/worktree facts, provider outcome, verification intent, capability evidence, and EvidenceBundleRef-compatible references
- document the protocol v0.2.0 evidence boundary and human-only merge boundary

## Verification
- npm run typecheck
- npm run build
- npm test

Closes #60

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive reference for Lane Artifact Output and PR Draft Intent, describing artifact boundaries, allowed paths, evidence rules, and protocol version constraints.

* **New Features**
  * Added lane artifact output creation and validation for completed runs, enforcing human-review boundaries, disallowing PR/auto-merge signals, and strict evidence handling (fail-closed behavior).

* **Tests**
  * Added test suite covering artifact creation, validation, success and failure modes for safety and evidence behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->