### PR TITLE
LOOP-X3A-005 vendor Track A operational evidence profile

### DIFF
--- a/protocol-snapshots/ensen-protocol/v0.3.0/README.md
+++ b/protocol-snapshots/ensen-protocol/v0.3.0/README.md
@@ -1,0 +1,20 @@
+# Ensen-protocol v0.3.0 Operational Evidence Profile Snapshot
+
+This directory is a copied Track A guidance snapshot from `TommyKammy/Ensen-protocol` release tag `v0.3.0`, protocol version `0.3.0`.
+
+The copied source is PROTOCOL-040 from Ensen-protocol issue #50 / PR #51, merged as commit `c33277e5a470883493f10f2c6951a0ca0d5818b0`.
+
+It is intentionally repo-owned by Ensen-loop. Ensen-loop must not require an Ensen-protocol checkout, package, service, fixture path, or runtime dependency to build, test, or operate.
+
+## Contents
+
+- `docs/integration/operational-evidence-profile.md`, copied contract guidance for X-Gate 3 Track A artifact hygiene.
+- `fixtures/operational-evidence-profile/v1/valid/public-fixture-safe-profile.json`, a public fixture-safe profile example.
+
+The copied material is local conformance evidence for owner-controlled repo / solo dogfood hygiene. It is not runtime integration, artifact storage, cleanup, recovery, a credential service, a retention system, or a compliance guarantee.
+
+## Update Policy
+
+Treat this directory as read-only protocol guidance and fixture-like data. Runtime code should access it only through explicit test or protocol helper boundaries.
+
+To update the snapshot, replace this versioned directory from a tagged Ensen-protocol release and update `manifest.json` in the same change. Do not point tests or runtime code at a sibling checkout as a mutable shared dependency.

--- a/protocol-snapshots/ensen-protocol/v0.3.0/docs/integration/operational-evidence-profile.md
+++ b/protocol-snapshots/ensen-protocol/v0.3.0/docs/integration/operational-evidence-profile.md
@@ -1,0 +1,118 @@
+# Operational Evidence Profile
+
+The operational evidence profile is contract guidance for Loop and Flow X-Gate
+3 Track A artifact hygiene checks before owner-controlled real input. It
+describes how evidence and audit artifacts should label publishable examples,
+local references, and producer facts without turning Ensen-protocol into a
+runtime implementation.
+
+This profile preserves the Ensen development charter: protocol over shared
+implementation, bounded execution, evidence before authority, and no premature
+compliance claims.
+
+## Track A Boundary
+
+Track A is owner-controlled repo / solo dogfood only. It is for synthetic and
+owner-controlled protocol evidence while Loop and Flow harden artifact safety
+checks.
+
+Track A non-goals are customer repo input, ERPNext live connector input,
+regulated data, electronic signature workflows, batch release workflows, final
+disposition decisions, and any compliance guarantee.
+
+Ensen-protocol defines this profile as contract text and public conformance
+examples only. It is not a runtime implementation, not artifact storage, not
+cleanup, not recovery, not a credential service, not a retention system, and
+not a compliance guarantee. Loop and Flow remain responsible for their own
+runtime behavior, artifact storage, cleanup, recovery, customer data handling,
+and operational enforcement.
+
+The short boundary rule is: not artifact storage, not cleanup, not recovery.
+
+## Profile Fields
+
+Use these terms when Loop or Flow records, exports, or tests operational
+evidence references:
+
+- `dataClassification`: required handling label for the evidence or audit
+  surface. Public fixture-safe artifacts use `public`. Local real-input
+  artifacts must use `internal`, `confidential`, or `restricted` as appropriate
+  and must not be copied into this repository as fixtures.
+- `checksum`: digest for the referenced evidence body when a stable body exists.
+  EvidenceBundleRef v1 supports `sha256` with a lowercase hexadecimal value.
+  Missing checksums are allowed only when the producing boundary explicitly
+  records why no stable body is available.
+- `producer metadata`: bounded public facts about the producer boundary, such as
+  `producer`, `producerVersion`, `protocolVersion`, `command`, `boundary`, and
+  `createdBy`. Producer metadata must not contain credentials, private repo
+  details, customer identifiers, or workstation-local absolute paths.
+- `retention hint`: advisory handling label such as `publicFixture`,
+  `localEphemeral`, `localRetained`, or `externalControlled`. A retention hint
+  is not a deletion guarantee, archive promise, legal hold, or final disposition
+  decision.
+- `confidential reference`: a local or external pointer to non-public evidence.
+  Confidential references may be recorded in Loop or Flow local artifacts, but
+  they are not public fixtures and must not be published as protocol examples.
+- `public fixture-safe artifact`: synthetic, publishable JSON or Markdown that
+  contains no raw secrets, tokens, customer data, private repository details,
+  regulated data, workstation-local absolute paths, or live credential-bearing
+  URIs.
+
+## Public Fixtures And Local References
+
+Loop and Flow should distinguish public fixture-safe artifacts from local
+confidential reference values at the boundary where evidence is emitted or
+copied:
+
+| Surface | Expected use | Publishable in Ensen-protocol |
+| --- | --- | --- |
+| Public fixture-safe artifact | Synthetic conformance row for parser, audit, or EvidenceBundleRef hygiene tests | Yes |
+| Local confidential reference | Owner-controlled real-input pointer retained in Loop or Flow local state | No |
+| Redacted summary | Public statement that a private artifact exists without exposing the value | Yes, when synthetic |
+
+Public examples should use repo-relative paths, neutral `file:///` examples, or
+placeholders such as `<evidence-root>`, `<credential-ref>`,
+`<repository-ref>`, and `<supervisor-config-path>`. They must not include raw
+workstation-local paths, real repository private details, or values that look
+like credentials.
+
+Local confidential reference values should stay in the implementation
+repository or evidence system that owns them. Protocol examples may describe
+the shape of a confidential reference with placeholders, but must not publish
+the real reference.
+
+## Evidence And Audit Mapping
+
+EvidenceBundleRef should carry the reference location, checksum when available,
+content type, and bounded producer metadata. It should not embed evidence
+bodies, test logs, screenshots, customer data, or secrets.
+
+AuditEvent should record append-only facts about evidence production,
+validation, rejection, or redaction. The audit payload may include
+`dataClassification`, `retentionHint`, redacted `referenceKind`, producer
+boundary, and checksum presence. It must not infer authorization, tenant,
+repository, account, or environment linkage from path shape or operator-facing
+summaries.
+
+Consumers must fail closed when data classification, provenance, scope,
+authorization context, or boundary signals are missing, malformed, or only
+partially trusted. A syntactically valid EvidenceBundleRef or AuditEvent is not
+proof that the referenced evidence is trusted or authorized.
+
+## Conformance Example
+
+The public conformance example lives at
+`fixtures/operational-evidence-profile/v1/valid/public-fixture-safe-profile.json`.
+It is fixture-like guidance, not a new EIP schema family.
+
+Loop and Flow may copy that example into local Track A artifact hygiene tests to
+verify that:
+
+- public examples remain `public` and synthetic;
+- checksum values use the supported `sha256` form;
+- producer metadata remains bounded and public;
+- retention hint values are advisory only;
+- confidential reference shape is represented with placeholders instead of real
+  local values;
+- public fixture-safe artifacts and local confidential references are not
+  treated as interchangeable.

--- a/protocol-snapshots/ensen-protocol/v0.3.0/fixtures/operational-evidence-profile/v1/valid/public-fixture-safe-profile.json
+++ b/protocol-snapshots/ensen-protocol/v0.3.0/fixtures/operational-evidence-profile/v1/valid/public-fixture-safe-profile.json
@@ -1,0 +1,38 @@
+{
+  "profile": "operational-evidence-profile.v1",
+  "scenario": "public-fixture-safe-artifact",
+  "track": "X-Gate 3 Track A",
+  "boundary": "owner-controlled repo / solo dogfood",
+  "evidence": {
+    "dataClassification": "public",
+    "referenceKind": "publicFixtureSafeArtifact",
+    "uri": "artifacts/evidence/synthetic-run/bundle.json",
+    "contentType": "application/json",
+    "checksum": {
+      "algorithm": "sha256",
+      "value": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+    }
+  },
+  "producerMetadata": {
+    "producer": "ensen-loop",
+    "producerVersion": "example-snapshot",
+    "protocolVersion": "example-protocol-snapshot",
+    "command": "npm test",
+    "boundary": "parser"
+  },
+  "retentionHint": "publicFixture",
+  "confidentialReferencePolicy": {
+    "allowedInPublicFixture": false,
+    "placeholder": "<evidence-root>/private-run/bundle.json",
+    "guidance": "Keep local confidential reference values in the owning Loop or Flow evidence boundary."
+  },
+  "nonGoals": [
+    "external repository input",
+    "ERPNext live connector",
+    "regulated data",
+    "electronic signature",
+    "batch release",
+    "final disposition",
+    "compliance guarantee"
+  ]
+}

--- a/protocol-snapshots/ensen-protocol/v0.3.0/manifest.json
+++ b/protocol-snapshots/ensen-protocol/v0.3.0/manifest.json
@@ -1,0 +1,24 @@
+{
+  "source": {
+    "repository": "TommyKammy/Ensen-protocol",
+    "releaseTag": "v0.3.0",
+    "protocolVersion": "0.3.0",
+    "sourceIssue": "https://github.com/TommyKammy/Ensen-protocol/issues/50",
+    "sourcePullRequest": "https://github.com/TommyKammy/Ensen-protocol/pull/51",
+    "sourceMergeCommit": "c33277e5a470883493f10f2c6951a0ca0d5818b0"
+  },
+  "policy": {
+    "updatePolicy": "Copied Track A guidance. Update only by replacing this directory from a tagged Ensen-protocol release.",
+    "runtimeDependency": false,
+    "integrationKind": "local conformance evidence",
+    "boundary": "owner-controlled repo / solo dogfood"
+  },
+  "includes": {
+    "guidance": [
+      "docs/integration/operational-evidence-profile.md"
+    ],
+    "fixtureLikeExamples": [
+      "fixtures/operational-evidence-profile/v1/valid/public-fixture-safe-profile.json"
+    ]
+  }
+}

--- a/test/protocol-snapshot.test.ts
+++ b/test/protocol-snapshot.test.ts
@@ -8,6 +8,11 @@ const snapshotRoot = path.join(
   "ensen-protocol",
   "v0.2.0",
 );
+const operationalEvidenceSnapshotRoot = path.join(
+  "protocol-snapshots",
+  "ensen-protocol",
+  "v0.3.0",
+);
 
 const expectedSchemas = [
   "schemas/eip.evidence-bundle-ref.v1.schema.json",
@@ -28,6 +33,12 @@ const expectedFixtureFamilies = [
 
 async function readJson(relativePath: string): Promise<unknown> {
   return JSON.parse(await readFile(path.join(snapshotRoot, relativePath), "utf8")) as unknown;
+}
+
+async function readOperationalEvidenceSnapshotJson(relativePath: string): Promise<unknown> {
+  return JSON.parse(
+    await readFile(path.join(operationalEvidenceSnapshotRoot, relativePath), "utf8"),
+  ) as unknown;
 }
 
 function assertJsonObject(value: unknown, message: string): asserts value is Record<string, unknown> {
@@ -201,4 +212,76 @@ test("includes protocol v0.2.0 capability variant fixtures without changing EIP 
     runResultSchema.$id,
     "https://eip.ensen.dev/schemas/eip.run-result.v1.schema.json",
   );
+});
+
+test("vendors the Ensen-protocol v0.3.0 Track A operational evidence profile fixture", async () => {
+  const manifest = await readOperationalEvidenceSnapshotJson("manifest.json");
+
+  assert.deepEqual(manifest, {
+    source: {
+      repository: "TommyKammy/Ensen-protocol",
+      releaseTag: "v0.3.0",
+      protocolVersion: "0.3.0",
+      sourceIssue: "https://github.com/TommyKammy/Ensen-protocol/issues/50",
+      sourcePullRequest: "https://github.com/TommyKammy/Ensen-protocol/pull/51",
+      sourceMergeCommit: "c33277e5a470883493f10f2c6951a0ca0d5818b0",
+    },
+    policy: {
+      updatePolicy:
+        "Copied Track A guidance. Update only by replacing this directory from a tagged Ensen-protocol release.",
+      runtimeDependency: false,
+      integrationKind: "local conformance evidence",
+      boundary: "owner-controlled repo / solo dogfood",
+    },
+    includes: {
+      guidance: ["docs/integration/operational-evidence-profile.md"],
+      fixtureLikeExamples: [
+        "fixtures/operational-evidence-profile/v1/valid/public-fixture-safe-profile.json",
+      ],
+    },
+  });
+
+  const profile = await readOperationalEvidenceSnapshotJson(
+    "fixtures/operational-evidence-profile/v1/valid/public-fixture-safe-profile.json",
+  );
+  assertJsonObject(profile, "operational evidence profile fixture must be a JSON object");
+  assert.equal(profile.profile, "operational-evidence-profile.v1");
+  assert.equal(profile.track, "X-Gate 3 Track A");
+  assert.equal(profile.boundary, "owner-controlled repo / solo dogfood");
+
+  const evidence = profile.evidence;
+  assertJsonObject(evidence, "operational evidence fixture evidence must be a JSON object");
+  assert.equal(evidence.dataClassification, "public");
+  assert.equal(evidence.referenceKind, "publicFixtureSafeArtifact");
+  assert.equal(evidence.uri, "artifacts/evidence/synthetic-run/bundle.json");
+
+  const checksum = evidence.checksum;
+  assertJsonObject(checksum, "operational evidence fixture checksum must be a JSON object");
+  assert.equal(checksum.algorithm, "sha256");
+  assert.equal(
+    checksum.value,
+    "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+  );
+
+  const producerMetadata = profile.producerMetadata;
+  assertJsonObject(
+    producerMetadata,
+    "operational evidence fixture producerMetadata must be a JSON object",
+  );
+  assert.equal(producerMetadata.producer, "ensen-loop");
+  assert.equal(producerMetadata.command, "npm test");
+  assert.equal(profile.retentionHint, "publicFixture");
+
+  const confidentialReferencePolicy = profile.confidentialReferencePolicy;
+  assertJsonObject(
+    confidentialReferencePolicy,
+    "operational evidence fixture confidentialReferencePolicy must be a JSON object",
+  );
+  assert.equal(confidentialReferencePolicy.allowedInPublicFixture, false);
+  assert.equal(confidentialReferencePolicy.placeholder, "<evidence-root>/private-run/bundle.json");
+
+  const serializedProfile = JSON.stringify(profile);
+  assert.doesNotMatch(serializedProfile, /\/Users\/|\/home\/|C:\\Users\\/);
+  assert.doesNotMatch(serializedProfile, /:\/\/[^/?#\s]+:[^/?#\s]+@/);
+  assert.doesNotMatch(serializedProfile, /\b(?:token|secret|password|api[_-]?key)\b\s*[:=]/i);
 });

--- a/test/protocol-snapshot.test.ts
+++ b/test/protocol-snapshot.test.ts
@@ -31,6 +31,9 @@ const expectedFixtureFamilies = [
   "run-status",
 ];
 
+const operationalEvidenceSecretLikeKeyPattern =
+  /(?:(["'])(?:token|secret|password|api[_-]?key)\1|(?:token|secret|password|api[_-]?key))\s*[:=]/i;
+
 async function readJson(relativePath: string): Promise<unknown> {
   return JSON.parse(await readFile(path.join(snapshotRoot, relativePath), "utf8")) as unknown;
 }
@@ -283,5 +286,14 @@ test("vendors the Ensen-protocol v0.3.0 Track A operational evidence profile fix
   const serializedProfile = JSON.stringify(profile);
   assert.doesNotMatch(serializedProfile, /\/Users\/|\/home\/|C:\\Users\\/);
   assert.doesNotMatch(serializedProfile, /:\/\/[^/?#\s]+:[^/?#\s]+@/);
-  assert.doesNotMatch(serializedProfile, /\b(?:token|secret|password|api[_-]?key)\b\s*[:=]/i);
+  assert.match(
+    JSON.stringify({ secret: "fixture-placeholder" }),
+    operationalEvidenceSecretLikeKeyPattern,
+    "fixture safety guard must reject quoted secret-like JSON key names",
+  );
+  assert.doesNotMatch(
+    serializedProfile,
+    operationalEvidenceSecretLikeKeyPattern,
+    "operational evidence fixture must not contain secret-like key names",
+  );
 });


### PR DESCRIPTION
## Summary
- vendor the Ensen-protocol v0.3.0 operational evidence profile guidance and public fixture-safe example under a local protocol snapshot
- preserve PROTOCOL-040 provenance for issue #50, PR #51, release v0.3.0, and merge commit c33277e5a470883493f10f2c6951a0ca0d5818b0
- add a snapshot regression test for Track A field coverage and fixture-safety hazards

## Verification
- npm ci
- npm test -- --test-name-pattern "v0.3.0 Track A"
- npm run typecheck
- npm run build
- npm test

Closes #88

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an operational evidence profile specification, usage/update guidance, and a public-fixture example within a new protocol snapshot.

* **Tests**
  * Added validation tests to verify protocol snapshot compliance, fixture metadata, evidence checksums, retention/confidentiality rules, and absence of local paths or secret-like keys.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->