### PR TITLE
LOOP-X3A-001 dogfood repository allowlist

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The Ensen-loop mission and development charter alignment are summarized in [docs
 
 The Phase 1 local Work Item validation skeleton is documented in [docs/reference/work-item-contract.md](docs/reference/work-item-contract.md).
 
-GitHub issue pickup is documented in [docs/reference/github-work-item-pickup.md](docs/reference/github-work-item-pickup.md). It is an owner-controlled, allowlisted, read-only SCMProvider `work-item-pickup` boundary that maps already-loaded GitHub issue facts into provider-neutral Work Item facts without mutating GitHub state or starting execution.
+GitHub issue pickup is documented in [docs/reference/github-work-item-pickup.md](docs/reference/github-work-item-pickup.md). It is an owner-controlled, allowlisted, read-only SCMProvider `work-item-pickup` boundary that maps already-loaded GitHub issue facts into provider-neutral Work Item facts without mutating GitHub state or starting execution. Dogfood execution-capable lane preparation uses a separate owner-controlled repository allowlist at the local lane boundary; GitHub pickup allowlist facts are not execution authority by themselves.
 
 Phase 4 patch and PR draft artifact output is documented in [docs/reference/lane-artifact-output.md](docs/reference/lane-artifact-output.md). It emits reviewable metadata for completed lane runs without embedding evidence payloads, opening pull requests, claiming merge readiness, or bypassing human review.
 

--- a/docs/architecture/local-lane-execution.md
+++ b/docs/architecture/local-lane-execution.md
@@ -96,6 +96,22 @@ worktree path, state file path, idempotency fact, and provider non-actions
 without creating branch, worktree, change request, agent session, or local
 provider state.
 
+Dogfood preparation requires a separate owner-controlled repository execution
+allowlist. That allowlist is operator-owned configuration, not GitHub issue text
+and not Ensen-flow approval state. Each matching entry binds
+`ownerIdentity`, `repositorySlug`, `repositoryUrl`, and `<repository-root>` with
+`ownerControlled: true`. A missing or mismatched dogfood allowlist blocks before
+prepare mode creates lane workspaces, state directories, provider sessions,
+branches, pull requests, or agent execution. Diagnostics name the failing
+category, such as `ownerIdentity`, `repositorySlug`, `repositoryUrl`, or
+`repositoryRoot`, without echoing raw local absolute paths.
+
+GitHub WorkItem pickup has its own read-only allowlist for collecting issue
+facts. Those pickup facts can feed the later authoritative scope record, but the
+pickup allowlist is not execution authority by itself. Execution-capable dogfood
+lanes must still match the dogfood repository allowlist at the local lane
+boundary.
+
 Prepare mode is explicit. It creates only the Ensen-loop local lane workspace
 and state directories, writes a queued LaneRunState, and records branch intent,
 repository scope, idempotency, and cleanup facts in the Lane Journal. It still
@@ -166,6 +182,8 @@ signals is missing or unsafe:
 - unsafe workspace root or state root resolution;
 - missing target binding when repository or workspace execution would depend on
   it;
+- missing or mismatched owner-controlled dogfood repository allowlist for
+  non-dry-run dogfood lane preparation;
 - missing policy context when policy posture is required for execution;
 - missing or malformed verification command evidence;
 - ambiguous executor outcome;

--- a/docs/architecture/provider-capabilities.md
+++ b/docs/architecture/provider-capabilities.md
@@ -56,6 +56,13 @@ records capability evidence without starting a Codex session. Execute intent is 
 separate guarded fact surface; it is still represented without starting a
 provider session until a later invocation layer owns that side effect.
 
+Dogfood execute-capable lanes require a local owner-controlled repository
+allowlist match before any non-dry-run preparation can mutate local lane
+workspace or state directories. That execution allowlist binds owner identity,
+repository slug, repository URL, and `<repository-root>` as one owner-controlled
+record. The GitHub WorkItem pickup allowlist remains read-only provenance for
+issue normalization; it does not authorize execution by itself.
+
 ## Dogfood Adapter Positions
 
 The first dogfood slice can use a GitHub adapter for SCMProvider behavior and a

--- a/docs/reference/github-work-item-pickup.md
+++ b/docs/reference/github-work-item-pickup.md
@@ -45,7 +45,15 @@ Successful pickup returns a Work Item with `source: "github-issue"` plus
 sanitized scope facts: provider, repository, issue number, issue URL,
 repository URL, requester login, and `ownerControlled: true`. These facts are
 authoritative input for later lane submission and idempotency binding, but they
-do not mean execution has started.
+do not mean execution has started and they do not authorize dogfood execution by
+themselves.
+
+Dogfood lane preparation has a separate owner-controlled execution allowlist at
+the local lane boundary. That allowlist must bind the owner identity, repository
+slug, repository URL, and local `<repository-root>` before non-dry-run
+preparation can create local lane workspace or state directories. GitHub pickup
+allowlist facts can help construct the authoritative scope record, but they are
+read-only provenance rather than execution authority.
 
 Malformed issue references, missing requester provenance, missing repository
 URL facts, secret-like input fields, and repositories that are not explicitly

--- a/src/lane/index.ts
+++ b/src/lane/index.ts
@@ -304,12 +304,12 @@ export async function planBranchLaneRunSkeleton(
     await assertRepositoryRootAllowlisted(repositoryRoot.realPath, input.allowedRepositoryRoots);
   }
 
-  if (mode === "prepare" || input.dogfoodRepositoryAllowlist !== undefined) {
+  if (mode === "prepare") {
     await assertDogfoodRepositoryAllowlisted({
       scope,
       repositoryRealPath: repositoryRoot.realPath,
       allowlist: input.dogfoodRepositoryAllowlist,
-      required: mode === "prepare",
+      required: true,
     });
   }
 
@@ -689,7 +689,7 @@ function collectDogfoodScopeIssues(scope: AuthoritativeLaneRunScope): string[] {
     issues.push("repositorySlug");
   }
 
-  if (!isGithubRepositoryUrl(scope.repositoryUrl, scope.repositorySlug)) {
+  if (!isRepositoryUrl(scope.repositoryUrl)) {
     issues.push("repositoryUrl");
   }
 
@@ -723,7 +723,7 @@ function collectDogfoodAllowlistEntryIssues(
       issues.push(`allowlist[${index}].repositorySlug`);
     }
 
-    if (!isGithubRepositoryUrl(entry.repositoryUrl, entry.repositorySlug)) {
+    if (!isRepositoryUrl(entry.repositoryUrl)) {
       issues.push(`allowlist[${index}].repositoryUrl`);
     }
 
@@ -735,8 +735,16 @@ function collectDogfoodAllowlistEntryIssues(
   return issues;
 }
 
-function isGithubRepositoryUrl(value: unknown, repositorySlug: string): value is string {
-  return typeof value === "string" && value === `https://github.com/${repositorySlug}`;
+function isRepositoryUrl(value: unknown): value is string {
+  if (typeof value !== "string" || value.length === 0) {
+    return false;
+  }
+
+  try {
+    return new URL(value).protocol === "https:";
+  } catch {
+    return false;
+  }
 }
 
 async function resolveCanonicalRepositoryRoot(rootPath: string): Promise<CanonicalLocalLaneRoot> {

--- a/src/lane/index.ts
+++ b/src/lane/index.ts
@@ -92,8 +92,18 @@ export type BranchLaneRunSkeletonMode = "dry-run" | "prepare";
 
 export interface AuthoritativeLaneRunScope {
   readonly ownerControlled: true;
+  readonly ownerIdentity?: string;
   readonly repositoryId: string;
   readonly repositorySlug: string;
+  readonly repositoryUrl?: string;
+  readonly repositoryRoot: string;
+}
+
+export interface OwnerControlledDogfoodRepositoryAllowlistEntry {
+  readonly ownerControlled: true;
+  readonly ownerIdentity: string;
+  readonly repositorySlug: string;
+  readonly repositoryUrl: string;
   readonly repositoryRoot: string;
 }
 
@@ -109,6 +119,7 @@ export interface PlanBranchLaneRunSkeletonInput {
   readonly baseBranch?: string;
   readonly authoritativeScope?: AuthoritativeLaneRunScope;
   readonly allowedRepositoryRoots?: readonly string[];
+  readonly dogfoodRepositoryAllowlist?: readonly OwnerControlledDogfoodRepositoryAllowlistEntry[];
   readonly recordedAt?: string;
 }
 
@@ -123,6 +134,8 @@ export interface BranchLaneRunSkeleton {
   readonly repository: {
     readonly id: string;
     readonly slug: string;
+    readonly url?: string;
+    readonly ownerIdentity?: string;
   };
   readonly branch: {
     readonly name: string;
@@ -291,6 +304,15 @@ export async function planBranchLaneRunSkeleton(
     await assertRepositoryRootAllowlisted(repositoryRoot.realPath, input.allowedRepositoryRoots);
   }
 
+  if (mode === "prepare" || input.dogfoodRepositoryAllowlist !== undefined) {
+    await assertDogfoodRepositoryAllowlisted({
+      scope,
+      repositoryRealPath: repositoryRoot.realPath,
+      allowlist: input.dogfoodRepositoryAllowlist,
+      required: mode === "prepare",
+    });
+  }
+
   const worktreeRoot = await resolveCanonicalLocalLaneRoot("workspace", input.worktreeRoot);
   const stateRoot = await resolveCanonicalLocalLaneRoot("state", input.stateRoot);
 
@@ -311,6 +333,8 @@ export async function planBranchLaneRunSkeleton(
     repository: {
       id: scope.repositoryId,
       slug: scope.repositorySlug,
+      url: scope.repositoryUrl,
+      ownerIdentity: scope.ownerIdentity,
     },
     branch: {
       name: input.branchName,
@@ -367,6 +391,12 @@ export async function planBranchLaneRunSkeleton(
           recordedAt,
           kind: "hypothesis",
           message: `authoritative scope: ${scope.repositorySlug} ${scope.repositoryId}`,
+        },
+        {
+          id: `${laneRunId}-dogfood-allowlist`,
+          recordedAt,
+          kind: "hypothesis",
+          message: `dogfood allowlist matched: ${scope.repositorySlug} ownerIdentity=${scope.ownerIdentity ?? "<missing>"}`,
         },
         {
           id: `${laneRunId}-branch`,
@@ -598,6 +628,115 @@ async function assertRepositoryRootAllowlisted(
   }
 
   throw new Error("Repository root is not allowlisted for lane skeleton planning.");
+}
+
+async function assertDogfoodRepositoryAllowlisted(input: {
+  readonly scope: AuthoritativeLaneRunScope;
+  readonly repositoryRealPath: string;
+  readonly allowlist?: readonly OwnerControlledDogfoodRepositoryAllowlistEntry[];
+  readonly required: boolean;
+}): Promise<void> {
+  if (!Array.isArray(input.allowlist)) {
+    if (input.required) {
+      throw new Error("Owner-controlled dogfood repository allowlist is required before prepare mutation.");
+    }
+
+    return;
+  }
+
+  const scopeIssues = collectDogfoodScopeIssues(input.scope);
+  if (scopeIssues.length > 0) {
+    throw new Error(`Dogfood repository scope is missing or malformed: ${scopeIssues.join(", ")}.`);
+  }
+
+  const entryIssues = collectDogfoodAllowlistEntryIssues(input.allowlist);
+  if (entryIssues.length > 0) {
+    throw new Error(`Dogfood repository allowlist is malformed: ${entryIssues.join(", ")}.`);
+  }
+
+  for (const entry of input.allowlist) {
+    if (
+      entry.ownerControlled === true &&
+      entry.ownerIdentity === input.scope.ownerIdentity &&
+      entry.repositorySlug === input.scope.repositorySlug &&
+      entry.repositoryUrl === input.scope.repositoryUrl
+    ) {
+      const allowed = await resolveCanonicalRepositoryRoot(entry.repositoryRoot);
+
+      if (allowed.realPath === input.repositoryRealPath) {
+        return;
+      }
+    }
+  }
+
+  throw new Error(
+    "Dogfood repository allowlist match is required before prepare mutation; mismatched fields may include ownerIdentity, repositorySlug, repositoryUrl, or repositoryRoot.",
+  );
+}
+
+function collectDogfoodScopeIssues(scope: AuthoritativeLaneRunScope): string[] {
+  const issues: string[] = [];
+
+  if (scope.ownerControlled !== true) {
+    issues.push("ownerControlled");
+  }
+
+  if (!isNonEmptyString(scope.ownerIdentity)) {
+    issues.push("ownerIdentity");
+  }
+
+  if (!repositorySlugPattern.test(scope.repositorySlug)) {
+    issues.push("repositorySlug");
+  }
+
+  if (!isGithubRepositoryUrl(scope.repositoryUrl, scope.repositorySlug)) {
+    issues.push("repositoryUrl");
+  }
+
+  if (!isNonEmptyString(scope.repositoryRoot)) {
+    issues.push("repositoryRoot");
+  }
+
+  return issues;
+}
+
+function collectDogfoodAllowlistEntryIssues(
+  allowlist: readonly OwnerControlledDogfoodRepositoryAllowlistEntry[],
+): string[] {
+  const issues: string[] = [];
+
+  allowlist.forEach((entry, index) => {
+    if (typeof entry !== "object" || entry === null) {
+      issues.push(`allowlist[${index}]`);
+      return;
+    }
+
+    if (entry.ownerControlled !== true) {
+      issues.push(`allowlist[${index}].ownerControlled`);
+    }
+
+    if (!isNonEmptyString(entry.ownerIdentity)) {
+      issues.push(`allowlist[${index}].ownerIdentity`);
+    }
+
+    if (!repositorySlugPattern.test(entry.repositorySlug)) {
+      issues.push(`allowlist[${index}].repositorySlug`);
+    }
+
+    if (!isGithubRepositoryUrl(entry.repositoryUrl, entry.repositorySlug)) {
+      issues.push(`allowlist[${index}].repositoryUrl`);
+    }
+
+    if (!isNonEmptyString(entry.repositoryRoot)) {
+      issues.push(`allowlist[${index}].repositoryRoot`);
+    }
+  });
+
+  return issues;
+}
+
+function isGithubRepositoryUrl(value: unknown, repositorySlug: string): value is string {
+  return typeof value === "string" && value === `https://github.com/${repositorySlug}`;
 }
 
 async function resolveCanonicalRepositoryRoot(rootPath: string): Promise<CanonicalLocalLaneRoot> {

--- a/test/lane-run-skeleton.test.ts
+++ b/test/lane-run-skeleton.test.ts
@@ -31,10 +31,13 @@ test("dry-runs a deterministic branch/worktree lane skeleton without filesystem 
       branchName: "codex/issue-58",
       authoritativeScope: {
         ownerControlled: true,
+        ownerIdentity: "owner-maintainer",
         repositoryId: "repo_01HV7Y8M8F2KQ5W3P9R6T4N2LOOP",
         repositorySlug: "TommyKammy/Ensen-loop",
+        repositoryUrl: "https://github.com/TommyKammy/Ensen-loop",
         repositoryRoot: roots.repositoryRoot,
       },
+      dogfoodRepositoryAllowlist: dogfoodAllowlist(roots.repositoryRoot),
     });
 
     assert.equal(skeleton.mode, "dry-run");
@@ -78,10 +81,13 @@ test("prepares a local skeleton tied to lane id, branch intent, scope, and resta
       baseBranch: "main",
       authoritativeScope: {
         ownerControlled: true,
+        ownerIdentity: "owner-maintainer",
         repositoryId: "repo_01HV7Y8M8F2KQ5W3P9R6T4N2LOOP",
         repositorySlug: "TommyKammy/Ensen-loop",
+        repositoryUrl: "https://github.com/TommyKammy/Ensen-loop",
         repositoryRoot: roots.repositoryRoot,
       },
+      dogfoodRepositoryAllowlist: dogfoodAllowlist(roots.repositoryRoot),
     });
 
     assert.equal(skeleton.mode, "prepare");
@@ -111,6 +117,94 @@ test("prepares a local skeleton tied to lane id, branch intent, scope, and resta
         .then((value) => JSON.parse(value).laneRunId),
       skeleton.laneRunId,
     );
+  } finally {
+    await roots.cleanup();
+  }
+});
+
+test("requires an owner-controlled dogfood repo allowlist before prepare mutation", async () => {
+  const roots = await createSkeletonRoots();
+  const allowedScope = {
+    ownerControlled: true,
+    ownerIdentity: "owner-maintainer",
+    repositoryId: "repo_01HV7Y8M8F2KQ5W3P9R6T4N2LOOP",
+    repositorySlug: "TommyKammy/Ensen-loop",
+    repositoryUrl: "https://github.com/TommyKammy/Ensen-loop",
+    repositoryRoot: roots.repositoryRoot,
+  } as const;
+  const allowlist = [
+    {
+      ownerControlled: true,
+      ownerIdentity: "owner-maintainer",
+      repositorySlug: "TommyKammy/Ensen-loop",
+      repositoryUrl: "https://github.com/TommyKammy/Ensen-loop",
+      repositoryRoot: roots.repositoryRoot,
+    },
+  ] as const;
+
+  try {
+    const dryRun = await planBranchLaneRunSkeleton({
+      workItem: readyWorkItem,
+      laneRunId: "run_dogfood_allowlisted_dry_run",
+      idempotencyKey: "issue-81-dogfood-allow-dryrun",
+      repositoryRoot: roots.repositoryRoot,
+      worktreeRoot: roots.worktreeRoot,
+      stateRoot: roots.stateRoot,
+      branchName: "codex/issue-81",
+      authoritativeScope: allowedScope,
+      dogfoodRepositoryAllowlist: allowlist,
+    });
+
+    assert.equal(dryRun.mode, "dry-run");
+    assert.equal(dryRun.repository.slug, "TommyKammy/Ensen-loop");
+    await assert.rejects(() => access(path.join(roots.worktreeRoot, "lane-runs")), /ENOENT/);
+    await assert.rejects(() => access(path.join(roots.stateRoot, "lane-runs")), /ENOENT/);
+
+    await assert.rejects(
+      () =>
+        planBranchLaneRunSkeleton({
+          mode: "prepare",
+          workItem: readyWorkItem,
+          laneRunId: "run_dogfood_missing_allowlist",
+          idempotencyKey: "issue-81-dogfood-missing-list",
+          repositoryRoot: roots.repositoryRoot,
+          worktreeRoot: roots.worktreeRoot,
+          stateRoot: roots.stateRoot,
+          branchName: "codex/issue-81",
+          authoritativeScope: allowedScope,
+        }),
+      /dogfood repository allowlist is required/,
+    );
+
+    await assert.rejects(
+      () =>
+        planBranchLaneRunSkeleton({
+          mode: "prepare",
+          workItem: readyWorkItem,
+          laneRunId: "run_dogfood_wrong_owner",
+          idempotencyKey: "issue-81-dogfood-wrong-owner",
+          repositoryRoot: roots.repositoryRoot,
+          worktreeRoot: roots.worktreeRoot,
+          stateRoot: roots.stateRoot,
+          branchName: "codex/issue-81",
+          authoritativeScope: {
+            ...allowedScope,
+            ownerIdentity: "flow-approval",
+          },
+          dogfoodRepositoryAllowlist: allowlist,
+        }),
+      (error: unknown) => {
+        assert.ok(error instanceof Error);
+        assert.match(error.message, /ownerIdentity/);
+        assert.doesNotMatch(error.message, new RegExp(escapeRegExp(roots.repositoryRoot)));
+        assert.doesNotMatch(error.message, new RegExp(escapeRegExp(roots.worktreeRoot)));
+        assert.doesNotMatch(error.message, new RegExp(escapeRegExp(roots.stateRoot)));
+        return true;
+      },
+    );
+
+    await assert.rejects(() => access(path.join(roots.worktreeRoot, "lane-runs")), /ENOENT/);
+    await assert.rejects(() => access(path.join(roots.stateRoot, "lane-runs")), /ENOENT/);
   } finally {
     await roots.cleanup();
   }
@@ -240,10 +334,13 @@ test("preserves pre-existing local skeleton directories when state persistence f
           branchName: "codex/issue-58-existing-fail",
           authoritativeScope: {
             ownerControlled: true,
+            ownerIdentity: "owner-maintainer",
             repositoryId: "repo_01HV7Y8M8F2KQ5W3P9R6T4N2LOOP",
             repositorySlug: "TommyKammy/Ensen-loop",
+            repositoryUrl: "https://github.com/TommyKammy/Ensen-loop",
             repositoryRoot: roots.repositoryRoot,
           },
+          dogfoodRepositoryAllowlist: dogfoodAllowlist(roots.repositoryRoot),
         }),
       /Lane run state file path must be a regular file/,
     );
@@ -280,4 +377,20 @@ async function createSkeletonRoots(): Promise<{
       await rm(root, { recursive: true, force: true });
     },
   };
+}
+
+function dogfoodAllowlist(repositoryRoot: string) {
+  return [
+    {
+      ownerControlled: true,
+      ownerIdentity: "owner-maintainer",
+      repositorySlug: "TommyKammy/Ensen-loop",
+      repositoryUrl: "https://github.com/TommyKammy/Ensen-loop",
+      repositoryRoot,
+    },
+  ] as const;
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }

--- a/test/lane-run-skeleton.test.ts
+++ b/test/lane-run-skeleton.test.ts
@@ -160,6 +160,27 @@ test("requires an owner-controlled dogfood repo allowlist before prepare mutatio
     await assert.rejects(() => access(path.join(roots.worktreeRoot, "lane-runs")), /ENOENT/);
     await assert.rejects(() => access(path.join(roots.stateRoot, "lane-runs")), /ENOENT/);
 
+    const mismatchedAllowlistDryRun = await planBranchLaneRunSkeleton({
+      workItem: readyWorkItem,
+      laneRunId: "run_dogfood_mismatch_dry_run",
+      idempotencyKey: "issue-81-dogfood-mismatch-dryrun",
+      repositoryRoot: roots.repositoryRoot,
+      worktreeRoot: roots.worktreeRoot,
+      stateRoot: roots.stateRoot,
+      branchName: "codex/issue-81",
+      authoritativeScope: allowedScope,
+      dogfoodRepositoryAllowlist: [
+        {
+          ...allowlist[0],
+          ownerIdentity: "different-owner",
+        },
+      ],
+    });
+
+    assert.equal(mismatchedAllowlistDryRun.mode, "dry-run");
+    await assert.rejects(() => access(path.join(roots.worktreeRoot, "lane-runs")), /ENOENT/);
+    await assert.rejects(() => access(path.join(roots.stateRoot, "lane-runs")), /ENOENT/);
+
     await assert.rejects(
       () =>
         planBranchLaneRunSkeleton({
@@ -205,6 +226,46 @@ test("requires an owner-controlled dogfood repo allowlist before prepare mutatio
 
     await assert.rejects(() => access(path.join(roots.worktreeRoot, "lane-runs")), /ENOENT/);
     await assert.rejects(() => access(path.join(roots.stateRoot, "lane-runs")), /ENOENT/);
+  } finally {
+    await roots.cleanup();
+  }
+});
+
+test("allows adapter-agnostic https repository URLs for prepare allowlist matching", async () => {
+  const roots = await createSkeletonRoots();
+  const repositoryUrl = "https://github.enterprise.example/scm/TommyKammy/Ensen-loop";
+
+  try {
+    const skeleton = await planBranchLaneRunSkeleton({
+      mode: "prepare",
+      workItem: readyWorkItem,
+      laneRunId: "run_dogfood_enterprise_url",
+      idempotencyKey: "issue-81-dogfood-enterprise-url",
+      repositoryRoot: roots.repositoryRoot,
+      worktreeRoot: roots.worktreeRoot,
+      stateRoot: roots.stateRoot,
+      branchName: "codex/issue-81-enterprise-url",
+      authoritativeScope: {
+        ownerControlled: true,
+        ownerIdentity: "owner-maintainer",
+        repositoryId: "repo_01HV7Y8M8F2KQ5W3P9R6T4N2LOOP",
+        repositorySlug: "TommyKammy/Ensen-loop",
+        repositoryUrl,
+        repositoryRoot: roots.repositoryRoot,
+      },
+      dogfoodRepositoryAllowlist: [
+        {
+          ownerControlled: true,
+          ownerIdentity: "owner-maintainer",
+          repositorySlug: "TommyKammy/Ensen-loop",
+          repositoryUrl,
+          repositoryRoot: roots.repositoryRoot,
+        },
+      ],
+    });
+
+    assert.equal(skeleton.mode, "prepare");
+    assert.equal(skeleton.repository.url, repositoryUrl);
   } finally {
     await roots.cleanup();
   }

--- a/test/lane-run-skeleton.test.ts
+++ b/test/lane-run-skeleton.test.ts
@@ -107,6 +107,7 @@ test("prepares a local skeleton tied to lane id, branch intent, scope, and resta
     const journalText = state.journal.entries.map((entry) => entry.message).join("\n");
     assert.match(journalText, /branch intent: codex\/issue-58-restart from main/);
     assert.match(journalText, /authoritative scope: TommyKammy\/Ensen-loop repo_01HV7Y8M8F2KQ5W3P9R6T4N2LOOP/);
+    assert.match(journalText, /dogfood allowlist matched: TommyKammy\/Ensen-loop ownerIdentity=owner-maintainer/);
     assert.match(journalText, /idempotency key: issue-58-lane-skeleton-restart/);
     assert.match(journalText, /cleanup: remove prepared local lane workspace and state directory for run_01HV7Y8M8F2KQ5W3P9R6T4N2RESTART/);
     assert.equal(JSON.stringify(state).includes(roots.repositoryRoot), false);

--- a/test/quality-kit-docs.test.ts
+++ b/test/quality-kit-docs.test.ts
@@ -103,6 +103,9 @@ test("documents the Phase 3 local lane execution contract", async () => {
     "workspace root",
     "state root",
     "ambiguous executor outcome",
+    "dogfood repository allowlist",
+    "GitHub WorkItem pickup",
+    "not execution authority by itself",
   ]) {
     assert.match(contract, new RegExp(phrase, "i"));
   }


### PR DESCRIPTION
## Summary
- Add a separate owner-controlled dogfood repository allowlist at the lane prepare boundary.
- Bind owner identity, repository slug, repository URL, and local repository root before non-dry-run preparation can mutate local lane workspace/state.
- Document that GitHub WorkItem pickup allowlist facts remain read-only provenance, not execution authority.

## Verification
- npm run typecheck
- npm run build
- npm test

Closes #81

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dogfood lane preparation now requires an owner-controlled repository allowlist before any non-dry-run preparation that could mutate local workspace/state.

* **Bug Fixes**
  * Clarified that GitHub WorkItem pickup provides read-only normalized facts and does not by itself authorize execution.

* **Documentation**
  * Expanded architecture and reference docs to describe allowlist gating, failure diagnostics, and scope distinctions.

* **Tests**
  * Updated tests to validate allowlist enforcement, error handling, and related documentation presence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->