### PR TITLE
LOOP-X3A-002 enforce dogfood dry-run proof

### DIFF
--- a/docs/architecture/provider-capabilities.md
+++ b/docs/architecture/provider-capabilities.md
@@ -37,7 +37,7 @@ against protocol `v0.2.0` before any operation is treated as available:
 
 | Operation | Support level | Boundary behavior |
 | --- | --- | --- |
-| `submit` | `supported` | May be planned as the execute-capable boundary only after explicit execute posture, repo-relative workspace, owner-controlled scope, and idempotency binding are present. |
+| `submit` | `supported` | May be planned as the execute-capable boundary only after explicit execute posture, repo-relative workspace, owner-controlled scope, idempotency binding, prior dry-run proof, and human operator approval are present. |
 | `status` | `partial` | Must fail closed for authoritative status polling; partial Codex observations are diagnostics, not RunStatusSnapshot truth. |
 | `cancel` | `unsupported` | Must fail closed and must not mark a lane run cancelled without an authoritative cancellation boundary. |
 | `fetchEvidence` | `partial` | May describe references or diagnostics, but must not claim durable evidence fetch support. |
@@ -51,10 +51,14 @@ Those examples are `eip.capability-variant.example.v1` guidance for provider
 boundary checks; they do not rename RunRequest, RunStatusSnapshot, RunResult, or
 EvidenceBundleRef artifacts to `v2`.
 
-Dry-run remains the default Codex intent. It describes the adapter invocation and
-records capability evidence without starting a Codex session. Execute intent is a
-separate guarded fact surface; it is still represented without starting a
-provider session until a later invocation layer owns that side effect.
+Dry-run remains the default Codex dogfood intent. It describes the adapter
+invocation and records capability evidence without starting a Codex session.
+Execute intent is a separate guarded fact surface; it is still represented
+without starting a provider session until a later invocation layer owns that side
+effect. Execute-capable dogfood input fails closed unless it carries an explicit
+prior dry-run proof and a human operator approval point. The boundary records
+that merge support is absent and merge authority remains human-only; patch
+output or PR draft intent must not be interpreted as merge readiness.
 
 Dogfood execute-capable lanes require a local owner-controlled repository
 allowlist match before any non-dry-run preparation can mutate local lane

--- a/docs/reference/lane-artifact-output.md
+++ b/docs/reference/lane-artifact-output.md
@@ -14,6 +14,12 @@ references. A lane run must be completed before artifact output is emitted.
 Status snapshots, provider prose, retries, timeout summaries, or operator text
 must not be used to synthesize a terminal artifact.
 
+For execute-capable dogfood lanes, AgentProvider metadata carries the
+dry-run-first precondition summary: dry-run proof required, proof provided,
+human operator approval provided, merge unsupported, and merge authority
+human-only. This metadata explains the approval boundary for reviewers; it does
+not grant merge authority.
+
 Artifact paths are public review metadata. They must stay repo-relative under
 `artifacts/`, avoid traversal, and avoid raw secrets or workstation-local
 absolute paths. Public artifact output must not embed raw evidence bodies,

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -38,6 +38,20 @@ export interface CodexAgentIdempotencyBinding {
   readonly scopeFingerprint: string;
 }
 
+export interface CodexAgentDryRunProof {
+  readonly mode: "dry-run";
+  readonly outcome: "planned";
+  readonly requestId: string;
+  readonly correlationId: string;
+  readonly completedAt: string;
+}
+
+export interface CodexAgentOperatorApprovalPoint {
+  readonly actorType: "human";
+  readonly decision: "execute-after-dry-run";
+  readonly approvedAt: string;
+}
+
 export interface CreateCodexAgentInvocationIntentInput {
   readonly mode?: CodexAgentInvocationMode;
   readonly capabilityEvidence: CodexAgentProviderCapabilityEvidence;
@@ -45,6 +59,8 @@ export interface CreateCodexAgentInvocationIntentInput {
   readonly allowedExecutionPosture?: "dry-run-only" | "execute-enabled";
   readonly scope?: CodexAgentScopeBinding;
   readonly idempotencyBinding?: CodexAgentIdempotencyBinding;
+  readonly dryRunProof?: CodexAgentDryRunProof;
+  readonly operatorApproval?: CodexAgentOperatorApprovalPoint;
 }
 
 export interface CodexAgentInvocationIntent {
@@ -58,6 +74,13 @@ export interface CodexAgentInvocationIntent {
     readonly operation: "submit";
   };
   readonly outcome: "planned" | "ready-to-invoke" | "blocked";
+  readonly executionPreconditions: {
+    readonly dryRunRequired: true;
+    readonly dryRunProof: "provided" | "missing";
+    readonly operatorApproval: "provided" | "missing";
+    readonly mergeSupported: false;
+    readonly mergeAuthority: "human-only";
+  };
   readonly diagnostics: readonly string[];
 }
 
@@ -114,6 +137,13 @@ export function createCodexAgentInvocationIntent(
       operation: "submit",
     },
     outcome: ok ? (mode === "execute" ? "ready-to-invoke" : "planned") : "blocked",
+    executionPreconditions: {
+      dryRunRequired: true,
+      dryRunProof: isSafeDryRunProof(input.dryRunProof) ? "provided" : "missing",
+      operatorApproval: isSafeOperatorApproval(input.operatorApproval) ? "provided" : "missing",
+      mergeSupported: false,
+      mergeAuthority: "human-only",
+    },
     diagnostics,
   };
 }
@@ -177,6 +207,14 @@ function validateExecuteBoundary(input: CreateCodexAgentInvocationIntentInput): 
     diagnostics.push("Codex execute intent requires idempotency binding.");
   }
 
+  if (!isSafeDryRunProof(input.dryRunProof)) {
+    diagnostics.push("Codex dogfood execute intent requires prior dry-run proof.");
+  }
+
+  if (!isSafeOperatorApproval(input.operatorApproval)) {
+    diagnostics.push("Codex dogfood execute intent requires explicit human operator approval after dry run.");
+  }
+
   const submitAvailability = requireCodexProviderOperation(input.capabilityEvidence, "submit");
 
   if (!submitAvailability.ok) {
@@ -209,6 +247,36 @@ function isSafeIdempotencyBinding(
     binding !== undefined &&
     idempotencyKeyPattern.test(binding.key) &&
     /^[A-Za-z0-9._:-]{12,160}$/.test(binding.scopeFingerprint)
+  );
+}
+
+function isSafeDryRunProof(proof: CodexAgentDryRunProof | undefined): proof is CodexAgentDryRunProof {
+  return (
+    proof !== undefined &&
+    proof.mode === "dry-run" &&
+    proof.outcome === "planned" &&
+    /^req_[A-Za-z0-9._:-]{12,160}$/.test(proof.requestId) &&
+    /^corr_[A-Za-z0-9._:-]{12,160}$/.test(proof.correlationId) &&
+    isMillisecondIsoTimestamp(proof.completedAt)
+  );
+}
+
+function isSafeOperatorApproval(
+  approval: CodexAgentOperatorApprovalPoint | undefined,
+): approval is CodexAgentOperatorApprovalPoint {
+  return (
+    approval !== undefined &&
+    approval.actorType === "human" &&
+    approval.decision === "execute-after-dry-run" &&
+    isMillisecondIsoTimestamp(approval.approvedAt)
+  );
+}
+
+function isMillisecondIsoTimestamp(value: unknown): value is string {
+  return (
+    typeof value === "string" &&
+    /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/.test(value) &&
+    !Number.isNaN(Date.parse(value))
   );
 }
 

--- a/src/artifact/index.ts
+++ b/src/artifact/index.ts
@@ -74,6 +74,7 @@ export interface LaneArtifactOutput {
     readonly mode: CodexAgentInvocationIntent["mode"];
     readonly outcome: CodexAgentInvocationIntent["outcome"];
     readonly startsProviderSession: false;
+    readonly executionPreconditions: CodexAgentInvocationIntent["executionPreconditions"];
   };
   readonly verificationIntent: LaneArtifactVerificationIntent;
   readonly capabilityEvidence: CodexAgentProviderCapabilityEvidence;
@@ -150,6 +151,7 @@ export function createLaneArtifactOutput(input: CreateLaneArtifactOutputInput): 
       mode: input.agentOutcome.mode,
       outcome: input.agentOutcome.outcome,
       startsProviderSession: input.agentOutcome.invocation.startsProviderSession,
+      executionPreconditions: input.agentOutcome.executionPreconditions,
     },
     verificationIntent: {
       commands: [...input.verificationIntent.commands],
@@ -311,6 +313,8 @@ function collectLaneArtifactOutputIssues(value: unknown): readonly LaneArtifactO
     });
   }
 
+  collectAgentProviderIssues(issues, value.agentProvider);
+
   if (
     !isRecord(value.humanReview) ||
     value.humanReview.required !== true ||
@@ -357,6 +361,45 @@ function collectLaneArtifactOutputIssues(value: unknown): readonly LaneArtifactO
   }
 
   return issues;
+}
+
+function collectAgentProviderIssues(
+  issues: LaneArtifactOutputValidationIssue[],
+  agentProvider: unknown,
+): void {
+  if (
+    !isRecord(agentProvider) ||
+    agentProvider.startsProviderSession !== false ||
+    (agentProvider.mode !== "dry-run" && agentProvider.mode !== "execute") ||
+    (agentProvider.outcome !== "planned" &&
+      agentProvider.outcome !== "ready-to-invoke" &&
+      agentProvider.outcome !== "blocked") ||
+    !isRecord(agentProvider.executionPreconditions) ||
+    agentProvider.executionPreconditions.dryRunRequired !== true ||
+    (agentProvider.executionPreconditions.dryRunProof !== "provided" &&
+      agentProvider.executionPreconditions.dryRunProof !== "missing") ||
+    (agentProvider.executionPreconditions.operatorApproval !== "provided" &&
+      agentProvider.executionPreconditions.operatorApproval !== "missing") ||
+    agentProvider.executionPreconditions.mergeSupported !== false ||
+    agentProvider.executionPreconditions.mergeAuthority !== "human-only"
+  ) {
+    issues.push({
+      path: "agentProvider",
+      message: "Lane artifact output must preserve dry-run-first and human-only merge preconditions.",
+    });
+    return;
+  }
+
+  if (
+    agentProvider.mode === "execute" &&
+    (agentProvider.executionPreconditions.dryRunProof !== "provided" ||
+      agentProvider.executionPreconditions.operatorApproval !== "provided")
+  ) {
+    issues.push({
+      path: "agentProvider.executionPreconditions",
+      message: "Execute-capable artifact metadata requires dry-run proof and human operator approval.",
+    });
+  }
 }
 
 function collectBranchIssues(

--- a/test/codex-agent-adapter.test.ts
+++ b/test/codex-agent-adapter.test.ts
@@ -46,7 +46,7 @@ test("fails closed before Codex execute intent when scope, posture, or idempoten
   assert.match(intent.diagnostics.join("\n"), /idempotency binding/i);
 });
 
-test("separates guarded Codex execute intent from dry-run preview", () => {
+test("blocks dogfood execute intent until a prior dry-run proof is present", () => {
   const intent = createCodexAgentInvocationIntent({
     mode: "execute",
     capabilityEvidence,
@@ -66,11 +66,57 @@ test("separates guarded Codex execute intent from dry-run preview", () => {
     },
   });
 
+  assert.equal(intent.ok, false);
+  assert.equal(intent.mode, "execute");
+  assert.equal(intent.invocation.startsProviderSession, false);
+  assert.equal(intent.outcome, "blocked");
+  assert.match(intent.diagnostics.join("\n"), /prior dry-run proof/i);
+});
+
+test("separates guarded Codex execute intent from dry-run preview after human approval", () => {
+  const intent = createCodexAgentInvocationIntent({
+    mode: "execute",
+    capabilityEvidence,
+    workspace: {
+      kind: "repo-relative",
+      path: ".",
+    },
+    allowedExecutionPosture: "execute-enabled",
+    scope: {
+      owner: "TommyKammy",
+      repository: "Ensen-loop",
+      issueNumber: 59,
+    },
+    idempotencyBinding: {
+      key: "issue-59-codex-submit",
+      scopeFingerprint: "TommyKammy-Ensen-loop-59",
+    },
+    dryRunProof: {
+      mode: "dry-run",
+      outcome: "planned",
+      requestId: "req_issue59DryRunProof01",
+      correlationId: "corr_issue59DryRunProof01",
+      completedAt: "2026-05-02T00:05:00.000Z",
+    },
+    operatorApproval: {
+      actorType: "human",
+      decision: "execute-after-dry-run",
+      approvedAt: "2026-05-02T00:06:00.000Z",
+    },
+  });
+
   assert.equal(intent.ok, true);
   assert.equal(intent.mode, "execute");
   assert.equal(intent.invocation.intent, "execute-codex-invocation");
   assert.equal(intent.invocation.startsProviderSession, false);
   assert.equal(intent.outcome, "ready-to-invoke");
+  assert.deepEqual(intent.executionPreconditions, {
+    dryRunRequired: true,
+    dryRunProof: "provided",
+    operatorApproval: "provided",
+    mergeSupported: false,
+    mergeAuthority: "human-only",
+  });
   assert.deepEqual(intent.diagnostics, []);
 });
 

--- a/test/lane-artifact-output.test.ts
+++ b/test/lane-artifact-output.test.ts
@@ -83,6 +83,18 @@ const agentOutcome = createCodexAgentInvocationIntent({
     key: "issue-60-codex-submit",
     scopeFingerprint: "TommyKammy-Ensen-loop-60",
   },
+  dryRunProof: {
+    mode: "dry-run",
+    outcome: "planned",
+    requestId: "req_issue60DryRunProof01",
+    correlationId: "corr_issue60DryRunProof01",
+    completedAt: "2026-05-02T00:04:00.000Z",
+  },
+  operatorApproval: {
+    actorType: "human",
+    decision: "execute-after-dry-run",
+    approvedAt: "2026-05-02T00:05:00.000Z",
+  },
 });
 
 type CreateArtifactInput = Parameters<typeof createLaneArtifactOutput>[0];
@@ -162,6 +174,13 @@ test("emits patch artifact metadata tied to completed lane state without raw evi
   assert.equal(artifact.humanReview.mergeAuthority, "human-only");
   assert.equal(artifact.createsPullRequest, false);
   assert.equal(artifact.mergeReady, false);
+  assert.deepEqual(artifact.agentProvider.executionPreconditions, {
+    dryRunRequired: true,
+    dryRunProof: "provided",
+    operatorApproval: "provided",
+    mergeSupported: false,
+    mergeAuthority: "human-only",
+  });
   assert.deepEqual(artifact.evidence.references, [
     {
       evidenceBundleId: safeEvidenceRef.id,
@@ -246,6 +265,8 @@ test("emits guarded PR draft intent without implying automatic merge authority",
   assert.equal(artifact.changeRequestIntent.humanReviewBoundary, true);
   assert.equal(artifact.mergeReady, false);
   assert.equal(artifact.autoMerge, false);
+  assert.equal(artifact.agentProvider.executionPreconditions.mergeSupported, false);
+  assert.equal(artifact.agentProvider.executionPreconditions.mergeAuthority, "human-only");
 });
 
 test("emits explicit unsupported fetchEvidence only when no evidence references are present", () => {


### PR DESCRIPTION
## Summary
- require prior dry-run proof and human operator approval before Codex dogfood execute intent becomes ready
- surface dry-run-first and human-only merge preconditions in artifact metadata
- document dogfood execute and PR draft boundaries as merge-unsupported and human-only

## Verification
- npm run typecheck
- npm run build
- npm test

Closes #78

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated provider capability documentation with enhanced execute operation gating and approval boundary requirements
  * Clarified artifact output metadata regarding execution approval conditions

* **New Features**
  * Execute operations now require dry-run proof and explicit human operator approval
  * Added execution preconditions tracking with enhanced validation for safety

* **Tests**
  * Added tests validating execution safeguards and approval requirements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->