### PR TITLE
Reject private repository details in evidence profile values

### DIFF
--- a/src/protocol/operational-evidence-profile.ts
+++ b/src/protocol/operational-evidence-profile.ts
@@ -62,6 +62,10 @@ const privateScopeKeyPattern =
   /^(?:customer|customerId|organization|owner|privateRepo|repository|repositorySlug|repo|tenant|tenantId)$/i;
 const credentialUriAuthorityPattern =
   /^[A-Za-z][A-Za-z0-9+.-]*:\/\/[^/?#\s]*[^/?#\s:@]+:[^/?#\s:@]+@/;
+const privateRepositoryDetailPatterns: readonly RegExp[] = [
+  /\b(?:https?:\/\/)?github\.com\/[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]*(?:private|customer|tenant|confidential|internal)[A-Za-z0-9_.-]*(?=$|[\s"'`<>)\]}?,.;:/#])/i,
+  /\bgit@github\.com:[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]*(?:private|customer|tenant|confidential|internal)[A-Za-z0-9_.-]*(?:\.git)?(?=$|[\s"'`<>)\]}?,.;:/#])/i,
+];
 const publicEvidenceUriPattern =
   /^artifacts\/evidence\/(?!.*(?:^|\/)\.\.(?:\/|$))[A-Za-z0-9._~@/-]+$/;
 const contentTypePattern =
@@ -377,8 +381,13 @@ function containsUnsafePublicString(value: string): boolean {
 
   return (
     containsUnsafePublicArtifactText(placeholderSafeValue) ||
-    credentialUriAuthorityPattern.test(placeholderSafeValue)
+    credentialUriAuthorityPattern.test(placeholderSafeValue) ||
+    containsPrivateRepositoryDetail(placeholderSafeValue)
   );
+}
+
+function containsPrivateRepositoryDetail(value: string): boolean {
+  return privateRepositoryDetailPatterns.some((pattern) => pattern.test(value));
 }
 
 function containsUnsafeKey(value: unknown): boolean {

--- a/test/operational-evidence-profile.test.ts
+++ b/test/operational-evidence-profile.test.ts
@@ -103,6 +103,42 @@ test("fails closed when public operational evidence contains unsafe values", asy
   }
 });
 
+test("rejects private repository details in allowed public string values", async () => {
+  const profile = await readProfileFixture();
+  const privateRepositoryDetail = "github.com/acme/private-customer-repo";
+  const cases = [
+    {
+      label: "producer metadata producer",
+      mutate: (copy: Record<string, unknown>) => {
+        copy.producerMetadata = {
+          producer: privateRepositoryDetail,
+          command: "npm test",
+        };
+      },
+    },
+    {
+      label: "confidential reference guidance",
+      mutate: (copy: Record<string, unknown>) => {
+        copy.confidentialReferencePolicy = {
+          allowedInPublicFixture: false,
+          placeholder: "<evidence-root>/private-run/bundle.json",
+          guidance: `Use ${privateRepositoryDetail} for the private run.`,
+        };
+      },
+    },
+  ];
+
+  for (const testCase of cases) {
+    const result = validateOperationalEvidenceProfile(cloneWith(profile, testCase.mutate));
+
+    assert.equal(result.ok, false, testCase.label);
+    const diagnostics = result.ok
+      ? ""
+      : result.issues.map((issue) => `${issue.path}: ${issue.message}`).join("\n");
+    assert.doesNotMatch(diagnostics, new RegExp(escapeRegExp(privateRepositoryDetail)));
+  }
+});
+
 test("does not treat public fixture-safe evidence and confidential references as interchangeable", async () => {
   const profile = await readProfileFixture();
   const result = validateOperationalEvidenceProfile(


### PR DESCRIPTION
## Summary
- reject private/customer/internal GitHub repository detail strings through the operational evidence profile public string safety path
- add focused regressions for allowed value positions in producer metadata and confidential reference guidance
- keep diagnostics generic so rejected repository details are not echoed

## Verification
- npm run typecheck
- npm run build
- npm test

Closes #94
Part of #77

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced operational evidence profile validation to detect and reject private repository details in public-facing fields. The system now identifies GitHub repository URLs in both HTTPS and SSH formats as unsafe content, preventing accidental exposure of sensitive repository information.

* **Tests**
  * Added test coverage for private repository detection in operational evidence profiles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->