### PR TITLE
LOOP-X3B-004: Ban customer lane automatic decisions

### DIFF
--- a/docs/reference/lane-artifact-output.md
+++ b/docs/reference/lane-artifact-output.md
@@ -3,7 +3,7 @@
 Phase 4 lane artifact output is a review surface for completed local lane runs.
 It can describe a patch artifact reference or a PR draft intent, but it does not
 create pull requests, merge branches, declare production readiness, or replace
-human review.
+human review. It never records an automatic final quality decision.
 
 ## Artifact Boundary
 
@@ -19,6 +19,10 @@ dry-run-first precondition summary: dry-run proof required, proof provided,
 human operator approval provided, merge unsupported, and merge authority
 human-only. This metadata explains the approval boundary for reviewers; it does
 not grant merge authority.
+
+Artifact output records merge authority and final quality decision authority as
+human-only control points. `mergeReady`, `autoMerge`, and
+`automaticQualityDecision` must remain false.
 
 Artifact paths are public review metadata. They must stay repo-relative under
 `artifacts/`, avoid traversal, and avoid raw secrets or workstation-local
@@ -76,5 +80,10 @@ review boundary and keeps these fields false:
 - pull request creation
 - merge readiness
 - automatic merge authority
+- automatic final quality decision
 
-The merge decision remains human-only.
+The merge decision and final quality decision remain human-only. Track B
+customer lane evidence can be exported only as patch artifact metadata; it cannot
+activate PR draft intent, automatic merge, or automatic quality-decision paths.
+This does not permit production use, live ERPNext write-back, regulated workflow
+execution, or compliance guarantees.

--- a/src/artifact/index.ts
+++ b/src/artifact/index.ts
@@ -7,6 +7,7 @@ import type { WorkItem } from "../core/index.js";
 import type { LaneRunState } from "../lane/index.js";
 import {
   type EvidenceBundleRef,
+  isCustomerLaneEvidenceRef,
   validateCustomerLaneEvidenceRef,
   validateEvidenceBundleRef,
 } from "../protocol/index.js";
@@ -95,9 +96,11 @@ export interface LaneArtifactOutput {
   readonly humanReview: {
     readonly required: true;
     readonly mergeAuthority: "human-only";
+    readonly qualityDecisionAuthority: "human-only";
   };
   readonly mergeReady: false;
   readonly autoMerge: false;
+  readonly automaticQualityDecision: false;
 }
 
 export interface LaneArtifactOutputValidationIssue {
@@ -176,9 +179,11 @@ export function createLaneArtifactOutput(input: CreateLaneArtifactOutputInput): 
     humanReview: {
       required: true,
       mergeAuthority: "human-only",
+      qualityDecisionAuthority: "human-only",
     },
     mergeReady: false,
     autoMerge: false,
+    automaticQualityDecision: false,
   };
   const validation = validateLaneArtifactOutput(artifact);
 
@@ -265,6 +270,13 @@ function collectCreateLaneArtifactOutputIssues(
     collectPrDraftScopeIssues(issues, input.ownerControlledRepository);
   }
 
+  if (input.kind === "pr-draft-intent" && input.evidenceRefs?.some(isCustomerLaneEvidenceRef) === true) {
+    issues.push({
+      path: "kind",
+      message: "Customer lane artifact output does not support PR draft intent.",
+    });
+  }
+
   collectEvidenceRefIssues(issues, input.laneRunState, input.evidenceRefs ?? []);
 
   return issues;
@@ -308,10 +320,16 @@ function collectLaneArtifactOutputIssues(value: unknown): readonly LaneArtifactO
     });
   }
 
-  if (value.createsPullRequest !== false || value.mergeReady !== false || value.autoMerge !== false) {
+  if (
+    value.createsPullRequest !== false ||
+    value.mergeReady !== false ||
+    value.autoMerge !== false ||
+    value.automaticQualityDecision !== false
+  ) {
     issues.push({
       path: "humanReview",
-      message: "Lane artifact output must not imply pull request creation, merge readiness, or auto merge.",
+      message:
+        "Lane artifact output must not imply pull request creation, merge readiness, auto merge, or automatic quality decision.",
     });
   }
 
@@ -320,11 +338,12 @@ function collectLaneArtifactOutputIssues(value: unknown): readonly LaneArtifactO
   if (
     !isRecord(value.humanReview) ||
     value.humanReview.required !== true ||
-    value.humanReview.mergeAuthority !== "human-only"
+    value.humanReview.mergeAuthority !== "human-only" ||
+    value.humanReview.qualityDecisionAuthority !== "human-only"
   ) {
     issues.push({
       path: "humanReview",
-      message: "Lane artifact output must preserve the human review boundary.",
+      message: "Lane artifact output must preserve the human merge and quality review boundary.",
     });
   }
 

--- a/test/lane-artifact-output.test.ts
+++ b/test/lane-artifact-output.test.ts
@@ -271,6 +271,44 @@ test("requires explicit Track B customer lane evidence classification before pub
   }
 });
 
+test("keeps customer lane artifact output at human merge and quality control points", () => {
+  const artifact = createLaneArtifactOutput(
+    createSafePatchInput({
+      evidenceRefs: [customerLaneEvidenceRef],
+    }),
+  );
+
+  assert.equal(artifact.humanReview.mergeAuthority, "human-only");
+  assert.equal(
+    (artifact.humanReview as Record<string, unknown>).qualityDecisionAuthority,
+    "human-only",
+  );
+  assert.equal((artifact as unknown as Record<string, unknown>).automaticQualityDecision, false);
+  assert.equal(artifact.changeRequestIntent.status, "not-requested");
+  assert.equal(artifact.mergeReady, false);
+  assert.equal(artifact.autoMerge, false);
+
+  assert.throws(
+    () =>
+      createLaneArtifactOutput(
+        createSafePatchInput({
+          kind: "pr-draft-intent",
+          artifactRef: {
+            uri: "artifacts/pr-drafts/issue-100.json",
+            mediaType: "application/json",
+          },
+          ownerControlledRepository: {
+            provider: "github",
+            repositorySlug: "TommyKammy/Ensen-loop",
+            changeRequestIntentSupported: true,
+          },
+          evidenceRefs: [customerLaneEvidenceRef],
+        }),
+      ),
+    /Customer lane artifact output does not support PR draft intent/i,
+  );
+});
+
 test("keeps Track B confidential evidence references metadata-only in public artifact export", () => {
   const missingPayloadFlagMetadata = { ...safeEvidenceRef.metadata };
   delete missingPayloadFlagMetadata.embedsEvidencePayload;


### PR DESCRIPTION
## Summary
- Records lane artifact merge and quality decision authority as human-only
- Keeps automatic quality decision false alongside mergeReady and autoMerge
- Rejects Track B customer lane PR draft intent while preserving patch artifact evidence metadata

## Verification
- npm ci
- npm run build && node --test dist/test/lane-artifact-output.test.js
- npm run typecheck
- npm run build && npm test

Closes #100
Part of #102