### PR TITLE
Bind dry-run proof to execute scope

### DIFF
--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -44,6 +44,8 @@ export interface CodexAgentDryRunProof {
   readonly requestId: string;
   readonly correlationId: string;
   readonly completedAt: string;
+  readonly scope: CodexAgentScopeBinding;
+  readonly idempotencyBinding: CodexAgentIdempotencyBinding;
 }
 
 export interface CodexAgentOperatorApprovalPoint {
@@ -209,6 +211,16 @@ function validateExecuteBoundary(input: CreateCodexAgentInvocationIntentInput): 
 
   if (!isSafeDryRunProof(input.dryRunProof)) {
     diagnostics.push("Codex dogfood execute intent requires prior dry-run proof.");
+  } else {
+    if (!isSameScopeBinding(input.dryRunProof.scope, input.scope)) {
+      diagnostics.push("Codex dogfood execute dry-run proof scope does not match execute scope.");
+    }
+
+    if (!isSameIdempotencyBinding(input.dryRunProof.idempotencyBinding, input.idempotencyBinding)) {
+      diagnostics.push(
+        "Codex dogfood execute dry-run proof idempotency binding does not match execute idempotency binding.",
+      );
+    }
   }
 
   if (!isSafeOperatorApproval(input.operatorApproval)) {
@@ -257,8 +269,29 @@ function isSafeDryRunProof(proof: CodexAgentDryRunProof | undefined): proof is C
     proof.outcome === "planned" &&
     /^req_[A-Za-z0-9._:-]{12,160}$/.test(proof.requestId) &&
     /^corr_[A-Za-z0-9._:-]{12,160}$/.test(proof.correlationId) &&
-    isMillisecondIsoTimestamp(proof.completedAt)
+    isMillisecondIsoTimestamp(proof.completedAt) &&
+    isSafeScope(proof.scope) &&
+    isSafeIdempotencyBinding(proof.idempotencyBinding)
   );
+}
+
+function isSameScopeBinding(
+  left: CodexAgentScopeBinding,
+  right: CodexAgentScopeBinding | undefined,
+): boolean {
+  return (
+    right !== undefined &&
+    left.owner === right.owner &&
+    left.repository === right.repository &&
+    left.issueNumber === right.issueNumber
+  );
+}
+
+function isSameIdempotencyBinding(
+  left: CodexAgentIdempotencyBinding,
+  right: CodexAgentIdempotencyBinding | undefined,
+): boolean {
+  return right !== undefined && left.key === right.key && left.scopeFingerprint === right.scopeFingerprint;
 }
 
 function isSafeOperatorApproval(

--- a/test/codex-agent-adapter.test.ts
+++ b/test/codex-agent-adapter.test.ts
@@ -97,6 +97,15 @@ test("separates guarded Codex execute intent from dry-run preview after human ap
       requestId: "req_issue59DryRunProof01",
       correlationId: "corr_issue59DryRunProof01",
       completedAt: "2026-05-02T00:05:00.000Z",
+      scope: {
+        owner: "TommyKammy",
+        repository: "Ensen-loop",
+        issueNumber: 59,
+      },
+      idempotencyBinding: {
+        key: "issue-59-codex-submit",
+        scopeFingerprint: "TommyKammy-Ensen-loop-59",
+      },
     },
     operatorApproval: {
       actorType: "human",
@@ -118,6 +127,98 @@ test("separates guarded Codex execute intent from dry-run preview after human ap
     mergeAuthority: "human-only",
   });
   assert.deepEqual(intent.diagnostics, []);
+});
+
+test("blocks dogfood execute intent when dry-run proof belongs to a different issue scope", () => {
+  const intent = createCodexAgentInvocationIntent({
+    mode: "execute",
+    capabilityEvidence,
+    workspace: {
+      kind: "repo-relative",
+      path: ".",
+    },
+    allowedExecutionPosture: "execute-enabled",
+    scope: {
+      owner: "TommyKammy",
+      repository: "Ensen-loop",
+      issueNumber: 59,
+    },
+    idempotencyBinding: {
+      key: "issue-59-codex-submit",
+      scopeFingerprint: "TommyKammy-Ensen-loop-59",
+    },
+    dryRunProof: {
+      mode: "dry-run",
+      outcome: "planned",
+      requestId: "req_issue58DryRunProof01",
+      correlationId: "corr_issue58DryRunProof01",
+      completedAt: "2026-05-02T00:05:00.000Z",
+      scope: {
+        owner: "TommyKammy",
+        repository: "Ensen-loop",
+        issueNumber: 58,
+      },
+      idempotencyBinding: {
+        key: "issue-59-codex-submit",
+        scopeFingerprint: "TommyKammy-Ensen-loop-59",
+      },
+    },
+    operatorApproval: {
+      actorType: "human",
+      decision: "execute-after-dry-run",
+      approvedAt: "2026-05-02T00:06:00.000Z",
+    },
+  });
+
+  assert.equal(intent.ok, false);
+  assert.equal(intent.outcome, "blocked");
+  assert.match(intent.diagnostics.join("\n"), /dry-run proof scope does not match execute scope/i);
+});
+
+test("blocks dogfood execute intent when dry-run proof idempotency binding differs", () => {
+  const intent = createCodexAgentInvocationIntent({
+    mode: "execute",
+    capabilityEvidence,
+    workspace: {
+      kind: "repo-relative",
+      path: ".",
+    },
+    allowedExecutionPosture: "execute-enabled",
+    scope: {
+      owner: "TommyKammy",
+      repository: "Ensen-loop",
+      issueNumber: 59,
+    },
+    idempotencyBinding: {
+      key: "issue-59-codex-submit",
+      scopeFingerprint: "TommyKammy-Ensen-loop-59",
+    },
+    dryRunProof: {
+      mode: "dry-run",
+      outcome: "planned",
+      requestId: "req_issue59DryRunProof01",
+      correlationId: "corr_issue59DryRunProof01",
+      completedAt: "2026-05-02T00:05:00.000Z",
+      scope: {
+        owner: "TommyKammy",
+        repository: "Ensen-loop",
+        issueNumber: 59,
+      },
+      idempotencyBinding: {
+        key: "issue-59-codex-submit",
+        scopeFingerprint: "TommyKammy-Ensen-loop-replayed",
+      },
+    },
+    operatorApproval: {
+      actorType: "human",
+      decision: "execute-after-dry-run",
+      approvedAt: "2026-05-02T00:06:00.000Z",
+    },
+  });
+
+  assert.equal(intent.ok, false);
+  assert.equal(intent.outcome, "blocked");
+  assert.match(intent.diagnostics.join("\n"), /dry-run proof idempotency binding does not match/i);
 });
 
 test("allows repo-relative workspace names that contain literal double-dot text", () => {

--- a/test/lane-artifact-output.test.ts
+++ b/test/lane-artifact-output.test.ts
@@ -89,6 +89,15 @@ const agentOutcome = createCodexAgentInvocationIntent({
     requestId: "req_issue60DryRunProof01",
     correlationId: "corr_issue60DryRunProof01",
     completedAt: "2026-05-02T00:04:00.000Z",
+    scope: {
+      owner: "TommyKammy",
+      repository: "Ensen-loop",
+      issueNumber: 60,
+    },
+    idempotencyBinding: {
+      key: "issue-60-codex-submit",
+      scopeFingerprint: "TommyKammy-Ensen-loop-60",
+    },
   },
   operatorApproval: {
     actorType: "human",


### PR DESCRIPTION
## Summary
- require dogfood dry-run proofs to carry explicit owner/repository/issue scope and idempotency provenance
- block execute intent when proof provenance does not match the approved execute scope
- keep matching execute proof plus human approval reaching ready-to-invoke

## Verification
- npm run typecheck
- npm run build
- npm test

Closes #86

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Strengthened operation validation to catch and prevent misaligned requests from executing, improving system safety and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->