### PR TITLE
Use non-failure runnable readiness diagnostic

### DIFF
--- a/src/work-item/index.ts
+++ b/src/work-item/index.ts
@@ -22,6 +22,7 @@ export type WorkItemValidationResult = WorkItemValidationSuccess | WorkItemValid
 export type IssueReadinessStatus = "runnable" | "blocked" | "needs-human-refinement";
 
 export type IssueReadinessDiagnosticCategory =
+  | "readiness_info"
   | "validation_failure"
   | "unsupported_capability"
   | "provider_rejection_before_run_binding"
@@ -201,7 +202,7 @@ export function evaluateIssueReadiness(input: IssueReadinessInput): IssueReadine
 
   if (status === "runnable") {
     diagnostics.push({
-      category: "validation_failure",
+      category: "readiness_info",
       path: "issue.behaviorDeltas",
       message: "Issue has one observable behavior delta.",
       severity: "info",

--- a/test/issue-readiness.test.ts
+++ b/test/issue-readiness.test.ts
@@ -37,9 +37,13 @@ test("accepts EIP major version 1 for a bounded owner-controlled issue", () => {
   assert.equal(result.runnable, true);
   assert.equal(result.workItem.id, runnableInput.workItem.id);
   assert.equal(result.workItem.title, runnableInput.workItem.title);
+  assert.equal(
+    result.diagnostics.some((diagnostic) => diagnostic.category === "validation_failure"),
+    false,
+  );
   assert.deepEqual(result.diagnostics, [
     {
-      category: "validation_failure",
+      category: "readiness_info",
       path: "issue.behaviorDeltas",
       message: "Issue has one observable behavior delta.",
       severity: "info",
@@ -141,9 +145,13 @@ test("does not require an EIP major version before readiness can become runnable
 
   assert.equal(result.status, "runnable");
   assert.equal(result.runnable, true);
+  assert.equal(
+    result.diagnostics.some((diagnostic) => diagnostic.category === "validation_failure"),
+    false,
+  );
   assert.deepEqual(result.diagnostics, [
     {
-      category: "validation_failure",
+      category: "readiness_info",
       path: "issue.behaviorDeltas",
       message: "Issue has one observable behavior delta.",
       severity: "info",


### PR DESCRIPTION
## Summary
- add a non-failure readiness_info diagnostic category for runnable readiness info
- update focused readiness tests to assert runnable results do not contain validation_failure diagnostics
- keep blocker and human-refinement failure categories unchanged

## Verification
- npm run typecheck
- npm run build
- npm test

Closes #71

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved diagnostic categorization for runnable issues; diagnostic messages are now correctly classified as readiness information rather than validation failures, providing clearer feedback.

* **Tests**
  * Updated test expectations to reflect improved diagnostic categorization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->