### PR TITLE
LOOP-FU-P4-001: Align readiness EIP major handling

### DIFF
--- a/docs/reference/issue-readiness.md
+++ b/docs/reference/issue-readiness.md
@@ -37,6 +37,11 @@ binding, unavailable evidence, unknown failure, and unsupported EIP major
 versions. These diagnostics are advisory inputs for a later lane boundary; they
 are not protocol terminal artifacts.
 
+The protocol snapshot version is separate from the EIP artifact schema family.
+The current released snapshot still uses `eip.*.v1` artifacts by default, so
+readiness accepts EIP major version `1` unless a caller supplies a narrower
+supported-major list. Unsupported future EIP majors continue to fail closed.
+
 ## Non-Goals
 
 - No automatic issue rewriting.
@@ -44,4 +49,3 @@ are not protocol terminal artifacts.
 - No protocol terminal artifact synthesis.
 - No automatic product, execution, or merge authority.
 - No dependency on Ensen-flow approval or workflow state.
-

--- a/src/work-item/index.ts
+++ b/src/work-item/index.ts
@@ -87,7 +87,7 @@ const localWorkItemStatuses = new Set<unknown>([
   "failed",
 ]);
 const defaultReadinessCapabilities = Object.freeze(["work-item-readiness"] as const);
-const defaultSupportedEipMajorVersions = Object.freeze([2] as const);
+const defaultSupportedEipMajorVersions = Object.freeze([1] as const);
 const workstationLocalPathPattern =
   /(?:^|[\s([{"'`:=<])(?:\/(?!\/)\S+|[A-Za-z]:[\\/]\S+|\\\\\S+)/;
 const secretLikeTextPattern =

--- a/test/issue-readiness.test.ts
+++ b/test/issue-readiness.test.ts
@@ -25,12 +25,12 @@ const runnableInput: IssueReadinessInput = {
     behaviorDeltas: ["Add issue readiness evaluation before lane execution."],
     scopeItems: ["Evaluate mapped WorkItem facts before worktree creation."],
     requestedCapabilities: ["work-item-readiness"],
-    eipMajorVersion: 2,
+    eipMajorVersion: 1,
     terminalState: "open",
   },
 };
 
-test("returns a runnable readiness result for a bounded owner-controlled issue", () => {
+test("accepts EIP major version 1 for a bounded owner-controlled issue", () => {
   const result = evaluateIssueReadiness(runnableInput);
 
   assert.equal(result.status, "runnable");
@@ -128,6 +128,27 @@ test("blocks unsupported EIP major versions without producing terminal protocol 
     },
   ]);
   assert.equal(result.boundary.emitsProtocolTerminalArtifact, false);
+});
+
+test("does not require an EIP major version before readiness can become runnable", () => {
+  const result = evaluateIssueReadiness({
+    ...runnableInput,
+    issue: {
+      ...runnableInput.issue,
+      eipMajorVersion: undefined,
+    },
+  });
+
+  assert.equal(result.status, "runnable");
+  assert.equal(result.runnable, true);
+  assert.deepEqual(result.diagnostics, [
+    {
+      category: "validation_failure",
+      path: "issue.behaviorDeltas",
+      message: "Issue has one observable behavior delta.",
+      severity: "info",
+    },
+  ]);
 });
 
 test("blocks oversized, unsupported-capability, and ambiguous terminal-state inputs", () => {


### PR DESCRIPTION
## Summary
- default issue readiness EIP schema-major support to current `eip.*.v1`
- add focused readiness coverage for EIP major 1, omitted major, and unsupported future majors
- clarify protocol snapshot version vs EIP artifact schema major in readiness docs

## Verification
- `npm ci`
- `npm run build && node --test dist/test/issue-readiness.test.js` (reproduced failure before implementation, passed after fix)
- `npm run typecheck`
- `npm run build`
- `npm test`
- `git diff --check`

Closes #69

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected issue readiness evaluation to default to EIP major version 1 instead of version 2.

* **Documentation**
  * Clarified protocol boundary specifications regarding EIP major version compatibility and snapshot independence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->