### PR TITLE
LOOP-X3B-003: Guard customer lane public artifacts

### DIFF
--- a/src/artifact/index.ts
+++ b/src/artifact/index.ts
@@ -124,6 +124,8 @@ const repoRelativePathPattern = /^(?:\.|[A-Za-z0-9._-][A-Za-z0-9._/-]*)$/;
 const artifactPathPattern = /^artifacts\/[A-Za-z0-9._~@/-]+$/;
 const mediaTypes = new Set<unknown>(["text/x-diff", "application/json", "text/markdown"]);
 const repositorySlugPattern = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
+const unsafePublicArtifactMessage =
+  "Lane artifact output must not contain raw secrets, customer identifiers, regulated content, or workstation-local absolute paths.";
 
 export function createLaneArtifactOutput(input: CreateLaneArtifactOutputInput): LaneArtifactOutput {
   const issues = collectCreateLaneArtifactOutputIssues(input);
@@ -356,7 +358,7 @@ function collectLaneArtifactOutputIssues(value: unknown): readonly LaneArtifactO
   if (containsUnsafePublicText(value)) {
     issues.push({
       path: "$",
-      message: "Lane artifact output must not contain raw secrets or workstation-local absolute paths.",
+      message: unsafePublicArtifactMessage,
     });
   }
 
@@ -460,7 +462,8 @@ function collectArtifactRefIssues(
   ) {
     issues.push({
       path: `${pathPrefix}.uri`,
-      message: "Artifact path must be repo-relative under artifacts/ without traversal, secrets, or workstation-local paths.",
+      message:
+        "Artifact path must be repo-relative under artifacts/ without traversal, secrets, customer identifiers, regulated content, or workstation-local paths.",
     });
   }
 
@@ -548,7 +551,8 @@ function collectEvidenceRefIssues(
     if (containsUnsafePublicText(evidenceRef)) {
       issues.push({
         path: `evidenceRefs[${index}]`,
-        message: "Artifact output evidence references must not contain raw secrets or workstation-local paths.",
+        message:
+          "Artifact output evidence references must not contain raw secrets, customer identifiers, regulated content, or workstation-local paths.",
       });
     }
 

--- a/src/safety/public-artifact.ts
+++ b/src/safety/public-artifact.ts
@@ -20,7 +20,7 @@ const customerIdentifierPatterns: readonly RegExp[] = [
 ];
 
 const customerPathPatterns: readonly RegExp[] = [
-  /\b(?:customers?|tenants?|accounts?|regulated|records?)\/[A-Za-z0-9._~@/-]+\b/gi,
+  /\b(?:customers?|tenants?|accounts?)\/[A-Za-z0-9._~@/-]+\b/gi,
   /<customer-ref>\/[A-Za-z0-9._~@/-]+\b/gi,
 ];
 

--- a/src/safety/public-artifact.ts
+++ b/src/safety/public-artifact.ts
@@ -1,4 +1,8 @@
 const secretLikePlaceholder = "<secret-like-value>";
+const customerIdentifierPlaceholder = "<customer-identifier>";
+const customerPathPlaceholder = "<customer-path>";
+const customerDomainPlaceholder = "<customer-domain>";
+const regulatedRecordLikePlaceholder = "<regulated-record-like-value>";
 
 const secretLikePatterns: readonly RegExp[] = [
   /-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----/gi,
@@ -10,19 +14,67 @@ const secretLikePatterns: readonly RegExp[] = [
   /\b(?:sk-[A-Za-z0-9][A-Za-z0-9_-]{8,}|xox[baprs]-[A-Za-z0-9-]{8,})\b/g,
 ];
 
+const customerIdentifierPatterns: readonly RegExp[] = [
+  /\b(?:customer|cust|tenant|account|organization|org)[_-]?id\s*[:=]\s*[A-Za-z0-9][A-Za-z0-9._~-]{5,}\b/gi,
+  /\b(?:cust|customer|tenant|acct|org)_[A-Za-z0-9][A-Za-z0-9._~-]{5,}\b/gi,
+];
+
+const customerPathPatterns: readonly RegExp[] = [
+  /\b(?:customers?|tenants?|accounts?|regulated|records?)\/[A-Za-z0-9._~@/-]+\b/gi,
+  /<customer-ref>\/[A-Za-z0-9._~@/-]+\b/gi,
+];
+
+const customerDomainPatterns: readonly RegExp[] = [
+  /\b[A-Za-z0-9-]+(?:\.[A-Za-z0-9-]+)*\.(?:customer|tenant|private|internal)\.example\b/gi,
+];
+
+const regulatedRecordLikePatterns: readonly RegExp[] = [
+  /\bMRN[-_:# ]*\d{6,}\b(?:\s+DOB\s+\d{4}-\d{2}-\d{2})?/gi,
+  /\bDOB\s+\d{4}-\d{2}-\d{2}\b/gi,
+  /\b(?:electronic signature|batch release|final disposition)\s+(?:record|approval|id)[-_:# ]*[A-Za-z0-9._~-]+\b/gi,
+];
+
 export const workstationLocalPathPattern =
   /(?:^|[\s"'([{<>=])(?:\/(?!\/)(?:[A-Za-z0-9._~@-]+(?:\/[A-Za-z0-9._~@-]+)*\/?)|~(?:[/\\]|\s|$)|\$HOME(?:[/\\]|\s|$)|%USERPROFILE%(?:[/\\]|\s|$)|[A-Za-z]:[\\/][^"'`<>\s]+|\\\\[^"'`<>\s\\]+\\[^"'`<>\s\\]+(?:\\[^"'`<>\s\\]+)*)/i;
 
 export function containsUnsafePublicArtifactText(value: string): boolean {
-  return secretLikePatterns.some((pattern) => {
-    pattern.lastIndex = 0;
-    return pattern.test(value);
-  }) || workstationLocalPathPattern.test(value);
+  return (
+    containsPattern(value, secretLikePatterns) ||
+    containsPattern(value, customerIdentifierPatterns) ||
+    containsPattern(value, customerPathPatterns) ||
+    containsPattern(value, customerDomainPatterns) ||
+    containsPattern(value, regulatedRecordLikePatterns) ||
+    workstationLocalPathPattern.test(value)
+  );
 }
 
 export function sanitizePublicDiagnosticMessage(message: string): string {
-  return secretLikePatterns.reduce((sanitized, pattern) => {
+  let sanitized = replacePatterns(message, secretLikePatterns, secretLikePlaceholder);
+  sanitized = replacePatterns(sanitized, customerIdentifierPatterns, customerIdentifierPlaceholder);
+  sanitized = replacePatterns(sanitized, customerPathPatterns, customerPathPlaceholder);
+  sanitized = replacePatterns(sanitized, customerDomainPatterns, customerDomainPlaceholder);
+  sanitized = replacePatterns(
+    sanitized,
+    regulatedRecordLikePatterns,
+    regulatedRecordLikePlaceholder,
+  );
+  return sanitized;
+}
+
+function containsPattern(value: string, patterns: readonly RegExp[]): boolean {
+  return patterns.some((pattern) => {
     pattern.lastIndex = 0;
-    return sanitized.replace(pattern, secretLikePlaceholder);
+    return pattern.test(value);
+  });
+}
+
+function replacePatterns(
+  message: string,
+  patterns: readonly RegExp[],
+  placeholder: string,
+): string {
+  return patterns.reduce((sanitized, pattern) => {
+    pattern.lastIndex = 0;
+    return sanitized.replace(pattern, placeholder);
   }, message);
 }

--- a/test/cli-diagnostics.test.ts
+++ b/test/cli-diagnostics.test.ts
@@ -58,6 +58,30 @@ test("CLI diagnostics redact secret-like values", () => {
   assert.match(sanitized, /config contained <secret-like-value>/);
 });
 
+test("CLI diagnostics redact customer and regulated-looking values", () => {
+  const customerId = "customer_id=cust_synthetic_123456";
+  const customerPath = "customers/synthetic-pharma/orders/export.json";
+  const customerDomain = "alpha-customer.customer.example";
+  const regulatedRecord = "MRN-12345678 DOB 1970-01-01";
+  const message = [
+    `artifact blocked for ${customerId}`,
+    `artifact blocked for customer path ${customerPath}`,
+    `artifact blocked for tenant ${customerDomain}`,
+    `artifact blocked for synthetic regulated fixture ${regulatedRecord}`,
+  ].join("\n");
+
+  const sanitized = sanitizeCliErrorMessage(message);
+
+  assert.doesNotMatch(sanitized, new RegExp(escapeRegExp(customerId)));
+  assert.doesNotMatch(sanitized, new RegExp(escapeRegExp(customerPath)));
+  assert.doesNotMatch(sanitized, new RegExp(escapeRegExp(customerDomain)));
+  assert.doesNotMatch(sanitized, new RegExp(escapeRegExp(regulatedRecord)));
+  assert.match(sanitized, /artifact blocked for <customer-identifier>/);
+  assert.match(sanitized, /artifact blocked for customer path <customer-path>/);
+  assert.match(sanitized, /artifact blocked for tenant <customer-domain>/);
+  assert.match(sanitized, /artifact blocked for synthetic regulated fixture <regulated-record-like-value>/);
+});
+
 function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }

--- a/test/customer-lane-evidence.test.ts
+++ b/test/customer-lane-evidence.test.ts
@@ -132,6 +132,33 @@ test("rejects free-form values in controlled metadata fields", () => {
   }
 });
 
+test("rejects synthetic customer identifiers, customer domains, and regulated records in controlled metadata", () => {
+  for (const [key, value] of [
+    ["checksumUnavailableReason", "customer_id=cust_synthetic_123456"],
+    ["checksumUnavailableReason", "tenant alpha-customer.customer.example"],
+    ["checksumUnavailableReason", "synthetic regulated fixture MRN-12345678 DOB 1970-01-01"],
+  ] as const) {
+    const result = validateCustomerLaneEvidenceRef({
+      ...safeEvidenceRef,
+      metadata: {
+        ...safeEvidenceRef.metadata,
+        dataClassification: "regulated",
+        embedsEvidencePayload: false,
+        [key]: value,
+      },
+    });
+
+    assert.equal(result.ok, false, `${value} must reject controlled metadata`);
+
+    if (!result.ok) {
+      assert.ok(
+        result.issues.some((issue) => issue.path === `metadata.${key}`),
+        `${value} rejection must point at the controlled metadata field`,
+      );
+    }
+  }
+});
+
 test("accepts bounded values in controlled metadata fields", () => {
   const result = validateCustomerLaneEvidenceRef({
     ...safeEvidenceRef,

--- a/test/lane-artifact-output.test.ts
+++ b/test/lane-artifact-output.test.ts
@@ -378,7 +378,7 @@ test("rejects generic local absolute paths in public artifact metadata without e
         ),
       (error: unknown) => {
         assert.ok(error instanceof Error);
-        assert.match(error.message, /raw secrets or workstation-local absolute paths/i);
+        assert.match(error.message, /raw secrets, customer identifiers, regulated content, or workstation-local absolute paths/i);
         assert.doesNotMatch(error.message, new RegExp(escapeRegExp(unsafePublicPath)));
         return true;
       },
@@ -409,7 +409,41 @@ test("rejects secret-like public artifact values without echoing raw values", ()
         ),
       (error: unknown) => {
         assert.ok(error instanceof Error);
-        assert.match(error.message, /raw secrets or workstation-local absolute paths/i);
+        assert.match(error.message, /raw secrets, customer identifiers, regulated content, or workstation-local absolute paths/i);
+        assert.doesNotMatch(error.message, new RegExp(escapeRegExp(unsafePublicValue)));
+        return true;
+      },
+    );
+  }
+});
+
+test("rejects customer and regulated-looking public artifact values without echoing raw values", () => {
+  const unsafePublicValues = [
+    "customer_id=cust_synthetic_123456",
+    "customer path customers/synthetic-pharma/orders/export.json",
+    "tenant at alpha-customer.customer.example",
+    "synthetic regulated fixture MRN-12345678 DOB 1970-01-01",
+  ];
+
+  for (const unsafePublicValue of unsafePublicValues) {
+    assert.throws(
+      () =>
+        createLaneArtifactOutput(
+          createSafePatchInput({
+            workItem: {
+              id: "workitem_issue60Patch01",
+              title: `LOOP-035: ${unsafePublicValue}`,
+              source: "github-issue-60",
+              status: "completed",
+            },
+          }),
+        ),
+      (error: unknown) => {
+        assert.ok(error instanceof Error);
+        assert.match(
+          error.message,
+          /raw secrets, customer identifiers, regulated content, or workstation-local absolute paths/i,
+        );
         assert.doesNotMatch(error.message, new RegExp(escapeRegExp(unsafePublicValue)));
         return true;
       },
@@ -681,7 +715,7 @@ test("validates nested public artifact fields and fails closed on unsafe seriali
   assert.equal(circularValidation.ok, false);
   assert.match(
     circularValidation.ok ? "" : circularValidation.issues.map((issue) => issue.message).join("\n"),
-    /raw secrets or workstation-local absolute paths/i,
+    /raw secrets, customer identifiers, regulated content, or workstation-local absolute paths/i,
   );
 });
 

--- a/test/lane-artifact-output.test.ts
+++ b/test/lane-artifact-output.test.ts
@@ -451,6 +451,20 @@ test("rejects customer and regulated-looking public artifact values without echo
   }
 });
 
+test("allows public record artifact paths without customer-specific prefixes", () => {
+  const artifact = createLaneArtifactOutput(
+    createSafePatchInput({
+      artifactRef: {
+        uri: "artifacts/records/report.json",
+        mediaType: "application/json",
+      },
+    }),
+  );
+
+  assert.equal(artifact.artifact.uri, "artifacts/records/report.json");
+  assert.equal(validateLaneArtifactOutput(artifact).ok, true);
+});
+
 test("emits guarded PR draft intent without implying automatic merge authority", () => {
   const artifact = createLaneArtifactOutput({
     kind: "pr-draft-intent",


### PR DESCRIPTION
## Summary
- extend public artifact safety checks for customer identifiers, customer paths, customer domains, and regulated-record-like synthetic values
- sanitize CLI diagnostics for the same customer/regulatory categories
- add focused artifact hygiene regression coverage for public artifacts, diagnostics, and controlled evidence metadata

## Verification
- npm ci
- npm run build && node --test dist/test/lane-artifact-output.test.js dist/test/cli-diagnostics.test.js dist/test/customer-lane-evidence.test.js
- npm run typecheck
- npm run build
- npm test
- npm install

Closes #99