### PR TITLE
LOOP-X3B-002: Require customer evidence classification

### DIFF
--- a/docs/architecture/local-lane-execution.md
+++ b/docs/architecture/local-lane-execution.md
@@ -183,6 +183,14 @@ location only when the URI or path is traversal-free, secret-safe, and scoped to
 the documented local artifact root. An EvidenceBundleRef does not by itself
 prove that a durable evidence bundle exists.
 
+Track B customer lane EvidenceBundleRef metadata must carry explicit Protocol
+`v0.4.0` classification before RunResult projection or public artifact export.
+Ensen-loop accepts `public`, `internal`, `customer-confidential`, and
+`regulated` for that boundary. Missing, unknown, or inferred classification
+blocks the projection. Customer-confidential and regulated references must stay
+metadata-only and must not expose raw customer files, raw records, credentials,
+secrets, private repository details, or workstation-local absolute paths.
+
 Phase 3 local lane persistence may write Ensen-loop-owned metadata under the
 prepared local state path using an EvidenceBundleRef `local_path` URI. That file
 records bounded development facts such as lane identifiers, executor outcome,

--- a/docs/architecture/local-lane-execution.md
+++ b/docs/architecture/local-lane-execution.md
@@ -188,8 +188,9 @@ Track B customer lane EvidenceBundleRef metadata must carry explicit Protocol
 Ensen-loop accepts `public`, `internal`, `customer-confidential`, and
 `regulated` for that boundary. Missing, unknown, or inferred classification
 blocks the projection. Customer-confidential and regulated references must stay
-metadata-only and must not expose raw customer files, raw records, credentials,
-secrets, private repository details, or workstation-local absolute paths.
+metadata-only, use bounded protocol vocabulary for controlled metadata fields,
+and must not expose raw customer files, raw records, credentials, secrets,
+private repository details, or workstation-local absolute paths.
 
 Phase 3 local lane persistence may write Ensen-loop-owned metadata under the
 prepared local state path using an EvidenceBundleRef `local_path` URI. That file

--- a/docs/reference/lane-artifact-output.md
+++ b/docs/reference/lane-artifact-output.md
@@ -61,9 +61,11 @@ repository names, issue text, comments, or nearby operator summaries.
 
 Customer-confidential and regulated references remain references only. They may
 carry safe metadata such as producer, protocol version, validation command,
-reference kind, checksum status, and explicit classification. They must not
-embed raw customer files, raw records, credentials, secrets, private repository
-details, or workstation-local absolute paths in public artifacts.
+reference kind, checksum status, and explicit classification. Controlled
+metadata values must come from bounded protocol vocabulary or bounded validation
+command forms; free-form customer text is not safe reference metadata. They must
+not embed raw customer files, raw records, credentials, secrets, private
+repository details, or workstation-local absolute paths in public artifacts.
 
 ## PR Draft Intent
 

--- a/docs/reference/lane-artifact-output.md
+++ b/docs/reference/lane-artifact-output.md
@@ -37,6 +37,34 @@ the evidence payload itself.
 and `unsupported` evidence retrieval fails closed for artifact references instead
 of inventing retrievable evidence.
 
+## Protocol v0.4.0 Track B Classification
+
+Protocol `v0.4.0` adds the Track B customer / regulated evidence classification
+profile. Ensen-loop consumes that copied snapshot as local conformance guidance,
+not as a runtime dependency on Ensen-protocol and not as a compliance claim.
+
+Track A operational evidence remains the public fixture-safe owner-controlled
+evidence profile. Track B customer lane evidence is a separate boundary. When an
+EvidenceBundleRef explicitly marks Track B customer lane or controlled evidence,
+public artifact export and RunResult projection require an explicit
+`dataClassification` value from the Loop-supported Track B set:
+
+- `public`
+- `internal`
+- `customer-confidential`
+- `regulated`
+
+Missing, unknown, legacy, or inferred classification fails closed before public
+artifact export or RunResult evidence projection. Classification must come from
+bounded reference metadata; Ensen-loop must not infer it from URI shape,
+repository names, issue text, comments, or nearby operator summaries.
+
+Customer-confidential and regulated references remain references only. They may
+carry safe metadata such as producer, protocol version, validation command,
+reference kind, checksum status, and explicit classification. They must not
+embed raw customer files, raw records, credentials, secrets, private repository
+details, or workstation-local absolute paths in public artifacts.
+
 ## PR Draft Intent
 
 PR draft intent is only an intent artifact. It requires owner-controlled

--- a/src/artifact/index.ts
+++ b/src/artifact/index.ts
@@ -7,6 +7,7 @@ import type { WorkItem } from "../core/index.js";
 import type { LaneRunState } from "../lane/index.js";
 import {
   type EvidenceBundleRef,
+  validateCustomerLaneEvidenceRef,
   validateEvidenceBundleRef,
 } from "../protocol/index.js";
 import {
@@ -549,6 +550,16 @@ function collectEvidenceRefIssues(
         path: `evidenceRefs[${index}]`,
         message: "Artifact output evidence references must not contain raw secrets or workstation-local paths.",
       });
+    }
+
+    const customerLaneValidation = validateCustomerLaneEvidenceRef(validation.ref);
+    if (!customerLaneValidation.ok) {
+      for (const issue of customerLaneValidation.issues) {
+        issues.push({
+          path: `evidenceRefs[${index}].${issue.path}`,
+          message: issue.message,
+        });
+      }
     }
   }
 }

--- a/src/protocol/customer-lane-evidence.ts
+++ b/src/protocol/customer-lane-evidence.ts
@@ -72,33 +72,20 @@ export function validateCustomerLaneEvidenceRef(
 export function isCustomerLaneEvidenceRef(evidenceRef: EvidenceBundleRef): boolean {
   const metadata = evidenceRef.metadata;
 
-  if (metadata === undefined) {
-    return false;
-  }
-
-  return (
-    metadata.evidenceTrack === "track-b" ||
-    customerLaneBoundaryValues.has(metadata.evidenceBoundary) ||
-    isControlledDataClassification(metadata.dataClassification) ||
-    metadata.controlledReference === true
-  );
+  return metadata !== undefined && hasCustomerLaneEvidenceSignal(metadata);
 }
 
 function collectCustomerLaneEvidenceRefIssues(
   evidenceRef: EvidenceBundleRef,
 ): readonly CustomerLaneEvidenceValidationIssue[] {
-  if (!isCustomerLaneEvidenceRef(evidenceRef)) {
-    return [];
-  }
-
   const issues: CustomerLaneEvidenceValidationIssue[] = [];
   const metadata = evidenceRef.metadata;
 
   if (metadata === undefined) {
-    issues.push({
-      path: "metadata",
-      message: "Track B customer lane evidence requires explicit bounded metadata.",
-    });
+    return issues;
+  }
+
+  if (!hasCustomerLaneEvidenceSignal(metadata)) {
     return issues;
   }
 
@@ -118,6 +105,17 @@ function collectCustomerLaneEvidenceRefIssues(
   }
 
   return issues;
+}
+
+function hasCustomerLaneEvidenceSignal(
+  metadata: Record<string, EvidenceBundleMetadataValue>,
+): boolean {
+  return (
+    metadata.evidenceTrack === "track-b" ||
+    customerLaneBoundaryValues.has(metadata.evidenceBoundary) ||
+    isControlledDataClassification(metadata.dataClassification) ||
+    metadata.controlledReference === true
+  );
 }
 
 function isControlledDataClassification(value: EvidenceBundleMetadataValue | undefined): boolean {

--- a/src/protocol/customer-lane-evidence.ts
+++ b/src/protocol/customer-lane-evidence.ts
@@ -72,11 +72,15 @@ export function validateCustomerLaneEvidenceRef(
 export function isCustomerLaneEvidenceRef(evidenceRef: EvidenceBundleRef): boolean {
   const metadata = evidenceRef.metadata;
 
+  if (metadata === undefined) {
+    return false;
+  }
+
   return (
-    metadata?.evidenceTrack === "track-b" ||
-    customerLaneBoundaryValues.has(metadata?.evidenceBoundary) ||
-    controlledClassifications.has(metadata?.dataClassification) ||
-    metadata?.controlledReference === true
+    metadata.evidenceTrack === "track-b" ||
+    customerLaneBoundaryValues.has(metadata.evidenceBoundary) ||
+    isControlledDataClassification(metadata.dataClassification) ||
+    metadata.controlledReference === true
   );
 }
 
@@ -107,13 +111,17 @@ function collectCustomerLaneEvidenceRefIssues(
   }
 
   if (
-    controlledClassifications.has(metadata.dataClassification) ||
+    isControlledDataClassification(metadata.dataClassification) ||
     metadata.controlledReference === true
   ) {
     collectControlledReferenceMetadataIssues(issues, metadata);
   }
 
   return issues;
+}
+
+function isControlledDataClassification(value: EvidenceBundleMetadataValue | undefined): boolean {
+  return controlledClassifications.has(value);
 }
 
 function collectControlledReferenceMetadataIssues(

--- a/src/protocol/customer-lane-evidence.ts
+++ b/src/protocol/customer-lane-evidence.ts
@@ -75,6 +75,7 @@ export function isCustomerLaneEvidenceRef(evidenceRef: EvidenceBundleRef): boole
   return (
     metadata?.evidenceTrack === "track-b" ||
     customerLaneBoundaryValues.has(metadata?.evidenceBoundary) ||
+    controlledClassifications.has(metadata?.dataClassification) ||
     metadata?.controlledReference === true
   );
 }
@@ -105,7 +106,10 @@ function collectCustomerLaneEvidenceRefIssues(
     });
   }
 
-  if (controlledClassifications.has(metadata.dataClassification)) {
+  if (
+    controlledClassifications.has(metadata.dataClassification) ||
+    metadata.controlledReference === true
+  ) {
     collectControlledReferenceMetadataIssues(issues, metadata);
   }
 

--- a/src/protocol/customer-lane-evidence.ts
+++ b/src/protocol/customer-lane-evidence.ts
@@ -1,0 +1,142 @@
+import { containsUnsafePublicArtifactText } from "../safety/public-artifact.js";
+import type { EvidenceBundleRef, EvidenceBundleMetadataValue } from "./evidence-bundle-ref.js";
+
+export type CustomerLaneEvidenceClassification =
+  | "public"
+  | "internal"
+  | "customer-confidential"
+  | "regulated";
+
+export interface CustomerLaneEvidenceValidationIssue {
+  readonly path: string;
+  readonly message: string;
+}
+
+export interface CustomerLaneEvidenceValidationSuccess {
+  readonly ok: true;
+}
+
+export interface CustomerLaneEvidenceValidationFailure {
+  readonly ok: false;
+  readonly issues: readonly CustomerLaneEvidenceValidationIssue[];
+}
+
+export type CustomerLaneEvidenceValidationResult =
+  | CustomerLaneEvidenceValidationSuccess
+  | CustomerLaneEvidenceValidationFailure;
+
+const allowedClassifications = new Set<unknown>([
+  "public",
+  "internal",
+  "customer-confidential",
+  "regulated",
+]);
+const controlledClassifications = new Set<unknown>(["customer-confidential", "regulated"]);
+const allowedCustomerLaneMetadataKeys = new Set([
+  "producer",
+  "producerBoundary",
+  "protocolVersion",
+  "validationCommand",
+  "artifactKind",
+  "referenceKind",
+  "evidenceTrack",
+  "evidenceBoundary",
+  "dataClassification",
+  "controlledReference",
+  "embedsEvidencePayload",
+  "localDevelopmentOnly",
+  "writesDurableEvidence",
+  "checksumUnavailableReason",
+]);
+const rawControlledMaterialKeyPattern =
+  /(?:^|[A-Z_-])(?:raw|body|content|payload|record|file|credential|password|secret|token|apiKey|customer|tenant|account|repository)(?:$|[A-Z_-])/;
+const customerLaneBoundaryValues = new Set<unknown>(["customer-lane", "customer-regulated"]);
+
+export function validateCustomerLaneEvidenceRef(
+  evidenceRef: EvidenceBundleRef,
+): CustomerLaneEvidenceValidationResult {
+  const issues = collectCustomerLaneEvidenceRefIssues(evidenceRef);
+
+  if (issues.length > 0) {
+    return {
+      ok: false,
+      issues,
+    };
+  }
+
+  return {
+    ok: true,
+  };
+}
+
+export function isCustomerLaneEvidenceRef(evidenceRef: EvidenceBundleRef): boolean {
+  const metadata = evidenceRef.metadata;
+
+  return (
+    metadata?.evidenceTrack === "track-b" ||
+    customerLaneBoundaryValues.has(metadata?.evidenceBoundary) ||
+    metadata?.controlledReference === true
+  );
+}
+
+function collectCustomerLaneEvidenceRefIssues(
+  evidenceRef: EvidenceBundleRef,
+): readonly CustomerLaneEvidenceValidationIssue[] {
+  if (!isCustomerLaneEvidenceRef(evidenceRef)) {
+    return [];
+  }
+
+  const issues: CustomerLaneEvidenceValidationIssue[] = [];
+  const metadata = evidenceRef.metadata;
+
+  if (metadata === undefined) {
+    issues.push({
+      path: "metadata",
+      message: "Track B customer lane evidence requires explicit bounded metadata.",
+    });
+    return issues;
+  }
+
+  if (!allowedClassifications.has(metadata.dataClassification)) {
+    issues.push({
+      path: "metadata.dataClassification",
+      message:
+        "Track B customer lane evidence requires an explicit allowed data classification.",
+    });
+  }
+
+  if (controlledClassifications.has(metadata.dataClassification)) {
+    collectControlledReferenceMetadataIssues(issues, metadata);
+  }
+
+  return issues;
+}
+
+function collectControlledReferenceMetadataIssues(
+  issues: CustomerLaneEvidenceValidationIssue[],
+  metadata: Record<string, EvidenceBundleMetadataValue>,
+): void {
+  if (metadata.embedsEvidencePayload !== false) {
+    issues.push({
+      path: "metadata.embedsEvidencePayload",
+      message: "Track B customer lane evidence references must not embed raw controlled material.",
+    });
+  }
+
+  for (const [key, value] of Object.entries(metadata)) {
+    if (!allowedCustomerLaneMetadataKeys.has(key) || rawControlledMaterialKeyPattern.test(key)) {
+      issues.push({
+        path: `metadata.${key}`,
+        message: "Track B customer lane evidence references must not embed raw controlled material.",
+      });
+      continue;
+    }
+
+    if (typeof value === "string" && containsUnsafePublicArtifactText(value)) {
+      issues.push({
+        path: `metadata.${key}`,
+        message: "Track B customer lane evidence references must not embed raw controlled material.",
+      });
+    }
+  }
+}

--- a/src/protocol/customer-lane-evidence.ts
+++ b/src/protocol/customer-lane-evidence.ts
@@ -32,6 +32,9 @@ const allowedClassifications = new Set<unknown>([
   "regulated",
 ]);
 const controlledClassifications = new Set<unknown>(["customer-confidential", "regulated"]);
+const commandMetadataPattern =
+  /^(?:npm (?:ci|test|run [a-z0-9:_-]+)|node --test [A-Za-z0-9._~@/-]+(?: [A-Za-z0-9._~@/-]+)*)$/;
+const boundedLabelPattern = /^[A-Za-z0-9][A-Za-z0-9._~-]{0,79}$/;
 const allowedCustomerLaneMetadataKeys = new Set([
   "producer",
   "producerBoundary",
@@ -50,7 +53,40 @@ const allowedCustomerLaneMetadataKeys = new Set([
 ]);
 const rawControlledMaterialKeyPattern =
   /(?:^|[A-Z_-])(?:raw|body|content|payload|record|file|credential|password|secret|token|apiKey|customer|tenant|account|repository)(?:$|[A-Z_-])/;
+const rawControlledMaterialValuePattern =
+  /\b(?:raw|body|content|payload|record|file|credential|password|secret|token|apiKey|customer|tenant|account|repository|patient|order)\b/i;
 const customerLaneBoundaryValues = new Set<unknown>(["customer-lane", "customer-regulated"]);
+const controlledMetadataStringValues = new Map<string, ReadonlySet<string>>([
+  ["producer", new Set(["ensen-loop"])],
+  ["producerBoundary", new Set(["loop-local", "owner-controlled", "customer-lane", "customer-regulated"])],
+  ["protocolVersion", new Set(["0.4.0"])],
+  [
+    "artifactKind",
+    new Set([
+      "phase4ArtifactEvidenceReference",
+      "localLaneEvidenceMetadata",
+      "validationReadyEvidenceMetadata",
+      "xGate2DryRunSmoke",
+    ]),
+  ],
+  [
+    "referenceKind",
+    new Set([
+      "controlledEvidenceReference",
+      "confidentialLocalReference",
+      "publicFixtureSafeArtifact",
+    ]),
+  ],
+  ["evidenceTrack", new Set(["track-b"])],
+  ["evidenceBoundary", customerLaneBoundaryValues as ReadonlySet<string>],
+  ["dataClassification", allowedClassifications as ReadonlySet<string>],
+]);
+const controlledMetadataBooleanKeys = new Set([
+  "controlledReference",
+  "embedsEvidencePayload",
+  "localDevelopmentOnly",
+  "writesDurableEvidence",
+]);
 
 export function validateCustomerLaneEvidenceRef(
   evidenceRef: EvidenceBundleRef,
@@ -98,8 +134,22 @@ function collectCustomerLaneEvidenceRefIssues(
   }
 
   if (
+    allowedClassifications.has(metadata.dataClassification) &&
+    metadata.evidenceBoundary === "customer-regulated" &&
+    !isControlledDataClassification(metadata.dataClassification)
+  ) {
+    issues.push({
+      path: "metadata.dataClassification",
+      message:
+        "Track B customer-regulated evidence requires customer-confidential or regulated data classification.",
+    });
+  }
+
+  if (
     isControlledDataClassification(metadata.dataClassification) ||
-    metadata.controlledReference === true
+    metadata.controlledReference === true ||
+    metadata.evidenceBoundary === "customer-regulated" ||
+    hasMalformedControlledReferenceSignal(metadata)
   ) {
     collectControlledReferenceMetadataIssues(issues, metadata);
   }
@@ -114,7 +164,8 @@ function hasCustomerLaneEvidenceSignal(
     metadata.evidenceTrack === "track-b" ||
     customerLaneBoundaryValues.has(metadata.evidenceBoundary) ||
     isControlledDataClassification(metadata.dataClassification) ||
-    metadata.controlledReference === true
+    metadata.controlledReference === true ||
+    hasMalformedControlledReferenceSignal(metadata)
   );
 }
 
@@ -126,6 +177,16 @@ function collectControlledReferenceMetadataIssues(
   issues: CustomerLaneEvidenceValidationIssue[],
   metadata: Record<string, EvidenceBundleMetadataValue>,
 ): void {
+  if (
+    Object.hasOwn(metadata, "controlledReference") &&
+    typeof metadata.controlledReference !== "boolean"
+  ) {
+    issues.push({
+      path: "metadata.controlledReference",
+      message: "Track B customer lane evidence controlledReference must be boolean when present.",
+    });
+  }
+
   if (metadata.embedsEvidencePayload !== false) {
     issues.push({
       path: "metadata.embedsEvidencePayload",
@@ -142,11 +203,70 @@ function collectControlledReferenceMetadataIssues(
       continue;
     }
 
+    if (key === "controlledReference" && typeof value !== "boolean") {
+      continue;
+    }
+
     if (typeof value === "string" && containsUnsafePublicArtifactText(value)) {
       issues.push({
         path: `metadata.${key}`,
         message: "Track B customer lane evidence references must not embed raw controlled material.",
       });
+      continue;
+    }
+
+    if (!isBoundedControlledMetadataValue(key, value)) {
+      issues.push({
+        path: `metadata.${key}`,
+        message:
+          "Track B customer lane evidence references require bounded controlled metadata values.",
+      });
     }
   }
+}
+
+function hasMalformedControlledReferenceSignal(
+  metadata: Record<string, EvidenceBundleMetadataValue>,
+): boolean {
+  return (
+    Object.hasOwn(metadata, "controlledReference") &&
+    metadata.controlledReference !== true &&
+    metadata.controlledReference !== false
+  );
+}
+
+function isBoundedControlledMetadataValue(
+  key: string,
+  value: EvidenceBundleMetadataValue,
+): boolean {
+  if (value === null) {
+    return false;
+  }
+
+  if (controlledMetadataBooleanKeys.has(key)) {
+    return typeof value === "boolean";
+  }
+
+  if (typeof value === "number") {
+    return false;
+  }
+
+  if (typeof value !== "string") {
+    return true;
+  }
+
+  if (key === "validationCommand") {
+    return commandMetadataPattern.test(value);
+  }
+
+  const allowedValues = controlledMetadataStringValues.get(key);
+  if (allowedValues !== undefined) {
+    return allowedValues.has(value);
+  }
+
+  if (rawControlledMaterialValuePattern.test(value)) {
+    return false;
+  }
+
+  return boundedLabelPattern.test(value);
 }

--- a/src/protocol/index.ts
+++ b/src/protocol/index.ts
@@ -1,3 +1,4 @@
+export * from "./customer-lane-evidence.js";
 export * from "./evidence-bundle-ref.js";
 export * from "./local-lane-projection.js";
 export * from "./operational-evidence-profile.js";

--- a/src/protocol/local-lane-projection.ts
+++ b/src/protocol/local-lane-projection.ts
@@ -1,4 +1,5 @@
 import type { LaneRunState, LaneRunStatus } from "../lane/index.js";
+import { validateCustomerLaneEvidenceRef } from "./customer-lane-evidence.js";
 import type { EvidenceBundleRef } from "./evidence-bundle-ref.js";
 import { validateEvidenceBundleRef } from "./evidence-bundle-ref.js";
 import type {
@@ -281,6 +282,11 @@ function projectEvidenceBundleRefs(
 
     if (validation.ref.correlationId !== correlationId) {
       throw new Error("Lane run evidence correlation identifier does not match the projection input.");
+    }
+
+    const customerLaneValidation = validateCustomerLaneEvidenceRef(validation.ref);
+    if (!customerLaneValidation.ok) {
+      throw new Error(`Lane run evidence is unsafe: ${formatIssues(customerLaneValidation.issues)}`);
     }
 
     projected.push(stripUndefined({

--- a/test/customer-lane-evidence.test.ts
+++ b/test/customer-lane-evidence.test.ts
@@ -1,0 +1,64 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  isCustomerLaneEvidenceRef,
+  validateCustomerLaneEvidenceRef,
+  type EvidenceBundleRef,
+} from "../src/protocol/index.js";
+
+const safeEvidenceRef: EvidenceBundleRef = {
+  schemaVersion: "eip.evidence-bundle-ref.v1",
+  id: "evb_issue98ValidatorEvidence01",
+  correlationId: "corr_issue98ValidatorEvidence01",
+  type: "local_path",
+  uri: "artifacts/evidence/issue-98/bundle-ref.json",
+  createdAt: "2026-05-13T00:00:00Z",
+  contentType: "application/json",
+  metadata: {
+    producer: "ensen-loop",
+    artifactKind: "phase4ArtifactEvidenceReference",
+    embedsEvidencePayload: false,
+  },
+};
+
+test("treats controlled classifications as customer-lane evidence signals", () => {
+  for (const dataClassification of ["customer-confidential", "regulated"]) {
+    const evidenceRef: EvidenceBundleRef = {
+      ...safeEvidenceRef,
+      metadata: {
+        ...safeEvidenceRef.metadata,
+        dataClassification,
+        embedsEvidencePayload: false,
+      },
+    };
+
+    assert.equal(
+      isCustomerLaneEvidenceRef(evidenceRef),
+      true,
+      `${dataClassification} must not bypass the Track B customer-lane guard`,
+    );
+    assert.deepEqual(validateCustomerLaneEvidenceRef(evidenceRef), { ok: true });
+  }
+});
+
+test("fails closed when controlled classification-only references embed raw metadata", () => {
+  const result = validateCustomerLaneEvidenceRef({
+    ...safeEvidenceRef,
+    metadata: {
+      ...safeEvidenceRef.metadata,
+      dataClassification: "regulated",
+      embedsEvidencePayload: false,
+      rawCustomerRecord: "synthetic customer record",
+    },
+  });
+
+  assert.equal(result.ok, false);
+
+  if (!result.ok) {
+    assert.deepEqual(
+      result.issues.map((issue) => issue.path),
+      ["metadata.rawCustomerRecord"],
+    );
+  }
+});

--- a/test/customer-lane-evidence.test.ts
+++ b/test/customer-lane-evidence.test.ts
@@ -62,3 +62,91 @@ test("fails closed when controlled classification-only references embed raw meta
     );
   }
 });
+
+test("fails closed when customer-regulated boundary uses public classification", () => {
+  const result = validateCustomerLaneEvidenceRef({
+    ...safeEvidenceRef,
+    metadata: {
+      ...safeEvidenceRef.metadata,
+      evidenceTrack: "track-b",
+      evidenceBoundary: "customer-regulated",
+      dataClassification: "public",
+      embedsEvidencePayload: false,
+    },
+  });
+
+  assert.equal(result.ok, false);
+
+  if (!result.ok) {
+    assert.deepEqual(
+      result.issues.map((issue) => issue.path),
+      ["metadata.dataClassification"],
+    );
+  }
+});
+
+test("fails closed when controlledReference is malformed", () => {
+  const result = validateCustomerLaneEvidenceRef({
+    ...safeEvidenceRef,
+    metadata: {
+      ...safeEvidenceRef.metadata,
+      controlledReference: "true",
+      embedsEvidencePayload: false,
+    },
+  });
+
+  assert.equal(result.ok, false);
+
+  if (!result.ok) {
+    assert.deepEqual(
+      result.issues.map((issue) => issue.path),
+      ["metadata.dataClassification", "metadata.controlledReference"],
+    );
+  }
+});
+
+test("rejects free-form values in controlled metadata fields", () => {
+  for (const [key, value] of [
+    ["producer", "customer order for Alice"],
+    ["referenceKind", "customer order for Alice"],
+    ["validationCommand", "customer order for Alice"],
+  ] as const) {
+    const result = validateCustomerLaneEvidenceRef({
+      ...safeEvidenceRef,
+      metadata: {
+        ...safeEvidenceRef.metadata,
+        dataClassification: "regulated",
+        embedsEvidencePayload: false,
+        [key]: value,
+      },
+    });
+
+    assert.equal(result.ok, false, `${key} must reject free-form controlled text`);
+
+    if (!result.ok) {
+      assert.ok(
+        result.issues.some((issue) => issue.path === `metadata.${key}`),
+        `${key} rejection must point at the controlled metadata field`,
+      );
+    }
+  }
+});
+
+test("accepts bounded values in controlled metadata fields", () => {
+  const result = validateCustomerLaneEvidenceRef({
+    ...safeEvidenceRef,
+    metadata: {
+      ...safeEvidenceRef.metadata,
+      protocolVersion: "0.4.0",
+      validationCommand: "npm test",
+      evidenceTrack: "track-b",
+      evidenceBoundary: "customer-lane",
+      dataClassification: "regulated",
+      referenceKind: "controlledEvidenceReference",
+      controlledReference: true,
+      embedsEvidencePayload: false,
+    },
+  });
+
+  assert.deepEqual(result, { ok: true });
+});

--- a/test/lane-artifact-output.test.ts
+++ b/test/lane-artifact-output.test.ts
@@ -66,6 +66,20 @@ const safeEvidenceRef: EvidenceBundleRef = {
   },
 };
 
+const customerLaneEvidenceRef: EvidenceBundleRef = {
+  ...safeEvidenceRef,
+  id: "evb_issue98TrackBEvidence01",
+  correlationId: "corr_issue98TrackBEvidence01",
+  metadata: {
+    producer: "ensen-loop",
+    evidenceTrack: "track-b",
+    evidenceBoundary: "customer-lane",
+    dataClassification: "customer-confidential",
+    referenceKind: "controlledEvidenceReference",
+    embedsEvidencePayload: false,
+  },
+};
+
 const agentOutcome = createCodexAgentInvocationIntent({
   mode: "execute",
   capabilityEvidence: CODEX_AGENT_PROVIDER_CAPABILITY_EVIDENCE,
@@ -198,6 +212,67 @@ test("emits patch artifact metadata tied to completed lane state without raw evi
     },
   ]);
   assert.doesNotMatch(JSON.stringify(artifact), /rawEvidence|customer data|token=/i);
+});
+
+test("requires explicit Track B customer lane evidence classification before public artifact export", () => {
+  assert.doesNotThrow(() =>
+    createLaneArtifactOutput(
+      createSafePatchInput({
+        evidenceRefs: [customerLaneEvidenceRef],
+      }),
+    ),
+  );
+
+  const missingClassificationMetadata = { ...customerLaneEvidenceRef.metadata };
+  delete missingClassificationMetadata.dataClassification;
+  const invalidMetadataCases = [
+    missingClassificationMetadata,
+    {
+      ...customerLaneEvidenceRef.metadata,
+      dataClassification: "unknown",
+    },
+    {
+      ...customerLaneEvidenceRef.metadata,
+      dataClassification: "confidential",
+    },
+  ];
+
+  for (const metadata of invalidMetadataCases) {
+    assert.throws(
+      () =>
+        createLaneArtifactOutput(
+          createSafePatchInput({
+            evidenceRefs: [
+              {
+                ...customerLaneEvidenceRef,
+                metadata,
+              },
+            ],
+          }),
+        ),
+      /Track B customer lane evidence requires an explicit allowed data classification/i,
+    );
+  }
+});
+
+test("keeps Track B confidential evidence references metadata-only in public artifact export", () => {
+  assert.throws(
+    () =>
+      createLaneArtifactOutput(
+        createSafePatchInput({
+          evidenceRefs: [
+            {
+              ...customerLaneEvidenceRef,
+              metadata: {
+                ...customerLaneEvidenceRef.metadata,
+                rawCustomerRecord: "synthetic customer order payload",
+              },
+            },
+          ],
+        }),
+      ),
+    /Track B customer lane evidence references must not embed raw controlled material/i,
+  );
 });
 
 test("rejects generic local absolute paths in public artifact metadata without echoing raw values", () => {

--- a/test/lane-artifact-output.test.ts
+++ b/test/lane-artifact-output.test.ts
@@ -222,6 +222,22 @@ test("requires explicit Track B customer lane evidence classification before pub
       }),
     ),
   );
+  assert.doesNotThrow(() =>
+    createLaneArtifactOutput(
+      createSafePatchInput({
+        evidenceRefs: [
+          {
+            ...safeEvidenceRef,
+            metadata: {
+              ...safeEvidenceRef.metadata,
+              dataClassification: "regulated",
+              embedsEvidencePayload: false,
+            },
+          },
+        ],
+      }),
+    ),
+  );
 
   const missingClassificationMetadata = { ...customerLaneEvidenceRef.metadata };
   delete missingClassificationMetadata.dataClassification;
@@ -266,6 +282,47 @@ test("keeps Track B confidential evidence references metadata-only in public art
               metadata: {
                 ...customerLaneEvidenceRef.metadata,
                 rawCustomerRecord: "synthetic customer order payload",
+              },
+            },
+          ],
+        }),
+      ),
+    /Track B customer lane evidence references must not embed raw controlled material/i,
+  );
+
+  assert.throws(
+    () =>
+      createLaneArtifactOutput(
+        createSafePatchInput({
+          evidenceRefs: [
+            {
+              ...safeEvidenceRef,
+              metadata: {
+                ...safeEvidenceRef.metadata,
+                dataClassification: "customer-confidential",
+                embedsEvidencePayload: false,
+                rawCustomerRecord: "synthetic customer record",
+              },
+            },
+          ],
+        }),
+      ),
+    /Track B customer lane evidence references must not embed raw controlled material/i,
+  );
+
+  assert.throws(
+    () =>
+      createLaneArtifactOutput(
+        createSafePatchInput({
+          evidenceRefs: [
+            {
+              ...safeEvidenceRef,
+              metadata: {
+                ...safeEvidenceRef.metadata,
+                dataClassification: "public",
+                controlledReference: true,
+                embedsEvidencePayload: false,
+                rawCustomerRecord: "synthetic customer record",
               },
             },
           ],

--- a/test/lane-artifact-output.test.ts
+++ b/test/lane-artifact-output.test.ts
@@ -272,6 +272,27 @@ test("requires explicit Track B customer lane evidence classification before pub
 });
 
 test("keeps Track B confidential evidence references metadata-only in public artifact export", () => {
+  const missingPayloadFlagMetadata = { ...safeEvidenceRef.metadata };
+  delete missingPayloadFlagMetadata.embedsEvidencePayload;
+
+  assert.throws(
+    () =>
+      createLaneArtifactOutput(
+        createSafePatchInput({
+          evidenceRefs: [
+            {
+              ...safeEvidenceRef,
+              metadata: {
+                ...missingPayloadFlagMetadata,
+                dataClassification: "regulated",
+              },
+            },
+          ],
+        }),
+      ),
+    /Track B customer lane evidence references must not embed raw controlled material/i,
+  );
+
   assert.throws(
     () =>
       createLaneArtifactOutput(

--- a/test/local-lane-eip-projection.test.ts
+++ b/test/local-lane-eip-projection.test.ts
@@ -139,6 +139,80 @@ test("projects persisted completed lane state to EIP status and succeeded result
   );
 });
 
+test("requires explicit Track B customer lane evidence classification before RunResult projection", async () => {
+  await withPersistedLaneRun(
+    {
+      name: "issue-42-succeeded",
+      outcome: "succeeded",
+    },
+    async ({ request, persisted }) => {
+      const trackBRef = {
+        ...persisted.evidenceBundleRefs[0],
+        metadata: {
+          ...persisted.evidenceBundleRefs[0].metadata,
+          evidenceTrack: "track-b",
+          evidenceBoundary: "customer-lane",
+          dataClassification: "regulated",
+          referenceKind: "controlledEvidenceReference",
+          embedsEvidencePayload: false,
+        },
+      };
+
+      assert.doesNotThrow(() =>
+        projectLaneRunResult({
+          state: persisted.state,
+          requestId: request.id,
+          correlationId: request.correlationId,
+          completedAt: "2026-05-01T00:00:03Z",
+          evidenceBundleRefs: [trackBRef],
+        }),
+      );
+
+      const missingClassificationMetadata: Record<string, string | number | boolean | null> = {
+        ...trackBRef.metadata,
+      };
+      delete missingClassificationMetadata.dataClassification;
+
+      assert.throws(
+        () =>
+          projectLaneRunResult({
+            state: persisted.state,
+            requestId: request.id,
+            correlationId: request.correlationId,
+            completedAt: "2026-05-01T00:00:03Z",
+            evidenceBundleRefs: [
+              {
+                ...trackBRef,
+                metadata: missingClassificationMetadata,
+              },
+            ],
+          }),
+        /Track B customer lane evidence requires an explicit allowed data classification/i,
+      );
+
+      assert.throws(
+        () =>
+          projectLaneRunResult({
+            state: persisted.state,
+            requestId: request.id,
+            correlationId: request.correlationId,
+            completedAt: "2026-05-01T00:00:03Z",
+            evidenceBundleRefs: [
+              {
+                ...trackBRef,
+                metadata: {
+                  ...trackBRef.metadata,
+                  dataClassification: "unknown",
+                },
+              },
+            ],
+          }),
+        /Track B customer lane evidence requires an explicit allowed data classification/i,
+      );
+    },
+  );
+});
+
 test("projects failed and blocked terminal lane state without inventing success evidence", async () => {
   await withPersistedLaneRun(
     {

--- a/test/local-lane-eip-projection.test.ts
+++ b/test/local-lane-eip-projection.test.ts
@@ -209,6 +209,51 @@ test("requires explicit Track B customer lane evidence classification before Run
           }),
         /Track B customer lane evidence requires an explicit allowed data classification/i,
       );
+
+      assert.throws(
+        () =>
+          projectLaneRunResult({
+            state: persisted.state,
+            requestId: request.id,
+            correlationId: request.correlationId,
+            completedAt: "2026-05-01T00:00:03Z",
+            evidenceBundleRefs: [
+              {
+                ...persisted.evidenceBundleRefs[0],
+                metadata: {
+                  ...persisted.evidenceBundleRefs[0].metadata,
+                  dataClassification: "regulated",
+                  embedsEvidencePayload: false,
+                  rawCustomerRecord: "synthetic customer record",
+                },
+              },
+            ],
+          }),
+        /Track B customer lane evidence references must not embed raw controlled material/i,
+      );
+
+      assert.throws(
+        () =>
+          projectLaneRunResult({
+            state: persisted.state,
+            requestId: request.id,
+            correlationId: request.correlationId,
+            completedAt: "2026-05-01T00:00:03Z",
+            evidenceBundleRefs: [
+              {
+                ...persisted.evidenceBundleRefs[0],
+                metadata: {
+                  ...persisted.evidenceBundleRefs[0].metadata,
+                  dataClassification: "internal",
+                  controlledReference: true,
+                  embedsEvidencePayload: false,
+                  rawCustomerRecord: "synthetic customer record",
+                },
+              },
+            ],
+          }),
+        /Track B customer lane evidence references must not embed raw controlled material/i,
+      );
     },
   );
 });


### PR DESCRIPTION
## Summary
- require explicit Track B customer lane evidence classification before public artifact export
- fail closed during RunResult projection for missing or unknown Track B evidence classification
- keep customer-confidential and regulated evidence references metadata-only and document the Protocol v0.4.0 boundary

## Tests
- npm run typecheck
- npm run build
- node --test dist/test/lane-artifact-output.test.js dist/test/local-lane-eip-projection.test.js
- npm test
- node --test dist/test/protocol-snapshot.test.js

Closes #98