### PR TITLE
LOOP-X3B-000 intake protocol v0.4.0 Track B boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ The copied Ensen-protocol v0.2.0 schema and conformance fixture snapshot is docu
 
 The copied Ensen-protocol v0.3.0 operational evidence profile snapshot is documented in [protocol-snapshots/ensen-protocol/v0.3.0/README.md](protocol-snapshots/ensen-protocol/v0.3.0/README.md). It is local conformance evidence for X-Gate 3 Track A artifact hygiene, not an Ensen-protocol runtime dependency.
 
+The copied Ensen-protocol v0.4.0 Track B evidence boundary snapshot is documented in [protocol-snapshots/ensen-protocol/v0.4.0/README.md](protocol-snapshots/ensen-protocol/v0.4.0/README.md). It records customer / regulated classification vocabulary and public-safe fixture examples for protocol intake only. It is not production regulated workflow support, ERPNext integration, electronic signature handling, batch release, final disposition, customer repository execution, or a compliance guarantee.
+
 ## X-Gate 3 Track A Closure Evidence
 
 Loop-side X-Gate 3 Track A is closed for the owner-controlled repo / solo dogfood boundary. The closure is limited to Loop-local safety, dry-run proof, copied Protocol guidance intake, and conformance checks. It does not create customer repo execution, automatic merge, compliance claims, Ensen-flow runtime behavior, or Protocol runtime imports. This closure records no Ensen-flow runtime behavior.

--- a/protocol-snapshots/ensen-protocol/v0.4.0/README.md
+++ b/protocol-snapshots/ensen-protocol/v0.4.0/README.md
@@ -1,0 +1,21 @@
+# Ensen-protocol v0.4.0 Track B Evidence Boundary Snapshot
+
+This directory is a copied Track B guidance snapshot from `TommyKammy/Ensen-protocol` release tag `v0.4.0`, protocol version `0.4.0`.
+
+The copied source is Ensen-protocol release commit `f6c3c5bee2574c8660f6954fe58a9e7625daad12`; the annotated tag object is `3e3eddbd0ca654644f7e2676361ff60a80bb972a`.
+
+It is intentionally repo-owned by Ensen-loop. Ensen-loop must not require an Ensen-protocol checkout, package, service, fixture path, or runtime dependency to build, test, or operate.
+
+## Contents
+
+- `docs/integration/customer-regulated-data-classification-profile.md`, copied Track B classification guidance for customer / regulated evidence planning.
+- `docs/integration/approval-and-draft-evidence-semantics.md`, copied Track B approval and draft-only evidence guidance.
+- `fixtures/customer-regulated-data-classification/v1/valid/public-safe-profile.json`, a public fixture-safe Track B classification example.
+- `fixtures/approval-evidence-semantics/v1/valid/public-safe-draft-action.json`, a public fixture-safe draft action example.
+- `schemas/eip.common.v1.schema.json`, copied schema evidence for the v0.4.0 `DataClassification` vocabulary.
+
+The copied material is local conformance evidence for protocol intake. It is not production regulated workflow support, ERPNext integration, customer repository execution, electronic signature handling, batch release, final disposition, runtime storage, or a compliance guarantee.
+
+Treat this directory as read-only protocol guidance and fixture-like data. Runtime code should access it only through explicit test or protocol helper boundaries.
+
+To update the snapshot, replace this versioned directory from a tagged Ensen-protocol release and update `manifest.json` in the same change. Do not point tests or runtime code at a sibling checkout as a mutable shared dependency.

--- a/protocol-snapshots/ensen-protocol/v0.4.0/docs/integration/approval-and-draft-evidence-semantics.md
+++ b/protocol-snapshots/ensen-protocol/v0.4.0/docs/integration/approval-and-draft-evidence-semantics.md
@@ -1,0 +1,125 @@
+# Track B Approval and Draft-Only Evidence Semantics
+
+Track B approval and draft-only evidence semantics define shared protocol
+vocabulary that Loop, Flow, Pharma, and future consumers can cite when an
+artifact records a proposed action, a human approval point, or a later approval
+state.
+
+This profile is contract text only. It does not add a runtime approval engine,
+workflow implementation, connector, ERPNext integration, electronic signature
+service, batch release process, final disposition process, validated system, or
+compliance guarantee.
+
+## Approval Vocabulary
+
+Use these values when approval state must be represented in Track B artifacts:
+
+| Value | Meaning |
+| --- | --- |
+| `approval-required` | A human approval point is required before the action can be committed or externally applied. |
+| `approved` | The required human approval point has been recorded by the authoritative workflow boundary. |
+| `rejected` | The proposed action or evidence was declined and must not be treated as approved or applied. |
+| `revoked` | A previously recorded approval was withdrawn by the authoritative workflow boundary. |
+| `superseded` | A newer proposal, approval record, or evidence record replaces this one for future handling. |
+
+These values describe evidence state. They do not make the protocol the final
+quality decision maker. Consumers must resolve authority, actor eligibility,
+tenant or repository scope, electronic record requirements, and final
+disposition rules in their own runtime or validation package boundary.
+
+## Draft-Only Action Artifacts
+
+A draft-only action artifact records an intended action before it is committed
+or externally applied. It is useful for read-only review, draft workflow
+planning, and evidence handoff where the protocol needs to describe the
+proposal without granting permission to mutate an external system.
+
+A draft-only action artifact should make these facts explicit:
+
+- the action intent is draft-only;
+- the external application state is not-applied;
+- the approval state is either `approval-required`, `rejected`, `revoked`, or
+  `superseded` until the authoritative workflow boundary records `approved`;
+- the artifact is not a committed artifact and not an externally applied
+  artifact;
+- any customer / regulated data classification follows
+  `customer-regulated-data-classification-profile.md`.
+
+A committed artifact is evidence that the producer boundary accepted the action
+as part of its durable state. An externally applied artifact is evidence that a
+consumer or connector boundary applied the action outside the protocol artifact
+itself. The protocol can reference those facts, but it does not perform the
+commit or external write-back.
+
+## AuditEvent Usage
+
+AuditEvent may record append-only facts about approval-required, approved,
+rejected, revoked, or superseded evidence. Event types should name the owning
+consumer namespace, for example `flow.approval.required` or
+`pharma.approval.rejected`.
+
+AuditEvent payloads should include bounded fields such as approval state,
+draft-only intent, not-applied external state, approver or reviewer reference,
+decision time, superseded reference id, rejection reason category, or revoked
+approval reference. They must not contain raw secrets, credentials, customer
+records, regulated record payloads, private repository details, live write-back
+tokens, electronic signature material, batch release records, final disposition
+records, or workstation-local absolute paths.
+
+Rejected, revoked, and superseded states are new append-only facts. Consumers
+should not edit older events to make them look as if they were never required
+or never approved.
+
+## EvidenceBundleRef Usage
+
+EvidenceBundleRef may point to a bounded approval evidence body, draft-only
+action artifact, rejection note, revocation record, or supersession record. The
+reference remains a reference artifact only; it does not embed the evidence
+body and does not prove the body is authorized for the current consumer.
+
+EvidenceBundleRef metadata may include public descriptors such as
+`approvalState`, `artifactIntent`, `externalApplicationState`,
+`supersedesRef`, or `decisionBoundary` when those values are synthetic,
+bounded, and safe for the exchange. Customer / regulated references require the
+Track B classification profile before they are handled.
+
+If provenance, approval authority, actor eligibility, scope binding,
+classification, or evidence boundary signals are missing or malformed,
+consumers should fail closed by rejecting, blocking, quarantining, or routing a
+follow-up instead of inferring approval from nearby names, path shape, comments,
+issue text, or operator-facing summaries.
+
+## Public Fixture Safety
+
+Public examples for this profile must remain synthetic and publishable. They
+must not contain customer data, regulated data, raw secrets, credentials,
+access tokens, private repository details, workstation-local absolute paths,
+live ERPNext write-back targets, electronic signature records, batch release
+records, final disposition records, or real external mutation evidence.
+
+Use placeholders such as `<approval-boundary>`, `<reviewer-ref>`,
+`<controlled-evidence-root>`, `<repository-ref>`, and
+`<supervisor-config-path>` when an example needs to name a boundary without
+exposing local or private state.
+
+The public-safe conformance example lives at
+`fixtures/approval-evidence-semantics/v1/valid/public-safe-draft-action.json`.
+It is fixture-like guidance, not a new EIP schema family.
+
+## Track B Non-Claims
+
+This profile gives downstream consumers a shared vocabulary for approval
+evidence. It is:
+
+- not automatic quality decision support;
+- not live write-back approval;
+- not electronic signature;
+- not batch release;
+- not final disposition;
+- not a validated system;
+- not a compliance guarantee.
+
+Loop, Flow, Pharma, and future consumers remain responsible for runtime
+authorization, human review UX, electronic record controls, quality decisions,
+customer boundary enforcement, regulated workflow controls, connector behavior,
+storage, retention, and validation evidence.

--- a/protocol-snapshots/ensen-protocol/v0.4.0/docs/integration/customer-regulated-data-classification-profile.md
+++ b/protocol-snapshots/ensen-protocol/v0.4.0/docs/integration/customer-regulated-data-classification-profile.md
@@ -1,0 +1,154 @@
+# Track B Customer / Regulated Data Classification Profile
+
+The Track B customer / regulated data classification profile defines the
+shared protocol vocabulary that Loop, Flow, Pharma, and future consumers can
+cite before customer or regulated evidence work begins.
+
+This profile is contract text only. It preserves the Ensen development charter:
+protocol over shared implementation, bounded execution, evidence before
+authority, and no premature compliance claims. It does not add a runtime
+validator package, connector, SDK, ERPNext integration, customer data access, or
+compliance guarantee.
+
+## Vocabulary
+
+Use the common `DataClassification` values from
+`schemas/eip.common.v1.schema.json`:
+
+| Value | Boundary |
+| --- | --- |
+| `public` | Synthetic fixture, example, documentation, or conformance data that is safe to publish. |
+| `internal` | Routine non-public protocol or operator evidence that is not customer-owned and not regulated. |
+| `confidential` | Sensitive business or user production facts that are not specifically customer-owned or regulated. |
+| `customer-confidential` | Customer-owned, customer-identifying, customer-provided, or customer-system-derived information. |
+| `regulated` | Evidence or data subject to regulated handling, privacy, retention, validation, electronic record, or domain-specific controls. |
+
+`restricted` remains a legacy high-sensitivity v1 label, but Track B customer /
+regulated references should use `customer-confidential` or `regulated` when
+those boundaries apply.
+
+## When Classification Required
+
+classification required is the Track B rule that a producer must emit an
+explicit profile value before customer / regulated evidence handling begins.
+
+Classification required applies before any Track B customer / regulated
+reference or evidence artifact is accepted, copied, exported, or used as
+handoff evidence.
+
+Classification is required for:
+
+- EvidenceBundleRef artifacts that point at customer evidence, regulated
+  evidence, customer system output, or regulated workflow evidence;
+- AuditEvent payloads that describe customer / regulated evidence production,
+  validation, rejection, redaction, retention, or handoff;
+- operational evidence profile records that cross from Track A synthetic or
+  owner-controlled evidence into Track B customer / regulated handling;
+- fixture-like examples that describe customer / regulated behavior, even when
+  the checked-in values are synthetic and `public`;
+- protocol snapshot records that name customer / regulated fixture families,
+  profile documents, or consumer-side conformance evidence.
+
+The fail-closed trigger is missing or unknown classification. Consumers should
+reject, block, quarantine, or route an explicit follow-up when classification is
+absent, not in the common vocabulary, inconsistent with the evidence boundary,
+or only implied by names, paths, comments, issue text, operator summaries,
+tenant hints, repository names, or nearby metadata.
+
+In short: missing classification and unknown classification must fail closed.
+
+## Artifact Mapping
+
+EvidenceBundleRef should carry only a stable reference, checksum when
+available, content type, and bounded public metadata. It must not embed
+customer data, regulated data, private repository details, raw secrets, or
+evidence bodies. For Track B, the reference handling boundary must have an
+explicit classification before the reference is used.
+
+A confidential reference is a reference to controlled material, not the
+controlled material itself. It may describe that a non-public artifact exists
+only through these bounded fields:
+
+- stable id: a durable synthetic identifier for the reference record, not a
+  customer identifier, tenant name, credential value, account id, repository
+  path, or regulated record id;
+- URI or locator: a placeholder or controlled-boundary locator such as
+  `<controlled-evidence-root>/...`, never a raw workstation-local absolute
+  path, live ERPNext URL, credential-bearing URI, private repository detail, or
+  exposed customer system path;
+- checksum: the digest algorithm and value for the controlled material when a
+  stable body exists, or an explicit producer reason when no stable body can be
+  digested;
+- producer metadata: bounded facts such as producer name, producer boundary,
+  protocol version, production time, and validation command, with no raw
+  secrets, credentials, tokens, private repository details, or workstation-local
+  paths;
+- data classification: the explicit `customer-confidential` or `regulated`
+  handling value for real controlled material, or `public` only when the value
+  is a synthetic public fixture example.
+
+Confidential references must be handled as not raw secret, not raw credential,
+not raw customer record, and not raw regulated record payloads. When any of the
+stable id, URI or locator, checksum expectation, producer metadata, or data
+classification signals are missing, malformed, or only inferred from nearby
+metadata, consumers should reject, quarantine, or route a follow-up instead of
+accepting the reference.
+
+AuditEvent should record append-only facts about classification, production,
+validation, rejection, redaction, and handoff. AuditEvent payloads may include
+`dataClassification`, redacted reference kind, producer boundary, checksum
+presence, and follow-up routing. They must not infer customer, tenant,
+repository, account, issue, environment, authorization, or regulated status from
+path shape or operator-facing summaries.
+
+The Track A `docs/integration/operational-evidence-profile.md` remains the
+public fixture-safe artifact hygiene profile. Track B uses the same public
+fixture safety rules, then adds required customer / regulated classification
+before any customer / regulated references are handled.
+
+The protocol snapshot policy in `docs/protocol-snapshot-policy.md` should name
+this profile when a copied snapshot includes Track B customer / regulated
+classification docs, fixtures, or downstream conformance evidence.
+
+Approval-required, approved, rejected, revoked, superseded, and draft-only
+action evidence should also follow
+`docs/integration/approval-and-draft-evidence-semantics.md`. Classification is
+still required for customer / regulated approval evidence, and approval state
+must not be inferred from names, paths, comments, issue text, operator
+summaries, or nearby metadata.
+
+## Public Fixture Safety
+
+Public examples for this profile must remain synthetic and publishable. They
+must use `public` classification and must not contain customer data, regulated
+data, raw secrets, credentials, access tokens, private repository details,
+workstation-local absolute paths, live ERPNext write-back targets, electronic
+signature records, batch release records, or final disposition records.
+
+Use placeholders such as `<customer-ref>`, `<regulated-evidence-ref>`,
+`<credential-ref>`, `<repository-ref>`, `<evidence-root>`, and
+`<supervisor-config-path>` when a profile example needs to name a boundary
+without exposing local or private state.
+
+The public-safe conformance example lives at
+`fixtures/customer-regulated-data-classification/v1/valid/public-safe-profile.json`.
+It is fixture-like guidance, not a new EIP schema family.
+
+## Track B Non-Claims
+
+Track B reached means the protocol contract has enough vocabulary for downstream
+customer / regulated evidence handling work to begin.
+
+- not production-ready
+- not a validated system
+- not a compliance guarantee
+- not automatic quality decision support
+- not live ERPNext write-back
+- not electronic signature
+- not batch release
+- not final disposition approval
+
+Loop, Flow, Pharma, and future consumers remain responsible for runtime
+authorization, customer boundary enforcement, regulated workflow controls,
+credential handling, storage, retention, audit storage, validation evidence,
+and any domain-specific compliance work.

--- a/protocol-snapshots/ensen-protocol/v0.4.0/fixtures/approval-evidence-semantics/v1/valid/public-safe-draft-action.json
+++ b/protocol-snapshots/ensen-protocol/v0.4.0/fixtures/approval-evidence-semantics/v1/valid/public-safe-draft-action.json
@@ -1,0 +1,55 @@
+{
+  "profile": "Track B approval and draft-only evidence semantics",
+  "schemaVersion": "approval-evidence-semantics.example.v1",
+  "dataClassification": "public",
+  "approvalVocabulary": [
+    "approval-required",
+    "approved",
+    "rejected",
+    "revoked",
+    "superseded"
+  ],
+  "draftOnlyActionArtifact": {
+    "id": "draft_action_01HX3K7Y2H5N8R4P9Q6M1A2B3C",
+    "intent": "draft-only",
+    "approvalState": "approval-required",
+    "externalApplicationState": "not-applied",
+    "subjectRef": "<repository-ref>",
+    "approvalBoundary": "<approval-boundary>",
+    "reviewerRef": "<reviewer-ref>"
+  },
+  "auditEventUsage": {
+    "schemaVersion": "eip.audit-event.v1",
+    "type": "flow.approval.required",
+    "payloadShape": {
+      "approvalState": "approval-required",
+      "artifactIntent": "draft-only",
+      "externalApplicationState": "not-applied",
+      "decisionBoundary": "<approval-boundary>"
+    }
+  },
+  "evidenceBundleRefUsage": {
+    "schemaVersion": "eip.evidence-bundle-ref.v1",
+    "type": "local_path",
+    "uri": "fixtures/approval-evidence-semantics/v1/valid/public-safe-draft-action.json",
+    "metadataShape": {
+      "approvalState": "approval-required",
+      "artifactIntent": "draft-only",
+      "externalApplicationState": "not-applied"
+    }
+  },
+  "rejectedRevokedSupersededHandling": {
+    "rejected": "append a rejected evidence fact and keep the action not-applied",
+    "revoked": "append a revoked evidence fact and require a new authoritative approval before applying",
+    "superseded": "append a superseded evidence fact that points to the newer authoritative reference"
+  },
+  "nonClaims": [
+    "not automatic quality decision",
+    "not live write-back approval",
+    "not electronic signature",
+    "not batch release",
+    "not final disposition",
+    "not a validated system",
+    "not a compliance guarantee"
+  ]
+}

--- a/protocol-snapshots/ensen-protocol/v0.4.0/fixtures/customer-regulated-data-classification/v1/valid/public-safe-profile.json
+++ b/protocol-snapshots/ensen-protocol/v0.4.0/fixtures/customer-regulated-data-classification/v1/valid/public-safe-profile.json
@@ -1,0 +1,56 @@
+{
+  "profile": "track-b-classification.v1",
+  "scenario": "public-safe-track-b-profile",
+  "track": "X-Gate 3 Track B",
+  "boundary": "customer / regulated evidence planning",
+  "exampleClassification": "public",
+  "classificationTerms": [
+    "public",
+    "internal",
+    "confidential",
+    "customer-confidential",
+    "regulated"
+  ],
+  "classificationRequiredFor": [
+    "EvidenceBundleRef Track B evidence references",
+    "AuditEvent regulated evidence handling facts",
+    "operational evidence profile handoff records",
+    "protocol snapshot records that include Track B classification evidence"
+  ],
+  "failClosedPolicy": {
+    "missingClassification": "reject or route explicit follow-up",
+    "unknownClassification": "reject or route explicit follow-up",
+    "inferredClassification": "do not infer from path shape, repository naming, or operator summaries"
+  },
+  "publicFixtureSafety": {
+    "containsCustomerData": false,
+    "containsRegulatedData": false,
+    "containsSecrets": false,
+    "containsPrivateRepositoryDetails": false,
+    "containsWorkstationLocalAbsolutePath": false,
+    "placeholderEvidenceRoot": "<evidence-root>/track-b/public-safe-example.json"
+  },
+  "confidentialReferenceExample": {
+    "id": "confref_synthetic_0001",
+    "locator": "<controlled-evidence-root>/track-b/synthetic-reference.json",
+    "checksum": {
+      "algorithm": "sha256",
+      "value": "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"
+    },
+    "producerMetadata": {
+      "producer": "synthetic-producer",
+      "boundary": "protocol-example",
+      "producedAt": "2026-01-01T00:00:00Z"
+    },
+    "dataClassification": "public"
+  },
+  "nonClaims": [
+    "not production-ready",
+    "not a validated system",
+    "not a compliance guarantee",
+    "not live ERPNext write-back",
+    "not electronic signature",
+    "not batch release",
+    "not final disposition approval"
+  ]
+}

--- a/protocol-snapshots/ensen-protocol/v0.4.0/manifest.json
+++ b/protocol-snapshots/ensen-protocol/v0.4.0/manifest.json
@@ -1,0 +1,29 @@
+{
+  "source": {
+    "repository": "TommyKammy/Ensen-protocol",
+    "releaseTag": "v0.4.0",
+    "protocolVersion": "0.4.0",
+    "sourceRelease": "https://github.com/TommyKammy/Ensen-protocol/releases/tag/v0.4.0",
+    "sourceReleaseCommit": "f6c3c5bee2574c8660f6954fe58a9e7625daad12",
+    "sourceTagObject": "3e3eddbd0ca654644f7e2676361ff60a80bb972a",
+    "sourceImplementationCommits": ["6fb03f7", "4e16a28", "7caf6a2"]
+  },
+  "policy": {
+    "updatePolicy": "Copied Track B guidance. Update only by replacing this directory from a tagged Ensen-protocol release.",
+    "runtimeDependency": false,
+    "integrationKind": "local conformance evidence",
+    "boundary": "customer / regulated evidence planning",
+    "productionRegulatedWorkflowSupport": false
+  },
+  "includes": {
+    "guidance": [
+      "docs/integration/customer-regulated-data-classification-profile.md",
+      "docs/integration/approval-and-draft-evidence-semantics.md"
+    ],
+    "fixtureLikeExamples": [
+      "fixtures/customer-regulated-data-classification/v1/valid/public-safe-profile.json",
+      "fixtures/approval-evidence-semantics/v1/valid/public-safe-draft-action.json"
+    ],
+    "schemaEvidence": ["schemas/eip.common.v1.schema.json"]
+  }
+}

--- a/protocol-snapshots/ensen-protocol/v0.4.0/schemas/eip.common.v1.schema.json
+++ b/protocol-snapshots/ensen-protocol/v0.4.0/schemas/eip.common.v1.schema.json
@@ -1,0 +1,215 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://eip.ensen.dev/schemas/eip.common.v1.schema.json",
+  "title": "EIP Common v1 Fixture Envelope",
+  "description": "Common schema conventions and reusable v1 type definitions for EIP artifacts.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "artifactId",
+    "correlationId",
+    "createdAt",
+    "actor",
+    "source",
+    "workItem",
+    "changeRequest",
+    "evidenceBundle",
+    "classification"
+  ],
+  "properties": {
+    "artifactId": {
+      "$ref": "#/$defs/PrefixedId"
+    },
+    "correlationId": {
+      "$ref": "#/$defs/CorrelationId"
+    },
+    "createdAt": {
+      "$ref": "#/$defs/IsoDateTimeUtc"
+    },
+    "actor": {
+      "$ref": "#/$defs/ActorRef"
+    },
+    "source": {
+      "$ref": "#/$defs/SourceRef"
+    },
+    "workItem": {
+      "$ref": "#/$defs/WorkItemRef"
+    },
+    "changeRequest": {
+      "$ref": "#/$defs/ChangeRequestRef"
+    },
+    "evidenceBundle": {
+      "$ref": "#/$defs/EvidenceBundleRef"
+    },
+    "classification": {
+      "$ref": "#/$defs/DataClassification"
+    },
+    "error": {
+      "$ref": "#/$defs/ErrorInfo"
+    },
+    "extensions": {
+      "$ref": "#/$defs/ExtensionMap"
+    }
+  },
+  "$defs": {
+    "PrefixedId": {
+      "type": "string",
+      "description": "Stable protocol identifier with a registered 2-8 character lowercase semantic prefix, underscore separator, and opaque suffix.",
+      "pattern": "^(?:actor|artifact|corr|cr|evb|evt|flowstep|policy|pr|repo|req|run|source|sts|workitem)_[A-Za-z0-9][A-Za-z0-9._~-]{5,127}$"
+    },
+    "CorrelationId": {
+      "type": "string",
+      "description": "Opaque idempotency and tracing identifier shared by related protocol artifacts.",
+      "pattern": "^corr_[A-Za-z0-9][A-Za-z0-9._~-]{11,127}$"
+    },
+    "IsoDateTimeUtc": {
+      "type": "string",
+      "description": "UTC timestamp using ISO 8601 extended format with a literal Z offset.",
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?Z$"
+    },
+    "ActorRef": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["actorId", "actorType"],
+      "properties": {
+        "actorId": {
+          "$ref": "#/$defs/PrefixedId"
+        },
+        "actorType": {
+          "type": "string",
+          "enum": ["human", "workflow", "system", "api_client", "connector", "executor", "agent"]
+        },
+        "displayName": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 160
+        }
+      }
+    },
+    "SourceRef": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["sourceId", "sourceType"],
+      "properties": {
+        "sourceId": {
+          "$ref": "#/$defs/PrefixedId"
+        },
+        "sourceType": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 80,
+          "pattern": "^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$"
+        },
+        "externalRef": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 240
+        }
+      }
+    },
+    "WorkItemRef": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["workItemId"],
+      "properties": {
+        "workItemId": {
+          "$ref": "#/$defs/PrefixedId"
+        },
+        "title": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 240
+        }
+      }
+    },
+    "ChangeRequestRef": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["changeRequestId"],
+      "properties": {
+        "changeRequestId": {
+          "$ref": "#/$defs/PrefixedId"
+        },
+        "status": {
+          "type": "string",
+          "enum": ["draft", "open", "accepted", "rejected", "superseded"]
+        }
+      }
+    },
+    "EvidenceBundleRef": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["evidenceBundleId"],
+      "properties": {
+        "evidenceBundleId": {
+          "$ref": "#/$defs/PrefixedId"
+        },
+        "digest": {
+          "type": "string",
+          "pattern": "^sha256:[a-f0-9]{64}$"
+        }
+      }
+    },
+    "ErrorInfo": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["code", "message"],
+      "properties": {
+        "code": {
+          "type": "string",
+          "pattern": "^[A-Z][A-Z0-9_]{2,63}$"
+        },
+        "message": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 1000
+        },
+        "retryable": {
+          "type": "boolean"
+        },
+        "details": {
+          "type": "object",
+          "additionalProperties": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "integer"
+              },
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        }
+      }
+    },
+    "ExtensionMap": {
+      "type": "object",
+      "description": "Vendor or artifact-specific extension values. Extension keys must use the x- prefix.",
+      "propertyNames": {
+        "pattern": "^x-.+$"
+      },
+      "additionalProperties": true
+    },
+    "DataClassification": {
+      "type": "string",
+      "description": "Classification label for fixture and production data handling. Track B customer and regulated evidence uses customer-confidential or regulated when those boundaries apply.",
+      "enum": [
+        "public",
+        "internal",
+        "confidential",
+        "customer-confidential",
+        "regulated",
+        "restricted"
+      ]
+    }
+  }
+}

--- a/src/protocol/run-request.ts
+++ b/src/protocol/run-request.ts
@@ -53,7 +53,13 @@ export interface RunRequest {
   readonly createdAt: string;
   readonly target?: RunRequestTarget;
   readonly policyContext?: RunRequestPolicyContext;
-  readonly dataClassification?: "public" | "internal" | "confidential" | "restricted";
+  readonly dataClassification?:
+    | "public"
+    | "internal"
+    | "confidential"
+    | "customer-confidential"
+    | "regulated"
+    | "restricted";
   readonly extensions?: Record<string, unknown>;
 }
 
@@ -212,6 +218,8 @@ const dataClassifications = new Set<unknown>([
   "public",
   "internal",
   "confidential",
+  "customer-confidential",
+  "regulated",
   "restricted",
 ]);
 
@@ -438,7 +446,7 @@ function collectRunRequestIssues(value: unknown): readonly RunRequestValidationI
     "dataClassification",
     value.dataClassification,
     dataClassifications,
-    "dataClassification must be one of: public, internal, confidential, restricted.",
+    "dataClassification must be one of: public, internal, confidential, customer-confidential, regulated, restricted.",
     true,
   );
   collectExtensionsIssues(issues, value.extensions);

--- a/test/operational-evidence-profile.test.ts
+++ b/test/operational-evidence-profile.test.ts
@@ -183,6 +183,30 @@ test("does not treat public fixture-safe evidence and confidential references as
   );
 });
 
+test("rejects Track B classifications in public operational evidence fixtures", async () => {
+  const profile = await readProfileFixture();
+
+  for (const dataClassification of ["customer-confidential", "regulated"]) {
+    const result = validateOperationalEvidenceProfile(
+      cloneWith(profile, (copy) => {
+        copy.evidence = {
+          dataClassification,
+          referenceKind: "publicFixtureSafeArtifact",
+          uri: "artifacts/evidence/synthetic-run/bundle.json",
+        };
+      }),
+    );
+
+    assert.equal(result.ok, false, `${dataClassification} must not be accepted in public fixtures`);
+    assert.ok(
+      result.ok
+        ? false
+        : result.issues.some((issue) => issue.path === "evidence.dataClassification"),
+      `${dataClassification} rejection must identify the evidence classification boundary`,
+    );
+  }
+});
+
 test("keeps checksum and retention hints within the public conformance profile", async () => {
   const profile = await readProfileFixture();
   const result = validateOperationalEvidenceProfile(

--- a/test/protocol-snapshot.test.ts
+++ b/test/protocol-snapshot.test.ts
@@ -13,6 +13,11 @@ const operationalEvidenceSnapshotRoot = path.join(
   "ensen-protocol",
   "v0.3.0",
 );
+const trackBEvidenceSnapshotRoot = path.join(
+  "protocol-snapshots",
+  "ensen-protocol",
+  "v0.4.0",
+);
 
 const expectedSchemas = [
   "schemas/eip.evidence-bundle-ref.v1.schema.json",
@@ -41,6 +46,12 @@ async function readJson(relativePath: string): Promise<unknown> {
 async function readOperationalEvidenceSnapshotJson(relativePath: string): Promise<unknown> {
   return JSON.parse(
     await readFile(path.join(operationalEvidenceSnapshotRoot, relativePath), "utf8"),
+  ) as unknown;
+}
+
+async function readTrackBEvidenceSnapshotJson(relativePath: string): Promise<unknown> {
+  return JSON.parse(
+    await readFile(path.join(trackBEvidenceSnapshotRoot, relativePath), "utf8"),
   ) as unknown;
 }
 
@@ -296,4 +307,87 @@ test("vendors the Ensen-protocol v0.3.0 Track A operational evidence profile fix
     operationalEvidenceSecretLikeKeyPattern,
     "operational evidence fixture must not contain secret-like key names",
   );
+});
+
+test("vendors the Ensen-protocol v0.4.0 Track B customer and regulated evidence boundary", async () => {
+  const manifest = await readTrackBEvidenceSnapshotJson("manifest.json");
+
+  assert.deepEqual(manifest, {
+    source: {
+      repository: "TommyKammy/Ensen-protocol",
+      releaseTag: "v0.4.0",
+      protocolVersion: "0.4.0",
+      sourceRelease: "https://github.com/TommyKammy/Ensen-protocol/releases/tag/v0.4.0",
+      sourceReleaseCommit: "f6c3c5bee2574c8660f6954fe58a9e7625daad12",
+      sourceTagObject: "3e3eddbd0ca654644f7e2676361ff60a80bb972a",
+      sourceImplementationCommits: ["6fb03f7", "4e16a28", "7caf6a2"],
+    },
+    policy: {
+      updatePolicy:
+        "Copied Track B guidance. Update only by replacing this directory from a tagged Ensen-protocol release.",
+      runtimeDependency: false,
+      integrationKind: "local conformance evidence",
+      boundary: "customer / regulated evidence planning",
+      productionRegulatedWorkflowSupport: false,
+    },
+    includes: {
+      guidance: [
+        "docs/integration/customer-regulated-data-classification-profile.md",
+        "docs/integration/approval-and-draft-evidence-semantics.md",
+      ],
+      fixtureLikeExamples: [
+        "fixtures/customer-regulated-data-classification/v1/valid/public-safe-profile.json",
+        "fixtures/approval-evidence-semantics/v1/valid/public-safe-draft-action.json",
+      ],
+      schemaEvidence: ["schemas/eip.common.v1.schema.json"],
+    },
+  });
+
+  const schema = await readTrackBEvidenceSnapshotJson("schemas/eip.common.v1.schema.json");
+  assertJsonObject(schema, "Track B common schema snapshot must be a JSON object");
+  const defs = schema.$defs;
+  assertJsonObject(defs, "Track B common schema snapshot must define $defs");
+  const dataClassification = defs.DataClassification;
+  assertJsonObject(
+    dataClassification,
+    "Track B common schema snapshot must define DataClassification",
+  );
+  assert.deepEqual(dataClassification.enum, [
+    "public",
+    "internal",
+    "confidential",
+    "customer-confidential",
+    "regulated",
+    "restricted",
+  ]);
+
+  const profile = await readTrackBEvidenceSnapshotJson(
+    "fixtures/customer-regulated-data-classification/v1/valid/public-safe-profile.json",
+  );
+  assertJsonObject(profile, "Track B classification profile fixture must be a JSON object");
+  assert.equal(profile.profile, "track-b-classification.v1");
+  assert.equal(profile.track, "X-Gate 3 Track B");
+  assert.equal(profile.boundary, "customer / regulated evidence planning");
+  assert.deepEqual(profile.classificationTerms, [
+    "public",
+    "internal",
+    "confidential",
+    "customer-confidential",
+    "regulated",
+  ]);
+
+  const publicFixtureSafety = profile.publicFixtureSafety;
+  assertJsonObject(
+    publicFixtureSafety,
+    "Track B classification fixture publicFixtureSafety must be a JSON object",
+  );
+  assert.equal(publicFixtureSafety.containsCustomerData, false);
+  assert.equal(publicFixtureSafety.containsRegulatedData, false);
+  assert.equal(publicFixtureSafety.containsSecrets, false);
+  assert.equal(publicFixtureSafety.containsPrivateRepositoryDetails, false);
+  assert.equal(publicFixtureSafety.containsWorkstationLocalAbsolutePath, false);
+
+  const serializedProfile = JSON.stringify(profile);
+  assert.doesNotMatch(serializedProfile, /\/Users\/|\/home\/|C:\\Users\\/);
+  assert.doesNotMatch(serializedProfile, /:\/\/[^/?#\s]+:[^/?#\s]+@/);
 });

--- a/test/run-request-input.test.ts
+++ b/test/run-request-input.test.ts
@@ -204,6 +204,22 @@ test("accepts non-repository RunRequest targets with protocol prefixed ids", asy
   }
 });
 
+test("accepts Track B customer and regulated RunRequest classification labels", async () => {
+  const fixture = path.join(runRequestFixtureRoot, "valid", "github-issue-request.json");
+  const base = await readJson(fixture);
+  assertRecord(base, "fixture");
+
+  for (const dataClassification of ["public", "internal", "customer-confidential", "regulated"]) {
+    const request = structuredClone(base);
+    assertRecord(request, "request");
+    request.dataClassification = dataClassification;
+
+    const result = validateRunRequest(request);
+
+    assert.equal(result.ok, true, `${dataClassification} classification must be accepted`);
+  }
+});
+
 test("rejects malformed and non-HTTPS RunRequest work item URLs", async () => {
   const fixture = path.join(runRequestFixtureRoot, "valid", "github-issue-request.json");
   const base = await readJson(fixture);


### PR DESCRIPTION
## Summary
- vendor Ensen-protocol v0.4.0 Track B customer / regulated evidence boundary snapshot under protocol-snapshots
- accept v0.4.0 Track B RunRequest dataClassification labels at the explicit protocol input boundary
- keep public operational evidence fixtures fail-closed for customer-confidential and regulated classifications
- document that this is protocol intake only, not production regulated workflow support

## Verification
- npm install
- npm run typecheck
- npm run build
- npm test
- node --test dist/test/eip-conformance-fixtures.test.js

Closes #96