### PR TITLE
LOOP-X3A-003 add dogfood artifact safety checks

### DIFF
--- a/src/artifact/index.ts
+++ b/src/artifact/index.ts
@@ -9,6 +9,9 @@ import {
   type EvidenceBundleRef,
   validateEvidenceBundleRef,
 } from "../protocol/index.js";
+import {
+  containsUnsafePublicArtifactText,
+} from "../safety/public-artifact.js";
 
 export type LaneArtifactOutputKind = "patch" | "pr-draft-intent";
 
@@ -120,10 +123,6 @@ const repoRelativePathPattern = /^(?:\.|[A-Za-z0-9._-][A-Za-z0-9._/-]*)$/;
 const artifactPathPattern = /^artifacts\/[A-Za-z0-9._~@/-]+$/;
 const mediaTypes = new Set<unknown>(["text/x-diff", "application/json", "text/markdown"]);
 const repositorySlugPattern = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
-const secretPattern =
-  /(?:password|passwd|token|secret|credential|api[_-]?key)\s*[:=]\s*[^\s"'`<>]+/i;
-const workstationLocalPathPattern =
-  /(?:^|[\s"'([{<>=])(?:\/(?!\/)(?:[A-Za-z0-9._~@-]+(?:\/[A-Za-z0-9._~@-]+)*\/?)|~(?:[/\\]|\s|$)|\$HOME(?:[/\\]|\s|$)|%USERPROFILE%(?:[/\\]|\s|$)|[A-Za-z]:[\\/][^"'`<>\s]+|\\\\[^"'`<>\s\\]+\\[^"'`<>\s\\]+(?:\\[^"'`<>\s\\]+)*)/i;
 
 export function createLaneArtifactOutput(input: CreateLaneArtifactOutputInput): LaneArtifactOutput {
   const issues = collectCreateLaneArtifactOutputIssues(input);
@@ -456,8 +455,7 @@ function collectArtifactRefIssues(
     !artifactPathPattern.test(artifactRef.uri) ||
     artifactRef.uri.includes("..") ||
     artifactRef.uri.includes("//") ||
-    workstationLocalPathPattern.test(artifactRef.uri) ||
-    secretPattern.test(artifactRef.uri)
+    containsUnsafePublicArtifactText(artifactRef.uri)
   ) {
     issues.push({
       path: `${pathPrefix}.uri`,
@@ -486,8 +484,7 @@ function collectVerificationIntentIssues(
       (command) =>
         typeof command !== "string" ||
         command.length === 0 ||
-        workstationLocalPathPattern.test(command) ||
-        secretPattern.test(command),
+        containsUnsafePublicArtifactText(command),
     )
   ) {
     issues.push({
@@ -575,7 +572,7 @@ function isSafeBranchName(branchName: unknown): boolean {
 function containsUnsafePublicText(value: unknown): boolean {
   try {
     const serialized = JSON.stringify(value, (_key, child) => {
-      if (typeof child === "string" && (secretPattern.test(child) || workstationLocalPathPattern.test(child))) {
+      if (typeof child === "string" && containsUnsafePublicArtifactText(child)) {
         return "[UNSAFE]";
       }
 

--- a/src/cli/diagnostics.ts
+++ b/src/cli/diagnostics.ts
@@ -1,3 +1,5 @@
+import { sanitizePublicDiagnosticMessage } from "../safety/public-artifact.js";
+
 const localPathPlaceholder = "<local-path>";
 
 const quotedAbsolutePathPattern =
@@ -7,7 +9,7 @@ const windowsUncPathPattern = /\\\\[^\s"'\r\n]+/g;
 const posixAbsolutePathPattern = /(^|[\s(:])\/[^\s"'\r\n)]+/g;
 
 export function sanitizeCliErrorMessage(message: string): string {
-  return message
+  return sanitizePublicDiagnosticMessage(message)
     .replace(quotedAbsolutePathPattern, (_match, quote: string) => `${quote}${localPathPlaceholder}${quote}`)
     .replace(windowsDrivePathPattern, localPathPlaceholder)
     .replace(windowsUncPathPattern, localPathPlaceholder)

--- a/src/executor/index.ts
+++ b/src/executor/index.ts
@@ -20,6 +20,7 @@ import {
   resolveLaneRunStatePath,
   writeLaneRunState,
 } from "../lane/index.js";
+import { containsUnsafePublicArtifactText } from "../safety/public-artifact.js";
 
 export type LaneExecutorMode = "deterministic-local-fake";
 export type LocalFakeExecutorOutcome = "succeeded" | "failed" | "blocked";
@@ -98,10 +99,6 @@ export interface PersistedLaneExecutorResult {
 const deterministicLocalFakeMode: LaneExecutorMode = "deterministic-local-fake";
 const fixtureNamePattern = /^[a-z0-9][a-z0-9._-]{2,127}$/;
 const localLaneIdPattern = /^[A-Za-z0-9][A-Za-z0-9._-]{2,127}$/;
-const credentialPattern =
-  /(?:password|passwd|token|secret|credential|api[_-]?key)\s*[:=]\s*\S+/i;
-const unsafeLocalPathPattern =
-  /(?:^|[\s"'([{<>=])(?:\/(?:[^\s"'`<>]*)?|~(?:[/\\]|\s|$)|\$HOME(?:[/\\]|\s|$)|%USERPROFILE%(?:[/\\]|\s|$)|[A-Za-z]:\\[^\s"'`<>]+|\\\\[^\\\s]+\\[^\\\s]+)/i;
 const redactedFixtureName = "[REDACTED_FIXTURE]";
 const unsupportedExecutorConfigurationReason = "Unsupported executor configuration.";
 
@@ -736,10 +733,7 @@ function collectFixtureIssues(fixture: LocalFakeExecutorFixture): readonly strin
 }
 
 function containsUnsafeFixtureText(value: string): boolean {
-  return (
-    credentialPattern.test(value) ||
-    unsafeLocalPathPattern.test(value)
-  );
+  return containsUnsafePublicArtifactText(value);
 }
 
 function replaceProtocolIdPrefix(value: string, prefix: string): string {

--- a/src/safety/public-artifact.ts
+++ b/src/safety/public-artifact.ts
@@ -1,0 +1,28 @@
+const secretLikePlaceholder = "<secret-like-value>";
+
+const secretLikePatterns: readonly RegExp[] = [
+  /-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----/gi,
+  /\b(?:authorization|proxy-authorization)\s*:\s*(?:bearer|basic|token)?\s*[^\s"'`<>;]+/gi,
+  /\b(?:cookie|set-cookie)\s*:\s*[A-Za-z0-9._~-]+=[^\s"'`<>;]+/gi,
+  /\b(?:password|passwd|token|secret|credential|api[_-]?key|apikey|session(?:id)?|access[_-]?token|refresh[_-]?token)\b\s*[:=]\s*[^\s"'`<>;]+/gi,
+  /\b(?:ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9_]{8,}\b/g,
+  /\bgithub_pat_[A-Za-z0-9_]{12,}\b/g,
+  /\b(?:sk-[A-Za-z0-9][A-Za-z0-9_-]{8,}|xox[baprs]-[A-Za-z0-9-]{8,})\b/g,
+];
+
+export const workstationLocalPathPattern =
+  /(?:^|[\s"'([{<>=])(?:\/(?!\/)(?:[A-Za-z0-9._~@-]+(?:\/[A-Za-z0-9._~@-]+)*\/?)|~(?:[/\\]|\s|$)|\$HOME(?:[/\\]|\s|$)|%USERPROFILE%(?:[/\\]|\s|$)|[A-Za-z]:[\\/][^"'`<>\s]+|\\\\[^"'`<>\s\\]+\\[^"'`<>\s\\]+(?:\\[^"'`<>\s\\]+)*)/i;
+
+export function containsUnsafePublicArtifactText(value: string): boolean {
+  return secretLikePatterns.some((pattern) => {
+    pattern.lastIndex = 0;
+    return pattern.test(value);
+  }) || workstationLocalPathPattern.test(value);
+}
+
+export function sanitizePublicDiagnosticMessage(message: string): string {
+  return secretLikePatterns.reduce((sanitized, pattern) => {
+    pattern.lastIndex = 0;
+    return sanitized.replace(pattern, secretLikePlaceholder);
+  }, message);
+}

--- a/test/cli-diagnostics.test.ts
+++ b/test/cli-diagnostics.test.ts
@@ -34,6 +34,30 @@ test("CLI filesystem diagnostics redact local absolute path shapes", () => {
   assert.match(sanitized, /EBUSY: resource busy or locked, open '<local-path>'/);
 });
 
+test("CLI diagnostics redact secret-like values", () => {
+  const authHeader = "Authorization: Bearer ghp_1234567890abcdef";
+  const sessionCookie = "Cookie: sessionid=s3ssion-value; path=/";
+  const privateKeyMarker = "-----BEGIN OPENSSH PRIVATE KEY-----";
+  const apiKeyAssignment = "apiKey = sk-test-1234567890abcdef";
+  const message = [
+    `request failed with ${authHeader}`,
+    `adapter returned ${sessionCookie}`,
+    `fixture included ${privateKeyMarker}`,
+    `config contained ${apiKeyAssignment}`,
+  ].join("\n");
+
+  const sanitized = sanitizeCliErrorMessage(message);
+
+  assert.doesNotMatch(sanitized, new RegExp(escapeRegExp(authHeader)));
+  assert.doesNotMatch(sanitized, new RegExp(escapeRegExp(sessionCookie)));
+  assert.doesNotMatch(sanitized, new RegExp(escapeRegExp(privateKeyMarker)));
+  assert.doesNotMatch(sanitized, new RegExp(escapeRegExp(apiKeyAssignment)));
+  assert.match(sanitized, /request failed with <secret-like-value>/);
+  assert.match(sanitized, /adapter returned <secret-like-value>/);
+  assert.match(sanitized, /fixture included <secret-like-value>/);
+  assert.match(sanitized, /config contained <secret-like-value>/);
+});
+
 function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }

--- a/test/executor-boundary.test.ts
+++ b/test/executor-boundary.test.ts
@@ -279,6 +279,28 @@ test("blocks unsafe fake fixture metadata without echoing raw secret or workstat
   });
 });
 
+test("blocks secret-like fake fixture diagnostics without echoing raw values", async () => {
+  await withPreparedLane(async (preparedContext) => {
+    const unsafeDiagnostic = "Authorization: Bearer ghp_1234567890abcdef";
+    const result = await invokeLaneExecutor({
+      executor: createDeterministicLocalFakeExecutor(),
+      mode: "deterministic-local-fake",
+      plan: createRunRequestExecutionPlan(request),
+      preparedContext,
+      completedAt: "2026-05-01T00:00:15Z",
+      fixture: {
+        name: "issue-40-auth-header",
+        outcome: "succeeded",
+        verificationSummary: unsafeDiagnostic,
+      },
+    });
+
+    assert.equal(result.status, "blocked");
+    assert.match(result.blockedReasons.join("\n"), /unsafe metadata/);
+    assert.doesNotMatch(JSON.stringify(result), new RegExp(escapeRegExp(unsafeDiagnostic)));
+  });
+});
+
 test("blocks common local workstation path forms in fake fixture metadata", async () => {
   await withPreparedLane(async (preparedContext) => {
     const fixtureTexts = [
@@ -309,6 +331,10 @@ test("blocks common local workstation path forms in fake fixture metadata", asyn
     }
   });
 });
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
 
 test("fails closed when prepared lane context is missing or unprepared", async () => {
   const stateRoot = await mkdtemp(path.join(os.tmpdir(), "ensen-loop-state-"));

--- a/test/lane-artifact-output.test.ts
+++ b/test/lane-artifact-output.test.ts
@@ -224,6 +224,37 @@ test("rejects generic local absolute paths in public artifact metadata without e
   }
 });
 
+test("rejects secret-like public artifact values without echoing raw values", () => {
+  const unsafePublicValues = [
+    "Authorization: Bearer ghp_1234567890abcdef",
+    "set-cookie: sessionid=s3ssion-value; HttpOnly",
+    "-----BEGIN OPENSSH PRIVATE KEY-----",
+    "apiKey = sk-test-1234567890abcdef",
+  ];
+
+  for (const unsafePublicValue of unsafePublicValues) {
+    assert.throws(
+      () =>
+        createLaneArtifactOutput(
+          createSafePatchInput({
+            workItem: {
+              id: "workitem_issue60Patch01",
+              title: `LOOP-035: ${unsafePublicValue}`,
+              source: "github-issue-60",
+              status: "completed",
+            },
+          }),
+        ),
+      (error: unknown) => {
+        assert.ok(error instanceof Error);
+        assert.match(error.message, /raw secrets or workstation-local absolute paths/i);
+        assert.doesNotMatch(error.message, new RegExp(escapeRegExp(unsafePublicValue)));
+        return true;
+      },
+    );
+  }
+});
+
 test("emits guarded PR draft intent without implying automatic merge authority", () => {
   const artifact = createLaneArtifactOutput({
     kind: "pr-draft-intent",


### PR DESCRIPTION
## Summary
- add shared public artifact safety matching/redaction for secret-like values and workstation-local paths
- apply the shared policy to lane artifact metadata, CLI diagnostics, and deterministic fake executor diagnostics
- add focused regression coverage for authorization headers, session cookies, private key markers, API keys, and non-echoing diagnostics

## Verification
- npm ci
- npm test -- --test-name-pattern "secret-like public artifact|CLI diagnostics redact secret-like" (reproduced failures before fix)
- npm test -- --test-name-pattern "secret-like public artifact|CLI diagnostics redact secret-like|secret-like fake fixture"
- npm run typecheck
- npm run build
- npm test
- git diff --check

Closes #80

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Error message sanitization now redacts unsafe content including credentials and local paths.

* **Tests**
  * Added comprehensive test coverage for message sanitization in CLI diagnostics.
  * Added test verification for artifact safety validation and executor fixture handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->