### PR TITLE
LOOP-X3B-001: Add customer repo allowlist boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ The Phase 3 bounded local lane execution contract is defined in [docs/architectu
 
 The Phase 4 dogfood provider capability boundary is defined in [docs/architecture/provider-capabilities.md](docs/architecture/provider-capabilities.md).
 
+The X-Gate 3 Track B customer repository allowlist policy boundary is defined in [docs/architecture/local-lane-execution.md](docs/architecture/local-lane-execution.md). It is a local safety boundary for explicit owner, repo, path, purpose, and approval-note authorization. It is not production-ready customer execution, regulated workflow support, or a compliance guarantee.
+
 The X-Gate 3 local fake lane smoke command is documented in [docs/runbooks/x-gate3-local-lane-smoke.md](docs/runbooks/x-gate3-local-lane-smoke.md).
 
 The Ensen-loop mission and development charter alignment are summarized in [docs/mission.md](docs/mission.md).

--- a/docs/architecture/local-lane-execution.md
+++ b/docs/architecture/local-lane-execution.md
@@ -112,6 +112,25 @@ pickup allowlist is not execution authority by itself. Execution-capable dogfood
 lanes must still match the dogfood repository allowlist at the local lane
 boundary.
 
+Track B customer repository preparation uses a separate customer repository
+allowlist. Customer repositories are not owner-controlled dogfood repositories
+and must not reuse the dogfood allowlist, GitHub pickup allowlist, issue text, or
+path naming conventions as execution authority. Each matching customer entry
+must explicitly bind the repository owner, repository name, `<repository-root>`,
+purpose, and approval note. Missing, malformed, placeholder, or mismatched
+customer policy facts block before prepare mode creates lane workspaces, state
+directories, provider sessions, branches, pull requests, or agent execution.
+Customer diagnostics name only the failing category, such as `owner`, `repo`,
+`repositoryRoot`, `purpose`, or `approvalNote`; they must not echo customer
+repository names, domains, local paths, or purpose text into public artifacts.
+
+Customer lane skeleton output and LaneRunState journal entries use sanitized
+customer placeholders instead of raw customer repository details. The allowlist
+match proves only that the local Track B safety boundary was satisfied for this
+bounded preparation step. It is not production-ready customer execution,
+regulated workflow support, ERPNext integration, electronic signature handling,
+batch release, final disposition, or a compliance guarantee.
+
 Prepare mode is explicit. It creates only the Ensen-loop local lane workspace
 and state directories, writes a queued LaneRunState, and records branch intent,
 repository scope, idempotency, and cleanup facts in the Lane Journal. It still

--- a/docs/architecture/provider-capabilities.md
+++ b/docs/architecture/provider-capabilities.md
@@ -67,6 +67,19 @@ repository slug, repository URL, and `<repository-root>` as one owner-controlled
 record. The GitHub WorkItem pickup allowlist remains read-only provenance for
 issue normalization; it does not authorize execution by itself.
 
+Customer repository lanes use a separate Track B allowlist boundary. They are
+not owner-controlled dogfood lanes and must carry an explicit customer
+repository classification plus an allowlist match on owner, repository name,
+`<repository-root>`, purpose, and approval note before prepare mode can mutate
+local lane workspace or state directories. Customer miss diagnostics must stay
+category-only and sanitized; public artifacts must not disclose customer
+repository names, domains, local paths, or purpose text.
+
+This Track B customer allowlist is a safety boundary for bounded local
+preparation. It does not make customer execution production-ready and does not
+claim regulated workflow support, ERPNext integration, electronic signature
+handling, batch release, final disposition, or compliance guarantees.
+
 ## Dogfood Adapter Positions
 
 The first dogfood slice can use a GitHub adapter for SCMProvider behavior and a

--- a/src/lane/index.ts
+++ b/src/lane/index.ts
@@ -90,6 +90,7 @@ export interface PreparedLocalLaneWorkspace {
 
 export type BranchLaneRunSkeletonMode = "dry-run" | "prepare";
 export type LaneRepositoryClassification = "owner-controlled-dogfood" | "customer-repository";
+const CUSTOMER_REPOSITORY_PLACEHOLDER = "<customer-repository>";
 
 export interface AuthoritativeLaneRunScope {
   readonly repositoryClassification?: LaneRepositoryClassification;
@@ -401,7 +402,7 @@ export async function planBranchLaneRunSkeleton(
             id: `${laneRunId}-scope`,
             recordedAt,
             kind: "hypothesis" as const,
-            message: `authoritative scope: customer-repository ${scope.repositoryId}`,
+            message: "authoritative scope: customer-repository",
           },
           {
             id: `${laneRunId}-customer-allowlist`,
@@ -668,7 +669,18 @@ function validateAuthoritativeLaneRunScope(scope: AuthoritativeLaneRunScope): vo
 }
 
 function resolveLaneRepositoryClassification(scope: AuthoritativeLaneRunScope): LaneRepositoryClassification {
-  return scope.repositoryClassification ?? "owner-controlled-dogfood";
+  if (scope.repositoryClassification === undefined) {
+    return "owner-controlled-dogfood";
+  }
+
+  if (
+    scope.repositoryClassification === "owner-controlled-dogfood" ||
+    scope.repositoryClassification === "customer-repository"
+  ) {
+    return scope.repositoryClassification;
+  }
+
+  throw new Error("Authoritative repository classification is unsupported.");
 }
 
 function createLaneRepositoryProjection(
@@ -678,8 +690,8 @@ function createLaneRepositoryProjection(
   if (classification === "customer-repository") {
     return {
       classification,
-      id: scope.repositoryId,
-      slug: "<customer-repository>",
+      id: CUSTOMER_REPOSITORY_PLACEHOLDER,
+      slug: CUSTOMER_REPOSITORY_PLACEHOLDER,
     };
   }
 

--- a/src/lane/index.ts
+++ b/src/lane/index.ts
@@ -954,9 +954,19 @@ function isRepositorySlugPart(value: unknown): value is string {
 }
 
 function isTrustedPolicyText(value: unknown): value is string {
+  if (typeof value !== "string") {
+    return false;
+  }
+
+  const trimmedValue = value.trim();
+
+  return trimmedValue.length > 0 && !isPlaceholderPolicyText(trimmedValue);
+}
+
+function isPlaceholderPolicyText(value: string): boolean {
   return (
-    isNonEmptyString(value) &&
-    !/\b(?:todo|tbd|sample|placeholder|example|fake)\b/i.test(value)
+    /^(?:todo|tbd)(?:\b|[-_ .:/#]).*/i.test(value) ||
+    /^(?:sample|placeholder|example|fake)(?:[-_ .:/#]*\d*)?$/i.test(value)
   );
 }
 

--- a/src/lane/index.ts
+++ b/src/lane/index.ts
@@ -89,14 +89,18 @@ export interface PreparedLocalLaneWorkspace {
 }
 
 export type BranchLaneRunSkeletonMode = "dry-run" | "prepare";
+export type LaneRepositoryClassification = "owner-controlled-dogfood" | "customer-repository";
 
 export interface AuthoritativeLaneRunScope {
-  readonly ownerControlled: true;
+  readonly repositoryClassification?: LaneRepositoryClassification;
+  readonly ownerControlled?: true;
   readonly ownerIdentity?: string;
   readonly repositoryId: string;
   readonly repositorySlug: string;
   readonly repositoryUrl?: string;
   readonly repositoryRoot: string;
+  readonly customerRepositoryPurpose?: string;
+  readonly customerApprovalNote?: string;
 }
 
 export interface OwnerControlledDogfoodRepositoryAllowlistEntry {
@@ -105,6 +109,15 @@ export interface OwnerControlledDogfoodRepositoryAllowlistEntry {
   readonly repositorySlug: string;
   readonly repositoryUrl: string;
   readonly repositoryRoot: string;
+}
+
+export interface CustomerRepositoryAllowlistEntry {
+  readonly repositoryClassification: "customer-repository";
+  readonly owner: string;
+  readonly repo: string;
+  readonly repositoryRoot: string;
+  readonly purpose: string;
+  readonly approvalNote: string;
 }
 
 export interface PlanBranchLaneRunSkeletonInput {
@@ -120,6 +133,7 @@ export interface PlanBranchLaneRunSkeletonInput {
   readonly authoritativeScope?: AuthoritativeLaneRunScope;
   readonly allowedRepositoryRoots?: readonly string[];
   readonly dogfoodRepositoryAllowlist?: readonly OwnerControlledDogfoodRepositoryAllowlistEntry[];
+  readonly customerRepositoryAllowlist?: readonly CustomerRepositoryAllowlistEntry[];
   readonly recordedAt?: string;
 }
 
@@ -132,6 +146,7 @@ export interface BranchLaneRunSkeleton {
   readonly laneRunId: string;
   readonly workItem: WorkItem;
   readonly repository: {
+    readonly classification: LaneRepositoryClassification;
     readonly id: string;
     readonly slug: string;
     readonly url?: string;
@@ -292,6 +307,7 @@ export async function planBranchLaneRunSkeleton(
   }
 
   validateAuthoritativeLaneRunScope(scope);
+  const repositoryClassification = resolveLaneRepositoryClassification(scope);
 
   const repositoryRoot = await resolveCanonicalRepositoryRoot(input.repositoryRoot);
   const scopedRepositoryRoot = await resolveCanonicalRepositoryRoot(scope.repositoryRoot);
@@ -305,12 +321,21 @@ export async function planBranchLaneRunSkeleton(
   }
 
   if (mode === "prepare") {
-    await assertDogfoodRepositoryAllowlisted({
-      scope,
-      repositoryRealPath: repositoryRoot.realPath,
-      allowlist: input.dogfoodRepositoryAllowlist,
-      required: true,
-    });
+    if (repositoryClassification === "customer-repository") {
+      await assertCustomerRepositoryAllowlisted({
+        scope,
+        repositoryRealPath: repositoryRoot.realPath,
+        allowlist: input.customerRepositoryAllowlist,
+        required: true,
+      });
+    } else {
+      await assertDogfoodRepositoryAllowlisted({
+        scope,
+        repositoryRealPath: repositoryRoot.realPath,
+        allowlist: input.dogfoodRepositoryAllowlist,
+        required: true,
+      });
+    }
   }
 
   const worktreeRoot = await resolveCanonicalLocalLaneRoot("workspace", input.worktreeRoot);
@@ -330,12 +355,7 @@ export async function planBranchLaneRunSkeleton(
     opensChangeRequest: false,
     laneRunId,
     workItem: { ...input.workItem },
-    repository: {
-      id: scope.repositoryId,
-      slug: scope.repositorySlug,
-      url: scope.repositoryUrl,
-      ownerIdentity: scope.ownerIdentity,
-    },
+    repository: createLaneRepositoryProjection(scope, repositoryClassification),
     branch: {
       name: input.branchName,
       base: input.baseBranch ?? "main",
@@ -374,6 +394,36 @@ export async function planBranchLaneRunSkeleton(
     workItemId: input.workItem.id,
   });
   const recordedAt = input.recordedAt ?? new Date().toISOString();
+  const scopeJournalEntries =
+    repositoryClassification === "customer-repository"
+      ? [
+          {
+            id: `${laneRunId}-scope`,
+            recordedAt,
+            kind: "hypothesis" as const,
+            message: `authoritative scope: customer-repository ${scope.repositoryId}`,
+          },
+          {
+            id: `${laneRunId}-customer-allowlist`,
+            recordedAt,
+            kind: "hypothesis" as const,
+            message: "customer repo allowlist matched: owner, repo, path, purpose, and approval note",
+          },
+        ]
+      : [
+          {
+            id: `${laneRunId}-scope`,
+            recordedAt,
+            kind: "hypothesis" as const,
+            message: `authoritative scope: ${scope.repositorySlug} ${scope.repositoryId}`,
+          },
+          {
+            id: `${laneRunId}-dogfood-allowlist`,
+            recordedAt,
+            kind: "hypothesis" as const,
+            message: `dogfood allowlist matched: ${scope.repositorySlug} ownerIdentity=${scope.ownerIdentity ?? "<missing>"}`,
+          },
+        ];
   const state = createLaneRunState({
     id: laneRunId,
     workItemId: input.workItem.id,
@@ -386,18 +436,7 @@ export async function planBranchLaneRunSkeleton(
       laneRunId,
       workItemId: input.workItem.id,
       entries: [
-        {
-          id: `${laneRunId}-scope`,
-          recordedAt,
-          kind: "hypothesis",
-          message: `authoritative scope: ${scope.repositorySlug} ${scope.repositoryId}`,
-        },
-        {
-          id: `${laneRunId}-dogfood-allowlist`,
-          recordedAt,
-          kind: "hypothesis",
-          message: `dogfood allowlist matched: ${scope.repositorySlug} ownerIdentity=${scope.ownerIdentity ?? "<missing>"}`,
-        },
+        ...scopeJournalEntries,
         {
           id: `${laneRunId}-branch`,
           recordedAt,
@@ -605,14 +644,52 @@ function assertSafeBranchName(branchName: string): void {
 }
 
 function validateAuthoritativeLaneRunScope(scope: AuthoritativeLaneRunScope): void {
+  const classification = resolveLaneRepositoryClassification(scope);
+
   if (
-    scope.ownerControlled !== true ||
     !isNonEmptyString(scope.repositoryId) ||
     !repositorySlugPattern.test(scope.repositorySlug) ||
     !isNonEmptyString(scope.repositoryRoot)
   ) {
     throw new Error("Authoritative repository scope is malformed.");
   }
+
+  if (classification === "owner-controlled-dogfood" && scope.ownerControlled !== true) {
+    throw new Error("Authoritative repository scope is malformed.");
+  }
+
+  if (classification === "customer-repository") {
+    const scopeIssues = collectCustomerScopeIssues(scope);
+
+    if (scopeIssues.length > 0) {
+      throw new Error(`Customer repository scope is missing or malformed: ${scopeIssues.join(", ")}.`);
+    }
+  }
+}
+
+function resolveLaneRepositoryClassification(scope: AuthoritativeLaneRunScope): LaneRepositoryClassification {
+  return scope.repositoryClassification ?? "owner-controlled-dogfood";
+}
+
+function createLaneRepositoryProjection(
+  scope: AuthoritativeLaneRunScope,
+  classification: LaneRepositoryClassification,
+): BranchLaneRunSkeleton["repository"] {
+  if (classification === "customer-repository") {
+    return {
+      classification,
+      id: scope.repositoryId,
+      slug: "<customer-repository>",
+    };
+  }
+
+  return {
+    classification,
+    id: scope.repositoryId,
+    slug: scope.repositorySlug,
+    url: scope.repositoryUrl,
+    ownerIdentity: scope.ownerIdentity,
+  };
 }
 
 async function assertRepositoryRootAllowlisted(
@@ -674,6 +751,53 @@ async function assertDogfoodRepositoryAllowlisted(input: {
   );
 }
 
+async function assertCustomerRepositoryAllowlisted(input: {
+  readonly scope: AuthoritativeLaneRunScope;
+  readonly repositoryRealPath: string;
+  readonly allowlist?: readonly CustomerRepositoryAllowlistEntry[];
+  readonly required: boolean;
+}): Promise<void> {
+  if (!Array.isArray(input.allowlist)) {
+    if (input.required) {
+      throw new Error("Customer repository allowlist is required before customer lane preparation.");
+    }
+
+    return;
+  }
+
+  const scopeIssues = collectCustomerScopeIssues(input.scope);
+  if (scopeIssues.length > 0) {
+    throw new Error(`Customer repository scope is missing or malformed: ${scopeIssues.join(", ")}.`);
+  }
+
+  const entryIssues = collectCustomerAllowlistEntryIssues(input.allowlist);
+  if (entryIssues.length > 0) {
+    throw new Error(`Customer repository allowlist is malformed: ${entryIssues.join(", ")}.`);
+  }
+
+  const scopeSlug = splitRepositorySlug(input.scope.repositorySlug);
+
+  for (const entry of input.allowlist) {
+    if (
+      entry.repositoryClassification === "customer-repository" &&
+      entry.owner === scopeSlug.owner &&
+      entry.repo === scopeSlug.repo &&
+      entry.purpose === input.scope.customerRepositoryPurpose &&
+      entry.approvalNote === input.scope.customerApprovalNote
+    ) {
+      const allowed = await resolveCanonicalRepositoryRoot(entry.repositoryRoot);
+
+      if (allowed.realPath === input.repositoryRealPath) {
+        return;
+      }
+    }
+  }
+
+  throw new Error(
+    "Customer repository allowlist match is required before customer lane preparation; mismatched fields may include owner, repo, repositoryRoot, purpose, or approvalNote.",
+  );
+}
+
 function collectDogfoodScopeIssues(scope: AuthoritativeLaneRunScope): string[] {
   const issues: string[] = [];
 
@@ -695,6 +819,36 @@ function collectDogfoodScopeIssues(scope: AuthoritativeLaneRunScope): string[] {
 
   if (!isNonEmptyString(scope.repositoryRoot)) {
     issues.push("repositoryRoot");
+  }
+
+  return issues;
+}
+
+function collectCustomerScopeIssues(scope: AuthoritativeLaneRunScope): string[] {
+  const issues: string[] = [];
+
+  if (scope.repositoryClassification !== "customer-repository") {
+    issues.push("repositoryClassification");
+  }
+
+  if (scope.ownerControlled === true) {
+    issues.push("ownerControlled");
+  }
+
+  if (!repositorySlugPattern.test(scope.repositorySlug)) {
+    issues.push("repositorySlug");
+  }
+
+  if (!isNonEmptyString(scope.repositoryRoot)) {
+    issues.push("repositoryRoot");
+  }
+
+  if (!isTrustedPolicyText(scope.customerRepositoryPurpose)) {
+    issues.push("customerRepositoryPurpose");
+  }
+
+  if (!isTrustedPolicyText(scope.customerApprovalNote)) {
+    issues.push("customerApprovalNote");
   }
 
   return issues;
@@ -733,6 +887,65 @@ function collectDogfoodAllowlistEntryIssues(
   });
 
   return issues;
+}
+
+function collectCustomerAllowlistEntryIssues(
+  allowlist: readonly CustomerRepositoryAllowlistEntry[],
+): string[] {
+  const issues: string[] = [];
+
+  allowlist.forEach((entry, index) => {
+    if (typeof entry !== "object" || entry === null) {
+      issues.push(`allowlist[${index}]`);
+      return;
+    }
+
+    if (entry.repositoryClassification !== "customer-repository") {
+      issues.push(`allowlist[${index}].repositoryClassification`);
+    }
+
+    if (!isRepositorySlugPart(entry.owner)) {
+      issues.push(`allowlist[${index}].owner`);
+    }
+
+    if (!isRepositorySlugPart(entry.repo)) {
+      issues.push(`allowlist[${index}].repo`);
+    }
+
+    if (!isNonEmptyString(entry.repositoryRoot)) {
+      issues.push(`allowlist[${index}].repositoryRoot`);
+    }
+
+    if (!isTrustedPolicyText(entry.purpose)) {
+      issues.push(`allowlist[${index}].purpose`);
+    }
+
+    if (!isTrustedPolicyText(entry.approvalNote)) {
+      issues.push(`allowlist[${index}].approvalNote`);
+    }
+  });
+
+  return issues;
+}
+
+function splitRepositorySlug(repositorySlug: string): { readonly owner: string; readonly repo: string } {
+  const [owner, repo] = repositorySlug.split("/");
+
+  return {
+    owner: owner ?? "",
+    repo: repo ?? "",
+  };
+}
+
+function isRepositorySlugPart(value: unknown): value is string {
+  return typeof value === "string" && /^[A-Za-z0-9_.-]+$/.test(value);
+}
+
+function isTrustedPolicyText(value: unknown): value is string {
+  return (
+    isNonEmptyString(value) &&
+    !/\b(?:todo|tbd|sample|placeholder|example|fake)\b/i.test(value)
+  );
 }
 
 function isRepositoryUrl(value: unknown): value is string {

--- a/test/lane-run-skeleton.test.ts
+++ b/test/lane-run-skeleton.test.ts
@@ -272,6 +272,123 @@ test("allows adapter-agnostic https repository URLs for prepare allowlist matchi
   }
 });
 
+test("requires explicit customer repo allowlist policy without leaking customer details", async () => {
+  const roots = await createSkeletonRoots();
+  const customerRoot = path.join(path.dirname(roots.repositoryRoot), "customer-repo");
+  const customerScope = {
+    repositoryClassification: "customer-repository",
+    repositoryId: "repo_01HV7Y8M8F2KQ5W3P9R6T4N2CUST",
+    repositorySlug: "allowed-owner/allowed-repo",
+    repositoryUrl: "https://scm.invalid/allowed-owner/allowed-repo",
+    repositoryRoot: customerRoot,
+    customerRepositoryPurpose: "authorized bounded local preparation",
+    customerApprovalNote: "approval note recorded for bounded local preparation",
+  } as const;
+
+  try {
+    await mkdir(customerRoot);
+
+    const skeleton = await planBranchLaneRunSkeleton({
+      mode: "prepare",
+      workItem: readyWorkItem,
+      laneRunId: "run_customer_allowlisted",
+      idempotencyKey: "issue-97-customer-allowlisted",
+      repositoryRoot: customerRoot,
+      worktreeRoot: roots.worktreeRoot,
+      stateRoot: roots.stateRoot,
+      branchName: "codex/issue-97-customer",
+      authoritativeScope: customerScope,
+      customerRepositoryAllowlist: [
+        {
+          repositoryClassification: "customer-repository",
+          owner: "allowed-owner",
+          repo: "allowed-repo",
+          repositoryRoot: customerRoot,
+          purpose: "authorized bounded local preparation",
+          approvalNote: "approval note recorded for bounded local preparation",
+        },
+      ],
+    });
+
+    assert.equal(skeleton.repository.classification, "customer-repository");
+    assert.equal(skeleton.repository.slug, "<customer-repository>");
+    assert.equal(skeleton.repository.url, undefined);
+
+    const serializedSkeleton = JSON.stringify(skeleton);
+    assert.doesNotMatch(serializedSkeleton, /allowed-owner/);
+    assert.doesNotMatch(serializedSkeleton, /allowed-repo/);
+    assert.doesNotMatch(serializedSkeleton, /scm\.invalid/);
+    assert.doesNotMatch(serializedSkeleton, /authorized bounded local preparation/);
+    assert.doesNotMatch(serializedSkeleton, new RegExp(escapeRegExp(customerRoot)));
+
+    const state = await readLaneRunState(roots.stateRoot, skeleton.laneRunId);
+    const serializedState = JSON.stringify(state);
+    assert.match(serializedState, /customer repo allowlist matched/);
+    assert.doesNotMatch(serializedState, /allowed-owner/);
+    assert.doesNotMatch(serializedState, /allowed-repo/);
+    assert.doesNotMatch(serializedState, /scm\.invalid/);
+    assert.doesNotMatch(serializedState, /authorized bounded local preparation/);
+    assert.doesNotMatch(serializedState, new RegExp(escapeRegExp(customerRoot)));
+
+    await assert.rejects(
+      () =>
+        planBranchLaneRunSkeleton({
+          mode: "prepare",
+          workItem: readyWorkItem,
+          laneRunId: "run_customer_missing_allowlist",
+          idempotencyKey: "issue-97-customer-missing-list",
+          repositoryRoot: customerRoot,
+          worktreeRoot: roots.worktreeRoot,
+          stateRoot: roots.stateRoot,
+          branchName: "codex/issue-97-customer-missing",
+          authoritativeScope: customerScope,
+        }),
+      /Customer repository allowlist is required/,
+    );
+
+    await assert.rejects(
+      () =>
+        planBranchLaneRunSkeleton({
+          mode: "prepare",
+          workItem: readyWorkItem,
+          laneRunId: "run_customer_wrong_purpose",
+          idempotencyKey: "issue-97-customer-wrong-purpose",
+          repositoryRoot: customerRoot,
+          worktreeRoot: roots.worktreeRoot,
+          stateRoot: roots.stateRoot,
+          branchName: "codex/issue-97-customer-wrong-purpose",
+          authoritativeScope: customerScope,
+          customerRepositoryAllowlist: [
+            {
+              repositoryClassification: "customer-repository",
+              owner: "allowed-owner",
+              repo: "allowed-repo",
+              repositoryRoot: customerRoot,
+              purpose: "different bounded local preparation",
+              approvalNote: "approval note recorded for bounded local preparation",
+            },
+          ],
+        }),
+      (error: unknown) => {
+        assert.ok(error instanceof Error);
+        assert.match(error.message, /owner, repo, repositoryRoot, purpose, or approvalNote/);
+        assert.doesNotMatch(error.message, /allowed-owner/);
+        assert.doesNotMatch(error.message, /allowed-repo/);
+        assert.doesNotMatch(error.message, /different bounded local preparation/);
+        assert.doesNotMatch(error.message, new RegExp(escapeRegExp(customerRoot)));
+        return true;
+      },
+    );
+
+    await assert.rejects(() => access(path.join(roots.worktreeRoot, "lane-runs", "run_customer_missing_allowlist")), /ENOENT/);
+    await assert.rejects(() => access(path.join(roots.stateRoot, "lane-runs", "run_customer_missing_allowlist")), /ENOENT/);
+    await assert.rejects(() => access(path.join(roots.worktreeRoot, "lane-runs", "run_customer_wrong_purpose")), /ENOENT/);
+    await assert.rejects(() => access(path.join(roots.stateRoot, "lane-runs", "run_customer_wrong_purpose")), /ENOENT/);
+  } finally {
+    await roots.cleanup();
+  }
+});
+
 test("fails closed before mutation for unsafe branch, missing scope, symlink root, and disallowed repository", async () => {
   const roots = await createSkeletonRoots();
   const outsideRoot = await mkdtemp(path.join(os.tmpdir(), "ensen-loop-outside-repo-"));

--- a/test/lane-run-skeleton.test.ts
+++ b/test/lane-run-skeleton.test.ts
@@ -282,7 +282,7 @@ test("requires explicit customer repo allowlist policy without leaking customer 
     repositorySlug: "allowed-owner/allowed-repo",
     repositoryUrl: "https://scm.invalid/allowed-owner/allowed-repo",
     repositoryRoot: customerRoot,
-    customerRepositoryPurpose: "authorized bounded local preparation",
+    customerRepositoryPurpose: "authorized bounded local preparation for an example escalation memo",
     customerApprovalNote: "approval note recorded for bounded local preparation",
   } as const;
 
@@ -305,7 +305,7 @@ test("requires explicit customer repo allowlist policy without leaking customer 
           owner: "allowed-owner",
           repo: "allowed-repo",
           repositoryRoot: customerRoot,
-          purpose: "authorized bounded local preparation",
+          purpose: "authorized bounded local preparation for an example escalation memo",
           approvalNote: "approval note recorded for bounded local preparation",
         },
       ],
@@ -322,6 +322,7 @@ test("requires explicit customer repo allowlist policy without leaking customer 
     assert.doesNotMatch(serializedSkeleton, /allowed-repo/);
     assert.doesNotMatch(serializedSkeleton, /scm\.invalid/);
     assert.doesNotMatch(serializedSkeleton, /authorized bounded local preparation/);
+    assert.doesNotMatch(serializedSkeleton, /example escalation memo/);
     assert.doesNotMatch(serializedSkeleton, new RegExp(escapeRegExp(customerRoot)));
 
     const state = await readLaneRunState(roots.stateRoot, skeleton.laneRunId);
@@ -332,6 +333,7 @@ test("requires explicit customer repo allowlist policy without leaking customer 
     assert.doesNotMatch(serializedState, /allowed-repo/);
     assert.doesNotMatch(serializedState, /scm\.invalid/);
     assert.doesNotMatch(serializedState, /authorized bounded local preparation/);
+    assert.doesNotMatch(serializedState, /example escalation memo/);
     assert.doesNotMatch(serializedState, new RegExp(escapeRegExp(customerRoot)));
 
     await assert.rejects(
@@ -384,10 +386,72 @@ test("requires explicit customer repo allowlist policy without leaking customer 
       },
     );
 
+    await assert.rejects(
+      () =>
+        planBranchLaneRunSkeleton({
+          mode: "prepare",
+          workItem: readyWorkItem,
+          laneRunId: "run_customer_blank_policy_text",
+          idempotencyKey: "issue-97-customer-blank-policy-text",
+          repositoryRoot: customerRoot,
+          worktreeRoot: roots.worktreeRoot,
+          stateRoot: roots.stateRoot,
+          branchName: "codex/issue-97-customer-blank-policy-text",
+          authoritativeScope: {
+            ...customerScope,
+            customerRepositoryPurpose: "   ",
+          },
+          customerRepositoryAllowlist: [
+            {
+              repositoryClassification: "customer-repository",
+              owner: "allowed-owner",
+              repo: "allowed-repo",
+              repositoryRoot: customerRoot,
+              purpose: "   ",
+              approvalNote: "approval note recorded for bounded local preparation",
+            },
+          ],
+        }),
+      /customerRepositoryPurpose/,
+    );
+
+    await assert.rejects(
+      () =>
+        planBranchLaneRunSkeleton({
+          mode: "prepare",
+          workItem: readyWorkItem,
+          laneRunId: "run_customer_placeholder_policy_text",
+          idempotencyKey: "issue-97-customer-placeholder-policy-text",
+          repositoryRoot: customerRoot,
+          worktreeRoot: roots.worktreeRoot,
+          stateRoot: roots.stateRoot,
+          branchName: "codex/issue-97-customer-placeholder-policy-text",
+          authoritativeScope: {
+            ...customerScope,
+            customerApprovalNote: "placeholder",
+          },
+          customerRepositoryAllowlist: [
+            {
+              repositoryClassification: "customer-repository",
+              owner: "allowed-owner",
+              repo: "allowed-repo",
+              repositoryRoot: customerRoot,
+              purpose: "authorized bounded local preparation for an example escalation memo",
+              approvalNote: "placeholder",
+            },
+          ],
+        }),
+      /customerApprovalNote/,
+    );
+
     await assert.rejects(() => access(path.join(roots.worktreeRoot, "lane-runs", "run_customer_missing_allowlist")), /ENOENT/);
     await assert.rejects(() => access(path.join(roots.stateRoot, "lane-runs", "run_customer_missing_allowlist")), /ENOENT/);
     await assert.rejects(() => access(path.join(roots.worktreeRoot, "lane-runs", "run_customer_wrong_purpose")), /ENOENT/);
     await assert.rejects(() => access(path.join(roots.stateRoot, "lane-runs", "run_customer_wrong_purpose")), /ENOENT/);
+    await assert.rejects(() => access(path.join(roots.worktreeRoot, "lane-runs", "run_customer_blank_policy_text")), /ENOENT/);
+    await assert.rejects(() => access(path.join(roots.stateRoot, "lane-runs", "run_customer_blank_policy_text")), /ENOENT/);
+    await assert.rejects(() => access(path.join(roots.worktreeRoot, "lane-runs", "run_customer_placeholder_policy_text")), /ENOENT/);
+    await assert.rejects(() => access(path.join(roots.stateRoot, "lane-runs", "run_customer_placeholder_policy_text")), /ENOENT/);
   } finally {
     await roots.cleanup();
   }

--- a/test/lane-run-skeleton.test.ts
+++ b/test/lane-run-skeleton.test.ts
@@ -275,9 +275,10 @@ test("allows adapter-agnostic https repository URLs for prepare allowlist matchi
 test("requires explicit customer repo allowlist policy without leaking customer details", async () => {
   const roots = await createSkeletonRoots();
   const customerRoot = path.join(path.dirname(roots.repositoryRoot), "customer-repo");
+  const customerRepositoryId = "allowed-owner-allowed-repo-customer-root-identifier";
   const customerScope = {
     repositoryClassification: "customer-repository",
-    repositoryId: "repo_01HV7Y8M8F2KQ5W3P9R6T4N2CUST",
+    repositoryId: customerRepositoryId,
     repositorySlug: "allowed-owner/allowed-repo",
     repositoryUrl: "https://scm.invalid/allowed-owner/allowed-repo",
     repositoryRoot: customerRoot,
@@ -311,10 +312,12 @@ test("requires explicit customer repo allowlist policy without leaking customer 
     });
 
     assert.equal(skeleton.repository.classification, "customer-repository");
+    assert.equal(skeleton.repository.id, "<customer-repository>");
     assert.equal(skeleton.repository.slug, "<customer-repository>");
     assert.equal(skeleton.repository.url, undefined);
 
     const serializedSkeleton = JSON.stringify(skeleton);
+    assert.doesNotMatch(serializedSkeleton, new RegExp(escapeRegExp(customerRepositoryId)));
     assert.doesNotMatch(serializedSkeleton, /allowed-owner/);
     assert.doesNotMatch(serializedSkeleton, /allowed-repo/);
     assert.doesNotMatch(serializedSkeleton, /scm\.invalid/);
@@ -324,6 +327,7 @@ test("requires explicit customer repo allowlist policy without leaking customer 
     const state = await readLaneRunState(roots.stateRoot, skeleton.laneRunId);
     const serializedState = JSON.stringify(state);
     assert.match(serializedState, /customer repo allowlist matched/);
+    assert.doesNotMatch(serializedState, new RegExp(escapeRegExp(customerRepositoryId)));
     assert.doesNotMatch(serializedState, /allowed-owner/);
     assert.doesNotMatch(serializedState, /allowed-repo/);
     assert.doesNotMatch(serializedState, /scm\.invalid/);
@@ -384,6 +388,48 @@ test("requires explicit customer repo allowlist policy without leaking customer 
     await assert.rejects(() => access(path.join(roots.stateRoot, "lane-runs", "run_customer_missing_allowlist")), /ENOENT/);
     await assert.rejects(() => access(path.join(roots.worktreeRoot, "lane-runs", "run_customer_wrong_purpose")), /ENOENT/);
     await assert.rejects(() => access(path.join(roots.stateRoot, "lane-runs", "run_customer_wrong_purpose")), /ENOENT/);
+  } finally {
+    await roots.cleanup();
+  }
+});
+
+test("rejects unsupported repository classifications before policy selection", async () => {
+  const roots = await createSkeletonRoots();
+
+  try {
+    await assert.rejects(
+      () =>
+        planBranchLaneRunSkeleton({
+          mode: "prepare",
+          workItem: readyWorkItem,
+          laneRunId: "run_unknown_repository_classification",
+          idempotencyKey: "issue-97-unknown-repository-classification",
+          repositoryRoot: roots.repositoryRoot,
+          worktreeRoot: roots.worktreeRoot,
+          stateRoot: roots.stateRoot,
+          branchName: "codex/issue-97-unknown-classification",
+          authoritativeScope: {
+            repositoryClassification: "partner-repository" as never,
+            ownerControlled: true,
+            ownerIdentity: "owner-maintainer",
+            repositoryId: "repo_01HV7Y8M8F2KQ5W3P9R6T4N2LOOP",
+            repositorySlug: "TommyKammy/Ensen-loop",
+            repositoryUrl: "https://github.com/TommyKammy/Ensen-loop",
+            repositoryRoot: roots.repositoryRoot,
+          },
+          dogfoodRepositoryAllowlist: dogfoodAllowlist(roots.repositoryRoot),
+        }),
+      /repository classification is unsupported/,
+    );
+
+    await assert.rejects(
+      () => access(path.join(roots.worktreeRoot, "lane-runs", "run_unknown_repository_classification")),
+      /ENOENT/,
+    );
+    await assert.rejects(
+      () => access(path.join(roots.stateRoot, "lane-runs", "run_unknown_repository_classification")),
+      /ENOENT/,
+    );
   } finally {
     await roots.cleanup();
   }

--- a/test/quality-kit-docs.test.ts
+++ b/test/quality-kit-docs.test.ts
@@ -117,6 +117,34 @@ test("documents the Phase 3 local lane execution contract", async () => {
   );
 });
 
+test("documents the Track B customer repository allowlist boundary", async () => {
+  const contract = await readMarkdown("docs/architecture/local-lane-execution.md");
+  const providerCapabilities = await readMarkdown("docs/architecture/provider-capabilities.md");
+  const readme = await readMarkdown("README.md");
+  const combined = `${contract}\n${providerCapabilities}\n${readme}`;
+
+  for (const phrase of [
+    "customer repository allowlist",
+    "Track B",
+    "owner",
+    "repository name",
+    "<repository-root>",
+    "purpose",
+    "approval note",
+    "not owner-controlled dogfood",
+    "sanitized",
+    "not production-ready customer execution",
+    "compliance guarantee",
+  ]) {
+    assert.match(combined, new RegExp(phrase, "i"));
+  }
+
+  assert.doesNotMatch(
+    combined,
+    /\/Users\/[^/\s]+|\/home\/[^/\s]+|\/root(?:\/|\b)|[A-Z]:[\\/]+Users[\\/]|~[\\/]/i,
+  );
+});
+
 test("documents dogfood rollback and cleanup boundaries", async () => {
   const runbook = await readMarkdown("docs/runbooks/dogfood-rollback-cleanup.md");
 


### PR DESCRIPTION
## Summary
- add a separate customer repository classification and allowlist boundary at branch lane prepare mode
- sanitize customer lane skeleton/state output so customer owner, repo, URL, path, and purpose text are not projected
- document the Track B boundary as local safety only, not production customer execution or compliance

## Verification
- npm run typecheck
- npm run build
- npm test

Part of #102
Closes #97