### PR TITLE
Reject local paths in artifact public metadata

### DIFF
--- a/src/artifact/index.ts
+++ b/src/artifact/index.ts
@@ -122,7 +122,7 @@ const repositorySlugPattern = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
 const secretPattern =
   /(?:password|passwd|token|secret|credential|api[_-]?key)\s*[:=]\s*[^\s"'`<>]+/i;
 const workstationLocalPathPattern =
-  /(?:^|[\s"'([{<>=])(?:\/Users\/[^/\s"'`<>]+|\/home\/[^/\s"'`<>]+|~(?:[/\\]|\s|$)|\$HOME(?:[/\\]|\s|$)|%USERPROFILE%(?:[/\\]|\s|$)|[A-Za-z]:\\Users\\[^\\\s"'`<>]+)/i;
+  /(?:^|[\s"'([{<>=])(?:\/(?!\/)(?:[A-Za-z0-9._~@-]+\/)+[A-Za-z0-9._~@-]+|~(?:[/\\]|\s|$)|\$HOME(?:[/\\]|\s|$)|%USERPROFILE%(?:[/\\]|\s|$)|[A-Za-z]:[\\/][^"'`<>\s]+|\\\\[^"'`<>\s\\]+\\[^"'`<>\s\\]+(?:\\[^"'`<>\s\\]+)*)/i;
 
 export function createLaneArtifactOutput(input: CreateLaneArtifactOutputInput): LaneArtifactOutput {
   const issues = collectCreateLaneArtifactOutputIssues(input);

--- a/src/artifact/index.ts
+++ b/src/artifact/index.ts
@@ -122,7 +122,7 @@ const repositorySlugPattern = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
 const secretPattern =
   /(?:password|passwd|token|secret|credential|api[_-]?key)\s*[:=]\s*[^\s"'`<>]+/i;
 const workstationLocalPathPattern =
-  /(?:^|[\s"'([{<>=])(?:\/(?!\/)(?:[A-Za-z0-9._~@-]+\/)+[A-Za-z0-9._~@-]+|~(?:[/\\]|\s|$)|\$HOME(?:[/\\]|\s|$)|%USERPROFILE%(?:[/\\]|\s|$)|[A-Za-z]:[\\/][^"'`<>\s]+|\\\\[^"'`<>\s\\]+\\[^"'`<>\s\\]+(?:\\[^"'`<>\s\\]+)*)/i;
+  /(?:^|[\s"'([{<>=])(?:\/(?!\/)(?:[A-Za-z0-9._~@-]+(?:\/[A-Za-z0-9._~@-]+)*\/?)|~(?:[/\\]|\s|$)|\$HOME(?:[/\\]|\s|$)|%USERPROFILE%(?:[/\\]|\s|$)|[A-Za-z]:[\\/][^"'`<>\s]+|\\\\[^"'`<>\s\\]+\\[^"'`<>\s\\]+(?:\\[^"'`<>\s\\]+)*)/i;
 
 export function createLaneArtifactOutput(input: CreateLaneArtifactOutputInput): LaneArtifactOutput {
   const issues = collectCreateLaneArtifactOutputIssues(input);

--- a/test/lane-artifact-output.test.ts
+++ b/test/lane-artifact-output.test.ts
@@ -174,6 +174,8 @@ test("emits patch artifact metadata tied to completed lane state without raw evi
 
 test("rejects generic local absolute paths in public artifact metadata without echoing raw values", () => {
   const unsafePublicPaths = [
+    posixRootPath("tmp"),
+    posixRootPath("var"),
     posixRootPath("var", "folders", "private-output.log"),
     posixRootPath("tmp", "private-output.log"),
     windowsDrivePath("Temp", "private-output.log"),

--- a/test/lane-artifact-output.test.ts
+++ b/test/lane-artifact-output.test.ts
@@ -85,6 +85,45 @@ const agentOutcome = createCodexAgentInvocationIntent({
   },
 });
 
+type CreateArtifactInput = Parameters<typeof createLaneArtifactOutput>[0];
+
+function createSafePatchInput(overrides: Partial<CreateArtifactInput> = {}): CreateArtifactInput {
+  return {
+    kind: "patch",
+    laneRunState: completedState,
+    workItem: {
+      id: "workitem_issue60Patch01",
+      title: "LOOP-035: Add patch or PR draft artifact output",
+      source: "github-issue-60",
+      status: "completed",
+    },
+    branch: {
+      name: "codex/issue-60",
+      base: "main",
+    },
+    worktree: {
+      kind: "repo-relative",
+      path: ".",
+    },
+    artifactRef: {
+      uri: "artifacts/patches/issue-60.patch",
+      mediaType: "text/x-diff",
+    },
+    agentOutcome,
+    verificationIntent: {
+      commands: ["npm test"],
+    },
+    capabilityEvidence: CODEX_AGENT_PROVIDER_CAPABILITY_EVIDENCE,
+    evidenceRefs: [safeEvidenceRef],
+    ...overrides,
+  };
+}
+
+const posixRootPath = (...segments: readonly string[]): string => ["", ...segments].join("/");
+const windowsDrivePath = (...segments: readonly string[]): string => ["C:", ...segments].join("\\");
+const windowsUncPath = (...segments: readonly string[]): string => ["", "", ...segments].join("\\");
+const escapeRegExp = (value: string): string => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
 test("emits patch artifact metadata tied to completed lane state without raw evidence", () => {
   const artifact = createLaneArtifactOutput({
     kind: "patch",
@@ -131,6 +170,37 @@ test("emits patch artifact metadata tied to completed lane state without raw evi
     },
   ]);
   assert.doesNotMatch(JSON.stringify(artifact), /rawEvidence|customer data|token=/i);
+});
+
+test("rejects generic local absolute paths in public artifact metadata without echoing raw values", () => {
+  const unsafePublicPaths = [
+    posixRootPath("var", "folders", "private-output.log"),
+    posixRootPath("tmp", "private-output.log"),
+    windowsDrivePath("Temp", "private-output.log"),
+    windowsUncPath("build-host", "share", "private-output.log"),
+  ];
+
+  for (const unsafePublicPath of unsafePublicPaths) {
+    assert.throws(
+      () =>
+        createLaneArtifactOutput(
+          createSafePatchInput({
+            workItem: {
+              id: "workitem_issue60Patch01",
+              title: `LOOP-035: output captured at ${unsafePublicPath}`,
+              source: "github-issue-60",
+              status: "completed",
+            },
+          }),
+        ),
+      (error: unknown) => {
+        assert.ok(error instanceof Error);
+        assert.match(error.message, /raw secrets or workstation-local absolute paths/i);
+        assert.doesNotMatch(error.message, new RegExp(escapeRegExp(unsafePublicPath)));
+        return true;
+      },
+    );
+  }
 });
 
 test("emits guarded PR draft intent without implying automatic merge authority", () => {


### PR DESCRIPTION
## Summary
- broaden artifact public metadata path detection to reject generic POSIX absolute paths, Windows drive paths, and UNC paths
- add focused regression coverage that diagnostics stay sanitized and safe artifacts/ references still pass

## Verification
- npm run typecheck
- npm run build
- npm test

Closes #70

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Broadened detection of workstation-local absolute paths (Unix, tilde/$HOME, Windows drive and UNC forms) to better prevent leaking local paths in outputs.

* **Tests**
  * Added tests verifying unsafe local-path values are rejected and error messages do not expose the raw path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->