### PR TITLE
LOOP-050: Add lane run queue and lock model

### DIFF
--- a/src/lane/index.ts
+++ b/src/lane/index.ts
@@ -786,6 +786,17 @@ export async function claimQueuedLaneRun(
 
     const existingLock = await readOptionalLaneRunLock(stateRoot, input.stableWorkItemId);
 
+    if (existingLock && isStaleQueueRecordForTerminalLock(queueRecord, existingLock)) {
+      const reason = `stale queued record for terminal lane run ${existingLock.laneRunId}`;
+
+      return {
+        ok: false,
+        reason,
+        lock: existingLock,
+        publicDiagnostics: createLaneRunLockDiagnostics(existingLock, reason),
+      };
+    }
+
     if (existingLock?.active === true) {
       const reason = `already claimed by active lane run ${existingLock.laneRunId}`;
 
@@ -1000,6 +1011,14 @@ async function assertNoActiveLaneRunLockForEnqueue(stateRoot: string, stableWork
       `Cannot enqueue lane run while stable work item is already claimed by active lane run ${existingLock.laneRunId}.`,
     );
   }
+}
+
+function isStaleQueueRecordForTerminalLock(queueRecord: LaneRunQueueRecord, lock: LaneRunLock): boolean {
+  if (lock.status === "active" || lock.releasedAt === undefined || lock.queueRecordId !== queueRecord.id) {
+    return false;
+  }
+
+  return Date.parse(queueRecord.queuedAt) <= Date.parse(lock.releasedAt);
 }
 
 async function recoverStaleLaneRunMutationLock(lockPath: string): Promise<boolean> {

--- a/src/lane/index.ts
+++ b/src/lane/index.ts
@@ -954,11 +954,14 @@ async function acquireLaneRunMutationLock(
   await assertExistingPathSafe(realRoot, lockRoot, "directory");
 
   for (let attempt = 0; attempt < 25; attempt += 1) {
+    let acquiredStats: Stats | undefined;
+
     try {
       await mkdir(lockPath, { mode: 0o700 });
+      acquiredStats = await lstat(lockPath);
       await assertExistingPathSafe(realRoot, lockPath, "directory");
       await writeLaneRunMutationLockOwner(realRoot, lockPath, owner);
-      const lockStats = await lstat(lockPath);
+      const lockStats = acquiredStats;
       const stopHeartbeat = startLaneRunMutationLockHeartbeat(lockPath);
 
       return async () => {
@@ -967,7 +970,10 @@ async function acquireLaneRunMutationLock(
       };
     } catch (error) {
       if (!isNodeError(error) || error.code !== "EEXIST") {
-        await rm(lockPath, { recursive: true, force: true });
+        if (acquiredStats) {
+          await removeCreatedLaneRunMutationLock(lockPath, owner.token, acquiredStats);
+        }
+
         throw error;
       }
 
@@ -982,6 +988,44 @@ async function acquireLaneRunMutationLock(
   }
 
   throw new Error("Lane run queue record is currently being modified; retry the lane run mutation.");
+}
+
+async function removeCreatedLaneRunMutationLock(
+  lockPath: string,
+  token: string,
+  acquiredStats: Stats,
+): Promise<void> {
+  const currentStats = await lstat(lockPath).catch((error: unknown) => {
+    if (isNodeError(error) && error.code === "ENOENT") {
+      return undefined;
+    }
+
+    throw error;
+  });
+
+  if (!currentStats || !currentStats.isDirectory() || !sameFileStats(acquiredStats, currentStats)) {
+    return;
+  }
+
+  const ownerPath = path.join(lockPath, laneRunMutationLockOwnerFilename(token));
+
+  try {
+    await rm(ownerPath);
+  } catch (error) {
+    if (!isNodeError(error) || error.code !== "ENOENT") {
+      throw error;
+    }
+  }
+
+  try {
+    await rmdir(lockPath);
+  } catch (error) {
+    if (isNodeError(error) && (error.code === "ENOENT" || error.code === "ENOTEMPTY")) {
+      return;
+    }
+
+    throw error;
+  }
 }
 
 function startLaneRunMutationLockHeartbeat(lockPath: string): () => void {
@@ -1027,11 +1071,33 @@ async function nextLaneRunQueueSequence(stateRoot: string, stableWorkItemId: str
 }
 
 function isStaleQueueRecordForTerminalLock(queueRecord: LaneRunQueueRecord, lock: LaneRunLock): boolean {
-  if (lock.status === "active" || lock.releasedAt === undefined || lock.queueRecordId !== queueRecord.id) {
+  if (lock.status === "active" || lock.releasedAt === undefined) {
     return false;
   }
 
-  return true;
+  if (lock.queueRecordId === queueRecord.id) {
+    return true;
+  }
+
+  const lockSequence = parseLaneRunQueueSequenceFromRecordId(lock.stableWorkItemId, lock.queueRecordId);
+
+  return lockSequence >= queueRecord.enqueueSequence;
+}
+
+function parseLaneRunQueueSequenceFromRecordId(stableWorkItemId: string, queueRecordId: string): number {
+  const prefix = `queue-${stableWorkItemId}-`;
+
+  if (!queueRecordId.startsWith(prefix)) {
+    throw new Error("Lane run lock queue record reference is malformed.");
+  }
+
+  const sequence = Number(queueRecordId.slice(prefix.length));
+
+  if (!Number.isSafeInteger(sequence) || sequence < 1) {
+    throw new Error("Lane run lock queue record sequence is malformed.");
+  }
+
+  return sequence;
 }
 
 function assertLaneRunCompletionTimestamp(claimedAt: string, completedAt: string): void {

--- a/src/lane/index.ts
+++ b/src/lane/index.ts
@@ -294,6 +294,7 @@ const idempotencyIntentPattern = /^[A-Za-z0-9][A-Za-z0-9._:-]{11,159}$/;
 const laneRunMutationLockStaleMs = 5 * 60 * 1000;
 const laneRunMutationLockHeartbeatMs = 60 * 1000;
 const laneRunMaxCompletionDurationMs = 7 * 24 * 60 * 60 * 1000;
+const laneRunCompletionClockSkewMs = 5 * 60 * 1000;
 const laneRunMutationLockOwnerTokenPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 const windowsReservedFilenameStems = new Set([
   "con",
@@ -1037,7 +1038,11 @@ function assertLaneRunCompletionTimestamp(claimedAt: string, completedAt: string
   const claimedAtMs = Date.parse(claimedAt);
   const completedAtMs = Date.parse(completedAt);
 
-  if (completedAtMs < claimedAtMs || completedAtMs - claimedAtMs > laneRunMaxCompletionDurationMs) {
+  if (
+    completedAtMs < claimedAtMs ||
+    completedAtMs - claimedAtMs > laneRunMaxCompletionDurationMs ||
+    completedAtMs - Date.now() > laneRunCompletionClockSkewMs
+  ) {
     throw new Error("Lane run lock completion timestamp must stay within the active claim window.");
   }
 }
@@ -1065,6 +1070,27 @@ async function recoverStaleLaneRunMutationLock(lockPath: string): Promise<boolea
 
   // The lock directory heartbeat is the lock-specific liveness signal; PIDs can be reused
   // and malformed owner metadata must not make a stale lock unrecoverable.
+  await delay(20);
+
+  const refreshedStats = await lstat(lockPath).catch((error: unknown) => {
+    if (isNodeError(error) && error.code === "ENOENT") {
+      return undefined;
+    }
+
+    throw error;
+  });
+
+  if (!refreshedStats) {
+    return true;
+  }
+
+  if (
+    !refreshedStats.isDirectory() ||
+    !sameFileStats(lockStats, refreshedStats) ||
+    Date.now() - refreshedStats.mtimeMs < laneRunMutationLockStaleMs
+  ) {
+    return false;
+  }
 
   try {
     await rm(lockPath, { recursive: true });

--- a/src/lane/index.ts
+++ b/src/lane/index.ts
@@ -782,6 +782,8 @@ export async function claimQueuedLaneRun(
     throw new Error("Lane run claim input is malformed.");
   }
 
+  assertLaneRunClaimTimestamp(input.claimedAt);
+
   return withLaneRunMutationLock(stateRoot, input.stableWorkItemId, async () => {
     const queueRecord = await readLaneRunQueueRecord(stateRoot, input.stableWorkItemId);
 
@@ -879,6 +881,11 @@ export async function completeLaneRunLock(
     assertLaneRunCompletionTimestamp(existingLock.claimedAt, input.completedAt);
 
     const queueRecord = await readLaneRunQueueRecord(stateRoot, input.stableWorkItemId);
+
+    if (queueRecord.id !== existingLock.queueRecordId) {
+      throw new Error("Lane run queue record does not match the active lane run lock.");
+    }
+
     const completedLock = toSerializableLaneRunLock({
       ...existingLock,
       status: input.terminalStatus,
@@ -1098,6 +1105,14 @@ function parseLaneRunQueueSequenceFromRecordId(stableWorkItemId: string, queueRe
   }
 
   return sequence;
+}
+
+function assertLaneRunClaimTimestamp(claimedAt: string): void {
+  const claimedAtMs = Date.parse(claimedAt);
+
+  if (claimedAtMs - Date.now() > laneRunCompletionClockSkewMs) {
+    throw new Error("Lane run claim timestamp must stay within the local clock tolerance.");
+  }
 }
 
 function assertLaneRunCompletionTimestamp(claimedAt: string, completedAt: string): void {
@@ -2311,6 +2326,10 @@ function parseLaneRunQueueRecord(value: unknown): LaneRunQueueRecord {
 
   const record = value as unknown as LaneRunQueueRecord;
 
+  if (!isCanonicalLaneRunQueueRecordId(record.stableWorkItemId, record.id, record.enqueueSequence)) {
+    throw new Error("Lane run queue record is malformed.");
+  }
+
   if (
     record.publicDiagnostics.stableWorkItemId !== record.stableWorkItemId ||
     record.publicDiagnostics.laneId !== record.laneId ||
@@ -2322,6 +2341,14 @@ function parseLaneRunQueueRecord(value: unknown): LaneRunQueueRecord {
   }
 
   return record;
+}
+
+function isCanonicalLaneRunQueueRecordId(stableWorkItemId: string, queueRecordId: string, enqueueSequence: number): boolean {
+  try {
+    return parseLaneRunQueueSequenceFromRecordId(stableWorkItemId, queueRecordId) === enqueueSequence;
+  } catch {
+    return false;
+  }
 }
 
 function parseLaneRunLock(value: unknown): LaneRunLock {

--- a/src/lane/index.ts
+++ b/src/lane/index.ts
@@ -1255,9 +1255,32 @@ async function writeJsonStateFile(
   try {
     await assertGenericStatePathSafeForWrite(stateRoot, statePath);
     await rename(temporaryPath, statePath);
+    await syncStateDirectory(realRoot, stateDirectory);
   } catch (error) {
     await rm(temporaryPath, { force: true });
     throw error;
+  }
+}
+
+async function syncStateDirectory(realRoot: string, stateDirectory: string): Promise<void> {
+  await assertExistingPathSafe(realRoot, stateDirectory, "directory");
+
+  const directory = await open(
+    stateDirectory,
+    constants.O_RDONLY | directoryFlag() | noFollowFlag() | nonBlockingFlag(),
+  );
+
+  try {
+    const stats = await directory.stat();
+
+    if (!stats.isDirectory()) {
+      throw new Error("Lane run durable state directory path must be a real directory.");
+    }
+
+    await assertExistingPathSafe(realRoot, stateDirectory, "directory");
+    await directory.sync();
+  } finally {
+    await directory.close();
   }
 }
 
@@ -1953,6 +1976,10 @@ function noFollowFlag(): number {
 
 function nonBlockingFlag(): number {
   return typeof constants.O_NONBLOCK === "number" ? constants.O_NONBLOCK : 0;
+}
+
+function directoryFlag(): number {
+  return typeof constants.O_DIRECTORY === "number" ? constants.O_DIRECTORY : 0;
 }
 
 async function assertOpenedLaneRunStateFileSafeForAccess(

--- a/src/lane/index.ts
+++ b/src/lane/index.ts
@@ -1,6 +1,7 @@
 import { constants } from "node:fs";
 import type { Stats } from "node:fs";
-import { lstat, mkdir, open, realpath, rm } from "node:fs/promises";
+import { randomUUID } from "node:crypto";
+import { lstat, mkdir, open, realpath, rename, rm } from "node:fs/promises";
 import type { FileHandle } from "node:fs/promises";
 import path from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
@@ -111,6 +112,13 @@ export interface LaneRunLockDiagnostics {
   readonly lockStatus: LaneRunLockStatus;
   readonly laneRunId: string;
   readonly reason: string;
+}
+
+interface LaneRunMutationLockOwner {
+  readonly schemaVersion: "ensen.lane-run-mutation-lock-owner.v1";
+  readonly token: string;
+  readonly pid: number;
+  readonly acquiredAt: string;
 }
 
 export interface LaneRunQueueRecord {
@@ -277,12 +285,38 @@ export const preparedLocalLaneMarkerSchemaVersion = "ensen.local-lane-prepared.v
 
 const laneRunIdPattern = /^[A-Za-z0-9][A-Za-z0-9._-]*$/;
 const localLaneDirectoryNamePattern = /^[A-Za-z0-9._-]{1,128}$/;
-const stableWorkItemIdPattern = /^[A-Za-z0-9][A-Za-z0-9._-]{0,159}$/;
+const stableWorkItemIdPattern = /^[a-z0-9][a-z0-9._-]{0,159}$/;
 const laneIdPattern = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/;
 const branchNamePattern = /^[A-Za-z0-9][A-Za-z0-9._/-]{0,159}$/;
 const repositorySlugPattern = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
 const idempotencyIntentPattern = /^[A-Za-z0-9][A-Za-z0-9._:-]{11,159}$/;
 const laneRunMutationLockStaleMs = 5 * 60 * 1000;
+const laneRunMutationLockOwnerFilename = "owner.json";
+const windowsReservedFilenameStems = new Set([
+  "con",
+  "prn",
+  "aux",
+  "nul",
+  "clock$",
+  "com1",
+  "com2",
+  "com3",
+  "com4",
+  "com5",
+  "com6",
+  "com7",
+  "com8",
+  "com9",
+  "lpt1",
+  "lpt2",
+  "lpt3",
+  "lpt4",
+  "lpt5",
+  "lpt6",
+  "lpt7",
+  "lpt8",
+  "lpt9",
+]);
 const isoDateTimePattern =
   /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.\d+)?(Z|[+-]\d{2}:\d{2})$/;
 const laneRunStatuses = new Set<unknown>([
@@ -883,6 +917,12 @@ async function acquireLaneRunMutationLock(
 ): Promise<() => Promise<void>> {
   const lockPath = resolveLaneRunMutationLockPath(stateRoot, stableWorkItemId);
   const lockRoot = path.dirname(lockPath);
+  const owner: LaneRunMutationLockOwner = {
+    schemaVersion: "ensen.lane-run-mutation-lock-owner.v1",
+    token: randomUUID(),
+    pid: process.pid,
+    acquiredAt: new Date().toISOString(),
+  };
 
   await mkdir(lockRoot, { recursive: true });
   const realRoot = await resolveCanonicalStateRoot(stateRoot);
@@ -892,16 +932,18 @@ async function acquireLaneRunMutationLock(
     try {
       await mkdir(lockPath, { mode: 0o700 });
       await assertExistingPathSafe(realRoot, lockPath, "directory");
+      await writeLaneRunMutationLockOwner(realRoot, lockPath, owner);
 
       return async () => {
-        await rm(lockPath, { recursive: true, force: true });
+        await releaseLaneRunMutationLock(lockPath, owner.token);
       };
     } catch (error) {
       if (!isNodeError(error) || error.code !== "EEXIST") {
+        await rm(lockPath, { recursive: true, force: true });
         throw error;
       }
 
-      const recoveredStaleLock = await recoverStaleLaneRunMutationLock(lockPath);
+      const recoveredStaleLock = await recoverStaleLaneRunMutationLock(realRoot, lockPath);
 
       if (recoveredStaleLock) {
         continue;
@@ -924,7 +966,7 @@ async function assertNoActiveLaneRunLockForEnqueue(stateRoot: string, stableWork
   }
 }
 
-async function recoverStaleLaneRunMutationLock(lockPath: string): Promise<boolean> {
+async function recoverStaleLaneRunMutationLock(realRoot: string, lockPath: string): Promise<boolean> {
   let lockStats: Stats;
 
   try {
@@ -945,6 +987,12 @@ async function recoverStaleLaneRunMutationLock(lockPath: string): Promise<boolea
     return false;
   }
 
+  const owner = await readOptionalLaneRunMutationLockOwner(realRoot, lockPath);
+
+  if (owner && isProcessAlive(owner.pid)) {
+    return false;
+  }
+
   try {
     await rm(lockPath, { recursive: true });
   } catch (error) {
@@ -956,6 +1004,74 @@ async function recoverStaleLaneRunMutationLock(lockPath: string): Promise<boolea
   }
 
   return true;
+}
+
+async function writeLaneRunMutationLockOwner(
+  realRoot: string,
+  lockPath: string,
+  owner: LaneRunMutationLockOwner,
+): Promise<void> {
+  const ownerPath = path.join(lockPath, laneRunMutationLockOwnerFilename);
+  const ownerFile = await open(
+    ownerPath,
+    constants.O_WRONLY | constants.O_CREAT | constants.O_EXCL | noFollowFlag() | nonBlockingFlag(),
+    0o600,
+  );
+
+  try {
+    await assertOpenedGenericStateFileSafeForAccess(realRoot, ownerPath, ownerFile);
+    await ownerFile.writeFile(`${JSON.stringify(owner, null, 2)}\n`, "utf8");
+  } finally {
+    await ownerFile.close();
+  }
+}
+
+async function readOptionalLaneRunMutationLockOwner(
+  realRoot: string,
+  lockPath: string,
+): Promise<LaneRunMutationLockOwner | undefined> {
+  const ownerPath = path.join(lockPath, laneRunMutationLockOwnerFilename);
+
+  let contents: string;
+  let file: FileHandle;
+
+  try {
+    file = await open(ownerPath, constants.O_RDONLY | noFollowFlag() | nonBlockingFlag());
+  } catch (error) {
+    if (isNodeError(error) && error.code === "ENOENT") {
+      return undefined;
+    }
+
+    throw error;
+  }
+
+  try {
+    await assertOpenedGenericStateFileSafeForAccess(realRoot, ownerPath, file);
+    contents = await file.readFile("utf8");
+  } finally {
+    await file.close();
+  }
+
+  return parseLaneRunMutationLockOwner(JSON.parse(contents) as unknown);
+}
+
+async function releaseLaneRunMutationLock(lockPath: string, token: string): Promise<void> {
+  const realRoot = await resolveCanonicalStateRoot(path.dirname(path.dirname(lockPath)));
+  const owner = await readOptionalLaneRunMutationLockOwner(realRoot, lockPath);
+
+  if (!owner || owner.token !== token) {
+    return;
+  }
+
+  try {
+    await rm(lockPath, { recursive: true });
+  } catch (error) {
+    if (isNodeError(error) && error.code === "ENOENT") {
+      return;
+    }
+
+    throw error;
+  }
 }
 
 function resolveLaneRunMutationLockPath(stateRoot: string, stableWorkItemId: string): string {
@@ -1030,18 +1146,36 @@ async function writeJsonStateFile(
   await mkdir(path.dirname(statePath), { recursive: true });
   await assertGenericStatePathSafeForWrite(stateRoot, statePath);
 
+  const stateDirectory = path.dirname(statePath);
+  const temporaryPath = path.join(stateDirectory, `.${path.basename(statePath)}.${process.pid}.${randomUUID()}.tmp`);
   const file = await open(
-    statePath,
-    constants.O_RDWR | constants.O_CREAT | noFollowFlag() | nonBlockingFlag(),
+    temporaryPath,
+    constants.O_WRONLY | constants.O_CREAT | constants.O_EXCL | noFollowFlag() | nonBlockingFlag(),
     0o600,
   );
+  let writeError: unknown;
 
   try {
-    await assertOpenedGenericStateFileSafeForAccess(realRoot, statePath, file);
-    await file.truncate(0);
+    await assertOpenedGenericStateFileSafeForAccess(realRoot, temporaryPath, file);
     await file.writeFile(`${JSON.stringify(value, null, 2)}\n`, "utf8");
+    await file.sync();
+  } catch (error) {
+    writeError = error;
   } finally {
     await file.close();
+  }
+
+  if (writeError) {
+    await rm(temporaryPath, { force: true });
+    throw writeError;
+  }
+
+  try {
+    await assertGenericStatePathSafeForWrite(stateRoot, statePath);
+    await rename(temporaryPath, statePath);
+  } catch (error) {
+    await rm(temporaryPath, { force: true });
+    throw error;
   }
 }
 
@@ -1092,8 +1226,35 @@ async function assertOpenedGenericStateFileSafeForAccess(
 }
 
 function assertSafeStableWorkItemId(stableWorkItemId: string): void {
+  if (!isSafeStableWorkItemId(stableWorkItemId)) {
+    throw new Error(
+      "Stable work item identifiers may only contain lowercase letters, numbers, dots, underscores, and hyphens, and must not use reserved filenames.",
+    );
+  }
+}
+
+function isSafeStableWorkItemId(stableWorkItemId: string): boolean {
   if (!stableWorkItemIdPattern.test(stableWorkItemId)) {
-    throw new Error("Stable work item identifiers may only contain letters, numbers, dots, underscores, and hyphens.");
+    return false;
+  }
+
+  return !windowsReservedFilenameStems.has(stableWorkItemId.split(".")[0]);
+}
+
+function isProcessAlive(pid: number): boolean {
+  if (!Number.isSafeInteger(pid) || pid <= 0) {
+    return false;
+  }
+
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    if (isNodeError(error) && error.code === "ESRCH") {
+      return false;
+    }
+
+    return true;
   }
 }
 
@@ -1885,7 +2046,7 @@ function parseLaneRunQueueRecord(value: unknown): LaneRunQueueRecord {
     ]) ||
     value.schemaVersion !== "ensen.lane-run-queue.v1" ||
     !isNonEmptyString(value.id) ||
-    !stableWorkItemIdPattern.test(String(value.stableWorkItemId)) ||
+    !isSafeStableWorkItemId(String(value.stableWorkItemId)) ||
     !isNonEmptyString(value.workItemId) ||
     !isNonEmptyString(value.source) ||
     !laneIdPattern.test(String(value.laneId)) ||
@@ -1955,7 +2116,7 @@ function parseLaneRunLock(value: unknown): LaneRunLock {
     value.startsAgentExecution !== false ||
     !hasExactKeys(value, expectedKeys) ||
     value.schemaVersion !== "ensen.lane-run-lock.v1" ||
-    !stableWorkItemIdPattern.test(String(value.stableWorkItemId)) ||
+    !isSafeStableWorkItemId(String(value.stableWorkItemId)) ||
     !isNonEmptyString(value.queueRecordId) ||
     !isLaneRunId(value.laneRunId) ||
     !laneIdPattern.test(String(value.laneId)) ||
@@ -1981,6 +2142,21 @@ function parseLaneRunLock(value: unknown): LaneRunLock {
   }
 
   return lock;
+}
+
+function parseLaneRunMutationLockOwner(value: unknown): LaneRunMutationLockOwner {
+  if (
+    !isRecord(value) ||
+    !hasExactKeys(value, ["schemaVersion", "token", "pid", "acquiredAt"]) ||
+    value.schemaVersion !== "ensen.lane-run-mutation-lock-owner.v1" ||
+    !isNonEmptyString(value.token) ||
+    !Number.isSafeInteger(value.pid) ||
+    !isIsoDateTime(value.acquiredAt)
+  ) {
+    throw new Error("Lane run mutation lock owner is malformed.");
+  }
+
+  return value as unknown as LaneRunMutationLockOwner;
 }
 
 function toSerializableLaneRunQueueRecord(record: LaneRunQueueRecord): LaneRunQueueRecord {
@@ -2084,7 +2260,7 @@ function isLaneRunQueueDiagnostics(value: unknown): value is LaneRunQueueDiagnos
       "repositoryClassification",
       "status",
     ]) &&
-    stableWorkItemIdPattern.test(String(value.stableWorkItemId)) &&
+    isSafeStableWorkItemId(String(value.stableWorkItemId)) &&
     laneIdPattern.test(String(value.laneId)) &&
     isNonEmptyString(value.source) &&
     isLaneRepositoryClassification(value.repositoryClassification) &&

--- a/src/lane/index.ts
+++ b/src/lane/index.ts
@@ -277,11 +277,12 @@ export const preparedLocalLaneMarkerSchemaVersion = "ensen.local-lane-prepared.v
 
 const laneRunIdPattern = /^[A-Za-z0-9][A-Za-z0-9._-]*$/;
 const localLaneDirectoryNamePattern = /^[A-Za-z0-9._-]{1,128}$/;
-const stableWorkItemIdPattern = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,159}$/;
+const stableWorkItemIdPattern = /^[A-Za-z0-9][A-Za-z0-9._-]{0,159}$/;
 const laneIdPattern = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/;
 const branchNamePattern = /^[A-Za-z0-9][A-Za-z0-9._/-]{0,159}$/;
 const repositorySlugPattern = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
 const idempotencyIntentPattern = /^[A-Za-z0-9][A-Za-z0-9._:-]{11,159}$/;
+const laneRunMutationLockStaleMs = 5 * 60 * 1000;
 const isoDateTimePattern =
   /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.\d+)?(Z|[+-]\d{2}:\d{2})$/;
 const laneRunStatuses = new Set<unknown>([
@@ -708,6 +709,14 @@ export async function enqueueLaneRun(
   });
 
   await withLaneRunMutationLock(stateRoot, input.stableWorkItemId, async () => {
+    const existingLock = await readOptionalLaneRunLock(stateRoot, input.stableWorkItemId);
+
+    if (existingLock?.active === true) {
+      throw new Error(
+        `Cannot enqueue lane run while stable work item is already claimed by active lane run ${existingLock.laneRunId}.`,
+      );
+    }
+
     await writeLaneRunQueueRecord(stateRoot, record);
   });
 
@@ -899,11 +908,49 @@ async function acquireLaneRunMutationLock(
         throw error;
       }
 
+      if (await recoverStaleLaneRunMutationLock(lockPath)) {
+        continue;
+      }
+
       await delay(20);
     }
   }
 
   throw new Error("Lane run queue record is currently being modified; retry the lane run mutation.");
+}
+
+async function recoverStaleLaneRunMutationLock(lockPath: string): Promise<boolean> {
+  let lockStats: Stats;
+
+  try {
+    lockStats = await lstat(lockPath);
+  } catch (error) {
+    if (isNodeError(error) && error.code === "ENOENT") {
+      return true;
+    }
+
+    throw error;
+  }
+
+  if (!lockStats.isDirectory()) {
+    throw new Error("Lane run mutation lock path is malformed.");
+  }
+
+  if (Date.now() - lockStats.mtimeMs < laneRunMutationLockStaleMs) {
+    return false;
+  }
+
+  try {
+    await rm(lockPath, { recursive: true });
+  } catch (error) {
+    if (isNodeError(error) && error.code === "ENOENT") {
+      return true;
+    }
+
+    throw error;
+  }
+
+  return true;
 }
 
 function resolveLaneRunMutationLockPath(stateRoot: string, stableWorkItemId: string): string {
@@ -1041,7 +1088,7 @@ async function assertOpenedGenericStateFileSafeForAccess(
 
 function assertSafeStableWorkItemId(stableWorkItemId: string): void {
   if (!stableWorkItemIdPattern.test(stableWorkItemId)) {
-    throw new Error("Stable work item identifiers may only contain letters, numbers, dots, underscores, colons, and hyphens.");
+    throw new Error("Stable work item identifiers may only contain letters, numbers, dots, underscores, and hyphens.");
   }
 }
 

--- a/src/lane/index.ts
+++ b/src/lane/index.ts
@@ -90,7 +90,96 @@ export interface PreparedLocalLaneWorkspace {
 
 export type BranchLaneRunSkeletonMode = "dry-run" | "prepare";
 export type LaneRepositoryClassification = "owner-controlled-dogfood" | "customer-repository";
+export type LaneRunQueueStatus = "queued" | "completed" | "revoked" | "superseded";
+export type LaneRunLockStatus = "active" | "completed" | "revoked" | "superseded";
 const CUSTOMER_REPOSITORY_PLACEHOLDER = "<customer-repository>";
+
+export interface LaneRunQueueDiagnostics {
+  readonly stableWorkItemId: string;
+  readonly laneId: string;
+  readonly source: string;
+  readonly repositoryClassification: LaneRepositoryClassification;
+  readonly status: LaneRunQueueStatus;
+}
+
+export interface LaneRunLockDiagnostics {
+  readonly stableWorkItemId: string;
+  readonly laneId: string;
+  readonly source: string;
+  readonly repositoryClassification: LaneRepositoryClassification;
+  readonly lockStatus: LaneRunLockStatus;
+  readonly laneRunId: string;
+  readonly reason: string;
+}
+
+export interface LaneRunQueueRecord {
+  readonly schemaVersion: "ensen.lane-run-queue.v1";
+  readonly id: string;
+  readonly stableWorkItemId: string;
+  readonly workItemId: WorkItem["id"];
+  readonly source: string;
+  readonly laneId: string;
+  readonly repositoryClassification: LaneRepositoryClassification;
+  readonly status: LaneRunQueueStatus;
+  readonly queuedAt: string;
+  readonly updatedAt: string;
+  readonly startsAgentExecution: false;
+  readonly metadata: Record<string, string>;
+  readonly publicDiagnostics: LaneRunQueueDiagnostics;
+}
+
+export interface LaneRunLock {
+  readonly schemaVersion: "ensen.lane-run-lock.v1";
+  readonly stableWorkItemId: string;
+  readonly queueRecordId: string;
+  readonly laneRunId: string;
+  readonly laneId: string;
+  readonly source: string;
+  readonly repositoryClassification: LaneRepositoryClassification;
+  readonly status: LaneRunLockStatus;
+  readonly active: boolean;
+  readonly claimedAt: string;
+  readonly claimedBy: string;
+  readonly releasedAt?: string;
+  readonly startsAgentExecution: false;
+}
+
+export interface EnqueueLaneRunInput {
+  readonly stableWorkItemId: string;
+  readonly workItemId: WorkItem["id"];
+  readonly source: string;
+  readonly laneId: string;
+  readonly repositoryClassification: LaneRepositoryClassification;
+  readonly queuedAt: string;
+  readonly metadata?: Record<string, string>;
+}
+
+export interface ClaimQueuedLaneRunInput {
+  readonly stableWorkItemId: string;
+  readonly laneRunId: string;
+  readonly claimedBy: string;
+  readonly claimedAt: string;
+}
+
+export interface CompleteLaneRunLockInput {
+  readonly stableWorkItemId: string;
+  readonly laneRunId: string;
+  readonly completedAt: string;
+  readonly terminalStatus: Exclude<LaneRunLockStatus, "active">;
+}
+
+export type ClaimQueuedLaneRunResult =
+  | {
+      readonly ok: true;
+      readonly lock: LaneRunLock;
+      readonly publicDiagnostics: LaneRunLockDiagnostics;
+    }
+  | {
+      readonly ok: false;
+      readonly reason: string;
+      readonly lock: LaneRunLock;
+      readonly publicDiagnostics: LaneRunLockDiagnostics;
+    };
 
 export interface AuthoritativeLaneRunScope {
   readonly repositoryClassification?: LaneRepositoryClassification;
@@ -187,6 +276,8 @@ export const preparedLocalLaneMarkerSchemaVersion = "ensen.local-lane-prepared.v
 
 const laneRunIdPattern = /^[A-Za-z0-9][A-Za-z0-9._-]*$/;
 const localLaneDirectoryNamePattern = /^[A-Za-z0-9._-]{1,128}$/;
+const stableWorkItemIdPattern = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,159}$/;
+const laneIdPattern = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/;
 const branchNamePattern = /^[A-Za-z0-9][A-Za-z0-9._/-]{0,159}$/;
 const repositorySlugPattern = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
 const idempotencyIntentPattern = /^[A-Za-z0-9][A-Za-z0-9._:-]{11,159}$/;
@@ -201,6 +292,8 @@ const laneRunStatuses = new Set<unknown>([
   "completed",
   "failed",
 ]);
+const laneRunQueueStatuses = new Set<unknown>(["queued", "completed", "revoked", "superseded"]);
+const laneRunLockStatuses = new Set<unknown>(["active", "completed", "revoked", "superseded"]);
 
 export function createLaneJournal(input: CreateLaneJournalInput): LaneJournal {
   return {
@@ -552,6 +645,342 @@ export async function readLaneRunState(stateRoot: string, laneRunId: string): Pr
   }
 
   return state;
+}
+
+export function resolveLaneRunQueueRecordPath(stateRoot: string, stableWorkItemId: string): string {
+  assertSafeStableWorkItemId(stableWorkItemId);
+
+  const resolvedRoot = path.resolve(stateRoot);
+  const queueRoot = path.join(resolvedRoot, "lane-run-queue");
+  const queuePath = path.join(queueRoot, `${stableWorkItemId}.json`);
+  const relativePath = path.relative(resolvedRoot, queuePath);
+
+  if (relativePath.startsWith("..") || path.isAbsolute(relativePath)) {
+    throw new Error("Lane run queue paths must stay inside the configured state root.");
+  }
+
+  return queuePath;
+}
+
+export function resolveLaneRunLockPath(stateRoot: string, stableWorkItemId: string): string {
+  assertSafeStableWorkItemId(stableWorkItemId);
+
+  const resolvedRoot = path.resolve(stateRoot);
+  const lockRoot = path.join(resolvedRoot, "lane-run-locks");
+  const lockPath = path.join(lockRoot, `${stableWorkItemId}.json`);
+  const relativePath = path.relative(resolvedRoot, lockPath);
+
+  if (relativePath.startsWith("..") || path.isAbsolute(relativePath)) {
+    throw new Error("Lane run lock paths must stay inside the configured state root.");
+  }
+
+  return lockPath;
+}
+
+export async function enqueueLaneRun(
+  stateRoot: string,
+  input: EnqueueLaneRunInput,
+): Promise<LaneRunQueueRecord> {
+  assertSafeStableWorkItemId(input.stableWorkItemId);
+  assertSafeLaneQueueMetadata(input);
+
+  const record = toSerializableLaneRunQueueRecord({
+    schemaVersion: "ensen.lane-run-queue.v1",
+    id: `queue-${input.stableWorkItemId}`,
+    stableWorkItemId: input.stableWorkItemId,
+    workItemId: input.workItemId,
+    source: input.source,
+    laneId: input.laneId,
+    repositoryClassification: input.repositoryClassification,
+    status: "queued",
+    queuedAt: input.queuedAt,
+    updatedAt: input.queuedAt,
+    startsAgentExecution: false,
+    metadata: input.metadata ?? {},
+    publicDiagnostics: {
+      stableWorkItemId: input.stableWorkItemId,
+      laneId: input.laneId,
+      source: input.source,
+      repositoryClassification: input.repositoryClassification,
+      status: "queued",
+    },
+  });
+
+  await writeLaneRunQueueRecord(stateRoot, record);
+
+  return record;
+}
+
+export async function readLaneRunQueueRecord(
+  stateRoot: string,
+  stableWorkItemId: string,
+): Promise<LaneRunQueueRecord> {
+  const queuePath = resolveLaneRunQueueRecordPath(stateRoot, stableWorkItemId);
+  const parsed = await readJsonStateFile(stateRoot, queuePath);
+  const record = parseLaneRunQueueRecord(parsed);
+
+  if (record.stableWorkItemId !== stableWorkItemId) {
+    throw new Error("Lane run queue record identifiers do not match the requested work item.");
+  }
+
+  return record;
+}
+
+export async function claimQueuedLaneRun(
+  stateRoot: string,
+  input: ClaimQueuedLaneRunInput,
+): Promise<ClaimQueuedLaneRunResult> {
+  assertSafeStableWorkItemId(input.stableWorkItemId);
+
+  if (!isLaneRunId(input.laneRunId) || !isNonEmptyString(input.claimedBy) || !isIsoDateTime(input.claimedAt)) {
+    throw new Error("Lane run claim input is malformed.");
+  }
+
+  const queueRecord = await readLaneRunQueueRecord(stateRoot, input.stableWorkItemId);
+
+  if (queueRecord.status !== "queued") {
+    throw new Error(`Lane run queue record is not claimable: ${queueRecord.status}.`);
+  }
+
+  const existingLock = await readOptionalLaneRunLock(stateRoot, input.stableWorkItemId);
+
+  if (existingLock?.active === true) {
+    const reason = `already claimed by active lane run ${existingLock.laneRunId}`;
+
+    return {
+      ok: false,
+      reason,
+      lock: existingLock,
+      publicDiagnostics: createLaneRunLockDiagnostics(existingLock, reason),
+    };
+  }
+
+  const lock = toSerializableLaneRunLock({
+    schemaVersion: "ensen.lane-run-lock.v1",
+    stableWorkItemId: queueRecord.stableWorkItemId,
+    queueRecordId: queueRecord.id,
+    laneRunId: input.laneRunId,
+    laneId: queueRecord.laneId,
+    source: queueRecord.source,
+    repositoryClassification: queueRecord.repositoryClassification,
+    status: "active",
+    active: true,
+    claimedAt: input.claimedAt,
+    claimedBy: input.claimedBy,
+    startsAgentExecution: false,
+  });
+
+  await writeLaneRunLock(stateRoot, lock);
+
+  return {
+    ok: true,
+    lock,
+    publicDiagnostics: createLaneRunLockDiagnostics(lock, "claimed"),
+  };
+}
+
+export async function readLaneRunLock(stateRoot: string, stableWorkItemId: string): Promise<LaneRunLock> {
+  const lockPath = resolveLaneRunLockPath(stateRoot, stableWorkItemId);
+  const parsed = await readJsonStateFile(stateRoot, lockPath);
+  const lock = parseLaneRunLock(parsed);
+
+  if (lock.stableWorkItemId !== stableWorkItemId) {
+    throw new Error("Lane run lock identifiers do not match the requested work item.");
+  }
+
+  return lock;
+}
+
+export async function completeLaneRunLock(
+  stateRoot: string,
+  input: CompleteLaneRunLockInput,
+): Promise<LaneRunLock> {
+  assertSafeStableWorkItemId(input.stableWorkItemId);
+
+  if (
+    !isLaneRunId(input.laneRunId) ||
+    !isIsoDateTime(input.completedAt) ||
+    !laneRunLockStatuses.has(input.terminalStatus)
+  ) {
+    throw new Error("Lane run lock completion input is malformed.");
+  }
+
+  const existingLock = await readLaneRunLock(stateRoot, input.stableWorkItemId);
+
+  if (existingLock.laneRunId !== input.laneRunId) {
+    throw new Error("Lane run lock completion does not match the active lane run.");
+  }
+
+  const completedLock = toSerializableLaneRunLock({
+    ...existingLock,
+    status: input.terminalStatus,
+    active: false,
+    releasedAt: input.completedAt,
+  });
+
+  await writeLaneRunLock(stateRoot, completedLock);
+
+  const queueRecord = await readLaneRunQueueRecord(stateRoot, input.stableWorkItemId);
+  await writeLaneRunQueueRecord(stateRoot, {
+    ...queueRecord,
+    status: input.terminalStatus,
+    updatedAt: input.completedAt,
+    publicDiagnostics: {
+      ...queueRecord.publicDiagnostics,
+      status: input.terminalStatus,
+    },
+  });
+
+  return completedLock;
+}
+
+async function readOptionalLaneRunLock(
+  stateRoot: string,
+  stableWorkItemId: string,
+): Promise<LaneRunLock | undefined> {
+  try {
+    return await readLaneRunLock(stateRoot, stableWorkItemId);
+  } catch (error) {
+    if (isNodeError(error) && error.code === "ENOENT") {
+      return undefined;
+    }
+
+    throw error;
+  }
+}
+
+async function writeLaneRunQueueRecord(stateRoot: string, record: LaneRunQueueRecord): Promise<string> {
+  const validatedRecord = parseLaneRunQueueRecord(record);
+  const queuePath = resolveLaneRunQueueRecordPath(stateRoot, validatedRecord.stableWorkItemId);
+
+  await writeJsonStateFile(stateRoot, queuePath, toSerializableLaneRunQueueRecord(validatedRecord));
+
+  return queuePath;
+}
+
+async function writeLaneRunLock(stateRoot: string, lock: LaneRunLock): Promise<string> {
+  const validatedLock = parseLaneRunLock(lock);
+  const lockPath = resolveLaneRunLockPath(stateRoot, validatedLock.stableWorkItemId);
+
+  await writeJsonStateFile(stateRoot, lockPath, toSerializableLaneRunLock(validatedLock));
+
+  return lockPath;
+}
+
+async function readJsonStateFile(stateRoot: string, statePath: string): Promise<unknown> {
+  const realRoot = await assertGenericStatePathSafeForRead(stateRoot, statePath);
+  const file = await open(statePath, constants.O_RDONLY | noFollowFlag() | nonBlockingFlag());
+  let contents: string;
+
+  try {
+    await assertOpenedGenericStateFileSafeForAccess(realRoot, statePath, file);
+    contents = await file.readFile("utf8");
+  } finally {
+    await file.close();
+  }
+
+  return JSON.parse(contents) as unknown;
+}
+
+async function writeJsonStateFile(
+  stateRoot: string,
+  statePath: string,
+  value: unknown,
+): Promise<void> {
+  const realRoot = await assertGenericStatePathSafeForWrite(stateRoot, statePath);
+  await mkdir(path.dirname(statePath), { recursive: true });
+  await assertGenericStatePathSafeForWrite(stateRoot, statePath);
+
+  const file = await open(
+    statePath,
+    constants.O_RDWR | constants.O_CREAT | noFollowFlag() | nonBlockingFlag(),
+    0o600,
+  );
+
+  try {
+    await assertOpenedGenericStateFileSafeForAccess(realRoot, statePath, file);
+    await file.truncate(0);
+    await file.writeFile(`${JSON.stringify(value, null, 2)}\n`, "utf8");
+  } finally {
+    await file.close();
+  }
+}
+
+async function assertGenericStatePathSafeForWrite(stateRoot: string, statePath: string): Promise<string> {
+  const realRoot = await resolveCanonicalStateRoot(stateRoot);
+  const stateDirectory = path.dirname(statePath);
+
+  await assertExistingPathSafe(realRoot, stateDirectory, "directory");
+  await assertExistingPathSafe(realRoot, statePath, "file");
+
+  return realRoot;
+}
+
+async function assertGenericStatePathSafeForRead(stateRoot: string, statePath: string): Promise<string> {
+  const realRoot = await resolveCanonicalStateRoot(stateRoot);
+  const stateDirectory = path.dirname(statePath);
+
+  await assertExistingPathSafe(realRoot, stateDirectory, "directory");
+  await assertExistingPathSafe(realRoot, statePath, "file");
+
+  return realRoot;
+}
+
+async function assertOpenedGenericStateFileSafeForAccess(
+  realRoot: string,
+  statePath: string,
+  file: FileHandle,
+): Promise<void> {
+  const openedStats = await file.stat();
+
+  if (!openedStats.isFile()) {
+    throw new Error("Lane run durable state file path must be a regular file.");
+  }
+
+  const pathStats = await lstat(statePath).catch((error: unknown) => {
+    if (isNodeError(error) && error.code === "ENOENT") {
+      throw new Error("Lane run durable state file changed during access.");
+    }
+
+    throw error;
+  });
+
+  if (!sameFileStats(openedStats, pathStats)) {
+    throw new Error("Lane run durable state file changed during access.");
+  }
+
+  await assertExistingPathSafe(realRoot, statePath, "file");
+}
+
+function assertSafeStableWorkItemId(stableWorkItemId: string): void {
+  if (!stableWorkItemIdPattern.test(stableWorkItemId)) {
+    throw new Error("Stable work item identifiers may only contain letters, numbers, dots, underscores, colons, and hyphens.");
+  }
+}
+
+function assertSafeLaneQueueMetadata(input: EnqueueLaneRunInput): void {
+  if (
+    !isNonEmptyString(input.workItemId) ||
+    !isNonEmptyString(input.source) ||
+    !laneIdPattern.test(input.laneId) ||
+    !isLaneRepositoryClassification(input.repositoryClassification) ||
+    !isIsoDateTime(input.queuedAt) ||
+    !isStringMetadata(input.metadata ?? {})
+  ) {
+    throw new Error("Lane run queue input is malformed.");
+  }
+}
+
+function createLaneRunLockDiagnostics(lock: LaneRunLock, reason: string): LaneRunLockDiagnostics {
+  return {
+    stableWorkItemId: lock.stableWorkItemId,
+    laneId: lock.laneId,
+    source: lock.source,
+    repositoryClassification: lock.repositoryClassification,
+    lockStatus: lock.status,
+    laneRunId: lock.laneRunId,
+    reason,
+  };
 }
 
 function validateLaneRunStateForWrite(state: LaneRunState): LaneRunState {
@@ -1293,6 +1722,174 @@ function parseLaneRunState(value: unknown): LaneRunState {
   return value as unknown as LaneRunState;
 }
 
+function parseLaneRunQueueRecord(value: unknown): LaneRunQueueRecord {
+  if (!isRecord(value)) {
+    throw new Error("Lane run queue record must be a JSON object.");
+  }
+
+  if (
+    value.startsAgentExecution !== false ||
+    !hasExactKeys(value, [
+      "schemaVersion",
+      "id",
+      "stableWorkItemId",
+      "workItemId",
+      "source",
+      "laneId",
+      "repositoryClassification",
+      "status",
+      "queuedAt",
+      "updatedAt",
+      "startsAgentExecution",
+      "metadata",
+      "publicDiagnostics",
+    ]) ||
+    value.schemaVersion !== "ensen.lane-run-queue.v1" ||
+    !isNonEmptyString(value.id) ||
+    !stableWorkItemIdPattern.test(String(value.stableWorkItemId)) ||
+    !isNonEmptyString(value.workItemId) ||
+    !isNonEmptyString(value.source) ||
+    !laneIdPattern.test(String(value.laneId)) ||
+    !isLaneRepositoryClassification(value.repositoryClassification) ||
+    !laneRunQueueStatuses.has(value.status) ||
+    !isIsoDateTime(value.queuedAt) ||
+    !isIsoDateTime(value.updatedAt) ||
+    !isStringMetadata(value.metadata) ||
+    !isLaneRunQueueDiagnostics(value.publicDiagnostics)
+  ) {
+    throw new Error("Lane run queue record is malformed.");
+  }
+
+  const record = value as unknown as LaneRunQueueRecord;
+
+  if (
+    record.publicDiagnostics.stableWorkItemId !== record.stableWorkItemId ||
+    record.publicDiagnostics.laneId !== record.laneId ||
+    record.publicDiagnostics.source !== record.source ||
+    record.publicDiagnostics.repositoryClassification !== record.repositoryClassification ||
+    record.publicDiagnostics.status !== record.status
+  ) {
+    throw new Error("Lane run queue record diagnostics do not match authoritative queue state.");
+  }
+
+  return record;
+}
+
+function parseLaneRunLock(value: unknown): LaneRunLock {
+  if (!isRecord(value)) {
+    throw new Error("Lane run lock must be a JSON object.");
+  }
+
+  const expectedKeys =
+    Object.hasOwn(value, "releasedAt")
+      ? [
+          "schemaVersion",
+          "stableWorkItemId",
+          "queueRecordId",
+          "laneRunId",
+          "laneId",
+          "source",
+          "repositoryClassification",
+          "status",
+          "active",
+          "claimedAt",
+          "claimedBy",
+          "releasedAt",
+          "startsAgentExecution",
+        ]
+      : [
+          "schemaVersion",
+          "stableWorkItemId",
+          "queueRecordId",
+          "laneRunId",
+          "laneId",
+          "source",
+          "repositoryClassification",
+          "status",
+          "active",
+          "claimedAt",
+          "claimedBy",
+          "startsAgentExecution",
+        ];
+
+  if (
+    value.startsAgentExecution !== false ||
+    !hasExactKeys(value, expectedKeys) ||
+    value.schemaVersion !== "ensen.lane-run-lock.v1" ||
+    !stableWorkItemIdPattern.test(String(value.stableWorkItemId)) ||
+    !isNonEmptyString(value.queueRecordId) ||
+    !isLaneRunId(value.laneRunId) ||
+    !laneIdPattern.test(String(value.laneId)) ||
+    !isNonEmptyString(value.source) ||
+    !isLaneRepositoryClassification(value.repositoryClassification) ||
+    !laneRunLockStatuses.has(value.status) ||
+    typeof value.active !== "boolean" ||
+    !isIsoDateTime(value.claimedAt) ||
+    !isNonEmptyString(value.claimedBy) ||
+    (Object.hasOwn(value, "releasedAt") && !isIsoDateTime(value.releasedAt))
+  ) {
+    throw new Error("Lane run lock is malformed.");
+  }
+
+  const lock = value as unknown as LaneRunLock;
+
+  if ((lock.status === "active") !== lock.active || (lock.status !== "active" && lock.releasedAt === undefined)) {
+    throw new Error("Lane run lock is malformed.");
+  }
+
+  return lock;
+}
+
+function toSerializableLaneRunQueueRecord(record: LaneRunQueueRecord): LaneRunQueueRecord {
+  return {
+    schemaVersion: record.schemaVersion,
+    id: record.id,
+    stableWorkItemId: record.stableWorkItemId,
+    workItemId: record.workItemId,
+    source: record.source,
+    laneId: record.laneId,
+    repositoryClassification: record.repositoryClassification,
+    status: record.status,
+    queuedAt: record.queuedAt,
+    updatedAt: record.updatedAt,
+    startsAgentExecution: record.startsAgentExecution,
+    metadata: { ...record.metadata },
+    publicDiagnostics: {
+      stableWorkItemId: record.publicDiagnostics.stableWorkItemId,
+      laneId: record.publicDiagnostics.laneId,
+      source: record.publicDiagnostics.source,
+      repositoryClassification: record.publicDiagnostics.repositoryClassification,
+      status: record.publicDiagnostics.status,
+    },
+  };
+}
+
+function toSerializableLaneRunLock(lock: LaneRunLock): LaneRunLock {
+  const base = {
+    schemaVersion: lock.schemaVersion,
+    stableWorkItemId: lock.stableWorkItemId,
+    queueRecordId: lock.queueRecordId,
+    laneRunId: lock.laneRunId,
+    laneId: lock.laneId,
+    source: lock.source,
+    repositoryClassification: lock.repositoryClassification,
+    status: lock.status,
+    active: lock.active,
+    claimedAt: lock.claimedAt,
+    claimedBy: lock.claimedBy,
+    startsAgentExecution: lock.startsAgentExecution,
+  } satisfies Omit<LaneRunLock, "releasedAt">;
+
+  if (lock.releasedAt === undefined) {
+    return base;
+  }
+
+  return {
+    ...base,
+    releasedAt: lock.releasedAt,
+  };
+}
+
 function isLaneJournal(value: unknown): value is LaneJournal {
   return (
     isRecord(value) &&
@@ -1332,6 +1929,44 @@ function isEvidenceRefs(value: unknown): value is LaneEvidenceRefs {
     Array.isArray(value.bundleRefs) &&
     value.bundleRefs.every(isNonEmptyString)
   );
+}
+
+function isLaneRunQueueDiagnostics(value: unknown): value is LaneRunQueueDiagnostics {
+  return (
+    isRecord(value) &&
+    hasExactKeys(value, [
+      "stableWorkItemId",
+      "laneId",
+      "source",
+      "repositoryClassification",
+      "status",
+    ]) &&
+    stableWorkItemIdPattern.test(String(value.stableWorkItemId)) &&
+    laneIdPattern.test(String(value.laneId)) &&
+    isNonEmptyString(value.source) &&
+    isLaneRepositoryClassification(value.repositoryClassification) &&
+    laneRunQueueStatuses.has(value.status)
+  );
+}
+
+function isLaneRepositoryClassification(value: unknown): value is LaneRepositoryClassification {
+  return value === "owner-controlled-dogfood" || value === "customer-repository";
+}
+
+function isStringMetadata(value: unknown): value is Record<string, string> {
+  if (!isRecord(value)) {
+    return false;
+  }
+
+  return Object.entries(value).every(([key, metadataValue]) => {
+    return (
+      /^[A-Za-z0-9][A-Za-z0-9._:-]{0,63}$/.test(key) &&
+      !/secret|token|password|credential/i.test(key) &&
+      typeof metadataValue === "string" &&
+      metadataValue.length > 0 &&
+      metadataValue.length <= 256
+    );
+  });
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/src/lane/index.ts
+++ b/src/lane/index.ts
@@ -1,7 +1,7 @@
 import { constants } from "node:fs";
 import type { Stats } from "node:fs";
 import { randomUUID } from "node:crypto";
-import { lstat, mkdir, open, realpath, rename, rm } from "node:fs/promises";
+import { lstat, mkdir, open, realpath, rename, rm, utimes } from "node:fs/promises";
 import type { FileHandle } from "node:fs/promises";
 import path from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
@@ -291,6 +291,7 @@ const branchNamePattern = /^[A-Za-z0-9][A-Za-z0-9._/-]{0,159}$/;
 const repositorySlugPattern = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
 const idempotencyIntentPattern = /^[A-Za-z0-9][A-Za-z0-9._:-]{11,159}$/;
 const laneRunMutationLockStaleMs = 5 * 60 * 1000;
+const laneRunMutationLockHeartbeatMs = 60 * 1000;
 const laneRunMutationLockOwnerFilename = "owner.json";
 const windowsReservedFilenameStems = new Set([
   "con",
@@ -743,6 +744,7 @@ export async function enqueueLaneRun(
   });
 
   await withLaneRunMutationLock(stateRoot, input.stableWorkItemId, async () => {
+    // Keep rediscovery from overwriting queue state while the same work item is actively claimed.
     await assertNoActiveLaneRunLockForEnqueue(stateRoot, input.stableWorkItemId);
     await writeLaneRunQueueRecord(stateRoot, record);
   });
@@ -933,8 +935,10 @@ async function acquireLaneRunMutationLock(
       await mkdir(lockPath, { mode: 0o700 });
       await assertExistingPathSafe(realRoot, lockPath, "directory");
       await writeLaneRunMutationLockOwner(realRoot, lockPath, owner);
+      const stopHeartbeat = startLaneRunMutationLockHeartbeat(lockPath);
 
       return async () => {
+        stopHeartbeat();
         await releaseLaneRunMutationLock(lockPath, owner.token);
       };
     } catch (error) {
@@ -954,6 +958,32 @@ async function acquireLaneRunMutationLock(
   }
 
   throw new Error("Lane run queue record is currently being modified; retry the lane run mutation.");
+}
+
+function startLaneRunMutationLockHeartbeat(lockPath: string): () => void {
+  const heartbeat = setInterval(() => {
+    void refreshLaneRunMutationLockHeartbeat(lockPath).catch(() => undefined);
+  }, laneRunMutationLockHeartbeatMs);
+
+  heartbeat.unref();
+
+  return () => {
+    clearInterval(heartbeat);
+  };
+}
+
+async function refreshLaneRunMutationLockHeartbeat(lockPath: string): Promise<void> {
+  const heartbeatAt = new Date();
+
+  try {
+    await utimes(lockPath, heartbeatAt, heartbeatAt);
+  } catch (error) {
+    if (isNodeError(error) && error.code === "ENOENT") {
+      return;
+    }
+
+    throw error;
+  }
 }
 
 async function assertNoActiveLaneRunLockForEnqueue(stateRoot: string, stableWorkItemId: string): Promise<void> {
@@ -987,6 +1017,7 @@ async function recoverStaleLaneRunMutationLock(realRoot: string, lockPath: strin
     return false;
   }
 
+  // A stale timestamp alone is not enough to reclaim a lock; live owners remain authoritative.
   const owner = await readOptionalLaneRunMutationLockOwner(realRoot, lockPath);
 
   if (owner && isProcessAlive(owner.pid)) {

--- a/src/lane/index.ts
+++ b/src/lane/index.ts
@@ -1,7 +1,7 @@
 import { constants } from "node:fs";
 import type { Stats } from "node:fs";
 import { randomUUID } from "node:crypto";
-import { lstat, mkdir, open, realpath, rename, rm, utimes } from "node:fs/promises";
+import { lstat, mkdir, open, realpath, rename, rm, rmdir, utimes } from "node:fs/promises";
 import type { FileHandle } from "node:fs/promises";
 import path from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
@@ -292,7 +292,7 @@ const repositorySlugPattern = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
 const idempotencyIntentPattern = /^[A-Za-z0-9][A-Za-z0-9._:-]{11,159}$/;
 const laneRunMutationLockStaleMs = 5 * 60 * 1000;
 const laneRunMutationLockHeartbeatMs = 60 * 1000;
-const laneRunMutationLockOwnerFilename = "owner.json";
+const laneRunMutationLockOwnerTokenPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 const windowsReservedFilenameStems = new Set([
   "con",
   "prn",
@@ -940,11 +940,12 @@ async function acquireLaneRunMutationLock(
       await mkdir(lockPath, { mode: 0o700 });
       await assertExistingPathSafe(realRoot, lockPath, "directory");
       await writeLaneRunMutationLockOwner(realRoot, lockPath, owner);
+      const lockStats = await lstat(lockPath);
       const stopHeartbeat = startLaneRunMutationLockHeartbeat(lockPath);
 
       return async () => {
         stopHeartbeat();
-        await releaseLaneRunMutationLock(lockPath, owner.token);
+        await releaseLaneRunMutationLock(lockPath, owner.token, lockStats);
       };
     } catch (error) {
       if (!isNodeError(error) || error.code !== "EEXIST") {
@@ -1043,7 +1044,7 @@ async function writeLaneRunMutationLockOwner(
   lockPath: string,
   owner: LaneRunMutationLockOwner,
 ): Promise<void> {
-  const ownerPath = path.join(lockPath, laneRunMutationLockOwnerFilename);
+  const ownerPath = path.join(lockPath, laneRunMutationLockOwnerFilename(owner.token));
   const ownerFile = await open(
     ownerPath,
     constants.O_WRONLY | constants.O_CREAT | constants.O_EXCL | noFollowFlag() | nonBlockingFlag(),
@@ -1061,8 +1062,9 @@ async function writeLaneRunMutationLockOwner(
 async function readOptionalLaneRunMutationLockOwner(
   realRoot: string,
   lockPath: string,
+  token: string,
 ): Promise<LaneRunMutationLockOwner | undefined> {
-  const ownerPath = path.join(lockPath, laneRunMutationLockOwnerFilename);
+  const ownerPath = path.join(lockPath, laneRunMutationLockOwnerFilename(token));
 
   let contents: string;
   let file: FileHandle;
@@ -1087,18 +1089,58 @@ async function readOptionalLaneRunMutationLockOwner(
   return parseLaneRunMutationLockOwner(JSON.parse(contents) as unknown);
 }
 
-async function releaseLaneRunMutationLock(lockPath: string, token: string): Promise<void> {
+async function releaseLaneRunMutationLock(
+  lockPath: string,
+  token: string,
+  acquiredStats: Stats,
+): Promise<void> {
   const realRoot = await resolveCanonicalStateRoot(path.dirname(path.dirname(lockPath)));
-  const owner = await readOptionalLaneRunMutationLockOwner(realRoot, lockPath);
+  const currentStats = await lstat(lockPath).catch((error: unknown) => {
+    if (isNodeError(error) && error.code === "ENOENT") {
+      return undefined;
+    }
+
+    throw error;
+  });
+
+  if (!currentStats || !currentStats.isDirectory() || !sameFileStats(acquiredStats, currentStats)) {
+    return;
+  }
+
+  const owner = await readOptionalLaneRunMutationLockOwner(realRoot, lockPath, token);
 
   if (!owner || owner.token !== token) {
     return;
   }
 
+  const latestStats = await lstat(lockPath).catch((error: unknown) => {
+    if (isNodeError(error) && error.code === "ENOENT") {
+      return undefined;
+    }
+
+    throw error;
+  });
+
+  if (!latestStats || !latestStats.isDirectory() || !sameFileStats(acquiredStats, latestStats)) {
+    return;
+  }
+
+  const ownerPath = path.join(lockPath, laneRunMutationLockOwnerFilename(token));
+
   try {
-    await rm(lockPath, { recursive: true });
+    await rm(ownerPath);
   } catch (error) {
     if (isNodeError(error) && error.code === "ENOENT") {
+      return;
+    }
+
+    throw error;
+  }
+
+  try {
+    await rmdir(lockPath);
+  } catch (error) {
+    if (isNodeError(error) && (error.code === "ENOENT" || error.code === "ENOTEMPTY")) {
       return;
     }
 
@@ -1119,6 +1161,14 @@ function resolveLaneRunMutationLockPath(stateRoot: string, stableWorkItemId: str
   }
 
   return lockPath;
+}
+
+function laneRunMutationLockOwnerFilename(token: string): string {
+  if (!laneRunMutationLockOwnerTokenPattern.test(token)) {
+    throw new Error("Lane run mutation lock owner token is malformed.");
+  }
+
+  return `owner-${token}.json`;
 }
 
 async function readOptionalLaneRunLock(

--- a/src/lane/index.ts
+++ b/src/lane/index.ts
@@ -709,14 +709,7 @@ export async function enqueueLaneRun(
   });
 
   await withLaneRunMutationLock(stateRoot, input.stableWorkItemId, async () => {
-    const existingLock = await readOptionalLaneRunLock(stateRoot, input.stableWorkItemId);
-
-    if (existingLock?.active === true) {
-      throw new Error(
-        `Cannot enqueue lane run while stable work item is already claimed by active lane run ${existingLock.laneRunId}.`,
-      );
-    }
-
+    await assertNoActiveLaneRunLockForEnqueue(stateRoot, input.stableWorkItemId);
     await writeLaneRunQueueRecord(stateRoot, record);
   });
 
@@ -908,7 +901,9 @@ async function acquireLaneRunMutationLock(
         throw error;
       }
 
-      if (await recoverStaleLaneRunMutationLock(lockPath)) {
+      const recoveredStaleLock = await recoverStaleLaneRunMutationLock(lockPath);
+
+      if (recoveredStaleLock) {
         continue;
       }
 
@@ -917,6 +912,16 @@ async function acquireLaneRunMutationLock(
   }
 
   throw new Error("Lane run queue record is currently being modified; retry the lane run mutation.");
+}
+
+async function assertNoActiveLaneRunLockForEnqueue(stateRoot: string, stableWorkItemId: string): Promise<void> {
+  const existingLock = await readOptionalLaneRunLock(stateRoot, stableWorkItemId);
+
+  if (existingLock?.active === true) {
+    throw new Error(
+      `Cannot enqueue lane run while stable work item is already claimed by active lane run ${existingLock.laneRunId}.`,
+    );
+  }
 }
 
 async function recoverStaleLaneRunMutationLock(lockPath: string): Promise<boolean> {

--- a/src/lane/index.ts
+++ b/src/lane/index.ts
@@ -124,6 +124,7 @@ interface LaneRunMutationLockOwner {
 export interface LaneRunQueueRecord {
   readonly schemaVersion: "ensen.lane-run-queue.v1";
   readonly id: string;
+  readonly enqueueSequence: number;
   readonly stableWorkItemId: string;
   readonly workItemId: WorkItem["id"];
   readonly source: string;
@@ -292,6 +293,7 @@ const repositorySlugPattern = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
 const idempotencyIntentPattern = /^[A-Za-z0-9][A-Za-z0-9._:-]{11,159}$/;
 const laneRunMutationLockStaleMs = 5 * 60 * 1000;
 const laneRunMutationLockHeartbeatMs = 60 * 1000;
+const laneRunMaxCompletionDurationMs = 7 * 24 * 60 * 60 * 1000;
 const laneRunMutationLockOwnerTokenPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 const windowsReservedFilenameStems = new Set([
   "con",
@@ -721,35 +723,37 @@ export async function enqueueLaneRun(
   assertSafeStableWorkItemId(input.stableWorkItemId);
   assertSafeLaneQueueMetadata(input);
 
-  const record = toSerializableLaneRunQueueRecord({
-    schemaVersion: "ensen.lane-run-queue.v1",
-    id: `queue-${input.stableWorkItemId}`,
-    stableWorkItemId: input.stableWorkItemId,
-    workItemId: input.workItemId,
-    source: input.source,
-    laneId: input.laneId,
-    repositoryClassification: input.repositoryClassification,
-    status: "queued",
-    queuedAt: input.queuedAt,
-    updatedAt: input.queuedAt,
-    startsAgentExecution: false,
-    metadata: input.metadata ?? {},
-    publicDiagnostics: {
-      stableWorkItemId: input.stableWorkItemId,
-      laneId: input.laneId,
-      source: input.source,
-      repositoryClassification: input.repositoryClassification,
-      status: "queued",
-    },
-  });
-
-  await withLaneRunMutationLock(stateRoot, input.stableWorkItemId, async () => {
+  return withLaneRunMutationLock(stateRoot, input.stableWorkItemId, async () => {
     // Keep rediscovery from overwriting queue state while the same work item is actively claimed.
     await assertNoActiveLaneRunLockForEnqueue(stateRoot, input.stableWorkItemId);
-    await writeLaneRunQueueRecord(stateRoot, record);
-  });
+    const enqueueSequence = await nextLaneRunQueueSequence(stateRoot, input.stableWorkItemId);
+    const record = toSerializableLaneRunQueueRecord({
+      schemaVersion: "ensen.lane-run-queue.v1",
+      id: `queue-${input.stableWorkItemId}-${enqueueSequence}`,
+      enqueueSequence,
+      stableWorkItemId: input.stableWorkItemId,
+      workItemId: input.workItemId,
+      source: input.source,
+      laneId: input.laneId,
+      repositoryClassification: input.repositoryClassification,
+      status: "queued",
+      queuedAt: input.queuedAt,
+      updatedAt: input.queuedAt,
+      startsAgentExecution: false,
+      metadata: input.metadata ?? {},
+      publicDiagnostics: {
+        stableWorkItemId: input.stableWorkItemId,
+        laneId: input.laneId,
+        source: input.source,
+        repositoryClassification: input.repositoryClassification,
+        status: "queued",
+      },
+    });
 
-  return record;
+    await writeLaneRunQueueRecord(stateRoot, record);
+
+    return record;
+  });
 }
 
 export async function readLaneRunQueueRecord(
@@ -870,6 +874,8 @@ export async function completeLaneRunLock(
     if (existingLock.status !== "active" || existingLock.active !== true) {
       throw new Error(`Lane run lock is already terminal: ${existingLock.status}.`);
     }
+
+    assertLaneRunCompletionTimestamp(existingLock.claimedAt, input.completedAt);
 
     const queueRecord = await readLaneRunQueueRecord(stateRoot, input.stableWorkItemId);
     const completedLock = toSerializableLaneRunLock({
@@ -1013,12 +1019,27 @@ async function assertNoActiveLaneRunLockForEnqueue(stateRoot: string, stableWork
   }
 }
 
+async function nextLaneRunQueueSequence(stateRoot: string, stableWorkItemId: string): Promise<number> {
+  const existingRecord = await readOptionalLaneRunQueueRecord(stateRoot, stableWorkItemId);
+
+  return existingRecord ? existingRecord.enqueueSequence + 1 : 1;
+}
+
 function isStaleQueueRecordForTerminalLock(queueRecord: LaneRunQueueRecord, lock: LaneRunLock): boolean {
   if (lock.status === "active" || lock.releasedAt === undefined || lock.queueRecordId !== queueRecord.id) {
     return false;
   }
 
-  return Date.parse(queueRecord.queuedAt) <= Date.parse(lock.releasedAt);
+  return true;
+}
+
+function assertLaneRunCompletionTimestamp(claimedAt: string, completedAt: string): void {
+  const claimedAtMs = Date.parse(claimedAt);
+  const completedAtMs = Date.parse(completedAt);
+
+  if (completedAtMs < claimedAtMs || completedAtMs - claimedAtMs > laneRunMaxCompletionDurationMs) {
+    throw new Error("Lane run lock completion timestamp must stay within the active claim window.");
+  }
 }
 
 async function recoverStaleLaneRunMutationLock(lockPath: string): Promise<boolean> {
@@ -1205,6 +1226,21 @@ async function readOptionalLaneRunLock(
   }
 }
 
+async function readOptionalLaneRunQueueRecord(
+  stateRoot: string,
+  stableWorkItemId: string,
+): Promise<LaneRunQueueRecord | undefined> {
+  try {
+    return await readLaneRunQueueRecord(stateRoot, stableWorkItemId);
+  } catch (error) {
+    if (isNodeError(error) && error.code === "ENOENT") {
+      return undefined;
+    }
+
+    throw error;
+  }
+}
+
 async function writeLaneRunQueueRecord(stateRoot: string, record: LaneRunQueueRecord): Promise<string> {
   const validatedRecord = parseLaneRunQueueRecord(record);
   const queuePath = resolveLaneRunQueueRecordPath(stateRoot, validatedRecord.stableWorkItemId);
@@ -1274,10 +1310,17 @@ async function writeJsonStateFile(
   try {
     await assertGenericStatePathSafeForWrite(stateRoot, statePath);
     await rename(temporaryPath, statePath);
-    await syncStateDirectory(realRoot, stateDirectory);
   } catch (error) {
     await rm(temporaryPath, { force: true });
     throw error;
+  }
+
+  try {
+    await syncStateDirectory(realRoot, stateDirectory);
+  } catch {
+    // The rename already made the logical state update visible. Directory fsync
+    // is a best-effort durability barrier and must not be reported as a failed
+    // write that callers might roll back into mixed queue/lock state.
   }
 }
 
@@ -2143,6 +2186,7 @@ function parseLaneRunQueueRecord(value: unknown): LaneRunQueueRecord {
     !hasExactKeys(value, [
       "schemaVersion",
       "id",
+      "enqueueSequence",
       "stableWorkItemId",
       "workItemId",
       "source",
@@ -2157,6 +2201,8 @@ function parseLaneRunQueueRecord(value: unknown): LaneRunQueueRecord {
     ]) ||
     value.schemaVersion !== "ensen.lane-run-queue.v1" ||
     !isNonEmptyString(value.id) ||
+    !Number.isSafeInteger(value.enqueueSequence) ||
+    Number(value.enqueueSequence) < 1 ||
     !isSafeStableWorkItemId(String(value.stableWorkItemId)) ||
     !isNonEmptyString(value.workItemId) ||
     !isNonEmptyString(value.source) ||
@@ -2274,6 +2320,7 @@ function toSerializableLaneRunQueueRecord(record: LaneRunQueueRecord): LaneRunQu
   return {
     schemaVersion: record.schemaVersion,
     id: record.id,
+    enqueueSequence: record.enqueueSequence,
     stableWorkItemId: record.stableWorkItemId,
     workItemId: record.workItemId,
     source: record.source,

--- a/src/lane/index.ts
+++ b/src/lane/index.ts
@@ -877,7 +877,7 @@ export async function completeLaneRunLock(
       },
     });
 
-    await persistCompletedLaneRunState(stateRoot, queueRecord, completedQueueRecord, completedLock);
+    await persistCompletedLaneRunState(stateRoot, existingLock, completedLock, completedQueueRecord);
 
     return completedLock;
   });
@@ -885,16 +885,21 @@ export async function completeLaneRunLock(
 
 async function persistCompletedLaneRunState(
   stateRoot: string,
-  previousQueueRecord: LaneRunQueueRecord,
-  completedQueueRecord: LaneRunQueueRecord,
+  previousLock: LaneRunLock,
   completedLock: LaneRunLock,
+  completedQueueRecord: LaneRunQueueRecord,
 ): Promise<void> {
-  await writeLaneRunQueueRecord(stateRoot, completedQueueRecord);
+  await writeLaneRunLock(stateRoot, completedLock);
 
   try {
-    await writeLaneRunLock(stateRoot, completedLock);
+    await writeLaneRunQueueRecord(stateRoot, completedQueueRecord);
   } catch (error) {
-    await writeLaneRunQueueRecord(stateRoot, previousQueueRecord);
+    try {
+      await writeLaneRunLock(stateRoot, previousLock);
+    } catch (rollbackError) {
+      throw new AggregateError([error, rollbackError], "Lane run completion failed and lock rollback failed.");
+    }
+
     throw error;
   }
 }
@@ -947,7 +952,7 @@ async function acquireLaneRunMutationLock(
         throw error;
       }
 
-      const recoveredStaleLock = await recoverStaleLaneRunMutationLock(realRoot, lockPath);
+      const recoveredStaleLock = await recoverStaleLaneRunMutationLock(lockPath);
 
       if (recoveredStaleLock) {
         continue;
@@ -996,7 +1001,7 @@ async function assertNoActiveLaneRunLockForEnqueue(stateRoot: string, stableWork
   }
 }
 
-async function recoverStaleLaneRunMutationLock(realRoot: string, lockPath: string): Promise<boolean> {
+async function recoverStaleLaneRunMutationLock(lockPath: string): Promise<boolean> {
   let lockStats: Stats;
 
   try {
@@ -1017,12 +1022,8 @@ async function recoverStaleLaneRunMutationLock(realRoot: string, lockPath: strin
     return false;
   }
 
-  // A stale timestamp alone is not enough to reclaim a lock; live owners remain authoritative.
-  const owner = await readOptionalLaneRunMutationLockOwner(realRoot, lockPath);
-
-  if (owner && isProcessAlive(owner.pid)) {
-    return false;
-  }
+  // The lock directory heartbeat is the lock-specific liveness signal; PIDs can be reused
+  // and malformed owner metadata must not make a stale lock unrecoverable.
 
   try {
     await rm(lockPath, { recursive: true });
@@ -1270,23 +1271,6 @@ function isSafeStableWorkItemId(stableWorkItemId: string): boolean {
   }
 
   return !windowsReservedFilenameStems.has(stableWorkItemId.split(".")[0]);
-}
-
-function isProcessAlive(pid: number): boolean {
-  if (!Number.isSafeInteger(pid) || pid <= 0) {
-    return false;
-  }
-
-  try {
-    process.kill(pid, 0);
-    return true;
-  } catch (error) {
-    if (isNodeError(error) && error.code === "ESRCH") {
-      return false;
-    }
-
-    return true;
-  }
 }
 
 function assertSafeLaneQueueMetadata(input: EnqueueLaneRunInput): void {

--- a/src/lane/index.ts
+++ b/src/lane/index.ts
@@ -3,6 +3,7 @@ import type { Stats } from "node:fs";
 import { lstat, mkdir, open, realpath, rm } from "node:fs/promises";
 import type { FileHandle } from "node:fs/promises";
 import path from "node:path";
+import { setTimeout as delay } from "node:timers/promises";
 
 import type { LaneAuditRefs } from "../audit/index.js";
 import {
@@ -706,7 +707,9 @@ export async function enqueueLaneRun(
     },
   });
 
-  await writeLaneRunQueueRecord(stateRoot, record);
+  await withLaneRunMutationLock(stateRoot, input.stableWorkItemId, async () => {
+    await writeLaneRunQueueRecord(stateRoot, record);
+  });
 
   return record;
 }
@@ -736,47 +739,49 @@ export async function claimQueuedLaneRun(
     throw new Error("Lane run claim input is malformed.");
   }
 
-  const queueRecord = await readLaneRunQueueRecord(stateRoot, input.stableWorkItemId);
+  return withLaneRunMutationLock(stateRoot, input.stableWorkItemId, async () => {
+    const queueRecord = await readLaneRunQueueRecord(stateRoot, input.stableWorkItemId);
 
-  if (queueRecord.status !== "queued") {
-    throw new Error(`Lane run queue record is not claimable: ${queueRecord.status}.`);
-  }
+    if (queueRecord.status !== "queued") {
+      throw new Error(`Lane run queue record is not claimable: ${queueRecord.status}.`);
+    }
 
-  const existingLock = await readOptionalLaneRunLock(stateRoot, input.stableWorkItemId);
+    const existingLock = await readOptionalLaneRunLock(stateRoot, input.stableWorkItemId);
 
-  if (existingLock?.active === true) {
-    const reason = `already claimed by active lane run ${existingLock.laneRunId}`;
+    if (existingLock?.active === true) {
+      const reason = `already claimed by active lane run ${existingLock.laneRunId}`;
+
+      return {
+        ok: false,
+        reason,
+        lock: existingLock,
+        publicDiagnostics: createLaneRunLockDiagnostics(existingLock, reason),
+      };
+    }
+
+    const lock = toSerializableLaneRunLock({
+      schemaVersion: "ensen.lane-run-lock.v1",
+      stableWorkItemId: queueRecord.stableWorkItemId,
+      queueRecordId: queueRecord.id,
+      laneRunId: input.laneRunId,
+      laneId: queueRecord.laneId,
+      source: queueRecord.source,
+      repositoryClassification: queueRecord.repositoryClassification,
+      status: "active",
+      active: true,
+      claimedAt: input.claimedAt,
+      claimedBy: input.claimedBy,
+      startsAgentExecution: false,
+    });
+
+    await writeLaneRunLock(stateRoot, lock);
 
     return {
-      ok: false,
-      reason,
-      lock: existingLock,
-      publicDiagnostics: createLaneRunLockDiagnostics(existingLock, reason),
+      ok: true,
+      lock,
+      publicDiagnostics: createLaneRunLockDiagnostics(lock, "claimed"),
     };
-  }
-
-  const lock = toSerializableLaneRunLock({
-    schemaVersion: "ensen.lane-run-lock.v1",
-    stableWorkItemId: queueRecord.stableWorkItemId,
-    queueRecordId: queueRecord.id,
-    laneRunId: input.laneRunId,
-    laneId: queueRecord.laneId,
-    source: queueRecord.source,
-    repositoryClassification: queueRecord.repositoryClassification,
-    status: "active",
-    active: true,
-    claimedAt: input.claimedAt,
-    claimedBy: input.claimedBy,
-    startsAgentExecution: false,
   });
-
-  await writeLaneRunLock(stateRoot, lock);
-
-  return {
-    ok: true,
-    lock,
-    publicDiagnostics: createLaneRunLockDiagnostics(lock, "claimed"),
-  };
 }
 
 export async function readLaneRunLock(stateRoot: string, stableWorkItemId: string): Promise<LaneRunLock> {
@@ -800,38 +805,120 @@ export async function completeLaneRunLock(
   if (
     !isLaneRunId(input.laneRunId) ||
     !isIsoDateTime(input.completedAt) ||
-    !laneRunLockStatuses.has(input.terminalStatus)
+    !laneRunLockStatuses.has(input.terminalStatus) ||
+    String(input.terminalStatus) === "active"
   ) {
     throw new Error("Lane run lock completion input is malformed.");
   }
 
-  const existingLock = await readLaneRunLock(stateRoot, input.stableWorkItemId);
+  return withLaneRunMutationLock(stateRoot, input.stableWorkItemId, async () => {
+    const existingLock = await readLaneRunLock(stateRoot, input.stableWorkItemId);
 
-  if (existingLock.laneRunId !== input.laneRunId) {
-    throw new Error("Lane run lock completion does not match the active lane run.");
+    if (existingLock.laneRunId !== input.laneRunId) {
+      throw new Error("Lane run lock completion does not match the active lane run.");
+    }
+
+    if (existingLock.status !== "active" || existingLock.active !== true) {
+      throw new Error(`Lane run lock is already terminal: ${existingLock.status}.`);
+    }
+
+    const queueRecord = await readLaneRunQueueRecord(stateRoot, input.stableWorkItemId);
+    const completedLock = toSerializableLaneRunLock({
+      ...existingLock,
+      status: input.terminalStatus,
+      active: false,
+      releasedAt: input.completedAt,
+    });
+    const completedQueueRecord = toSerializableLaneRunQueueRecord({
+      ...queueRecord,
+      status: input.terminalStatus,
+      updatedAt: input.completedAt,
+      publicDiagnostics: {
+        ...queueRecord.publicDiagnostics,
+        status: input.terminalStatus,
+      },
+    });
+
+    await persistCompletedLaneRunState(stateRoot, queueRecord, completedQueueRecord, completedLock);
+
+    return completedLock;
+  });
+}
+
+async function persistCompletedLaneRunState(
+  stateRoot: string,
+  previousQueueRecord: LaneRunQueueRecord,
+  completedQueueRecord: LaneRunQueueRecord,
+  completedLock: LaneRunLock,
+): Promise<void> {
+  await writeLaneRunQueueRecord(stateRoot, completedQueueRecord);
+
+  try {
+    await writeLaneRunLock(stateRoot, completedLock);
+  } catch (error) {
+    await writeLaneRunQueueRecord(stateRoot, previousQueueRecord);
+    throw error;
+  }
+}
+
+async function withLaneRunMutationLock<T>(
+  stateRoot: string,
+  stableWorkItemId: string,
+  operation: () => Promise<T>,
+): Promise<T> {
+  const release = await acquireLaneRunMutationLock(stateRoot, stableWorkItemId);
+
+  try {
+    return await operation();
+  } finally {
+    await release();
+  }
+}
+
+async function acquireLaneRunMutationLock(
+  stateRoot: string,
+  stableWorkItemId: string,
+): Promise<() => Promise<void>> {
+  const lockPath = resolveLaneRunMutationLockPath(stateRoot, stableWorkItemId);
+  const lockRoot = path.dirname(lockPath);
+
+  await mkdir(lockRoot, { recursive: true });
+  const realRoot = await resolveCanonicalStateRoot(stateRoot);
+  await assertExistingPathSafe(realRoot, lockRoot, "directory");
+
+  for (let attempt = 0; attempt < 25; attempt += 1) {
+    try {
+      await mkdir(lockPath, { mode: 0o700 });
+      await assertExistingPathSafe(realRoot, lockPath, "directory");
+
+      return async () => {
+        await rm(lockPath, { recursive: true, force: true });
+      };
+    } catch (error) {
+      if (!isNodeError(error) || error.code !== "EEXIST") {
+        throw error;
+      }
+
+      await delay(20);
+    }
   }
 
-  const completedLock = toSerializableLaneRunLock({
-    ...existingLock,
-    status: input.terminalStatus,
-    active: false,
-    releasedAt: input.completedAt,
-  });
+  throw new Error("Lane run queue record is currently being modified; retry the lane run mutation.");
+}
 
-  await writeLaneRunLock(stateRoot, completedLock);
+function resolveLaneRunMutationLockPath(stateRoot: string, stableWorkItemId: string): string {
+  assertSafeStableWorkItemId(stableWorkItemId);
 
-  const queueRecord = await readLaneRunQueueRecord(stateRoot, input.stableWorkItemId);
-  await writeLaneRunQueueRecord(stateRoot, {
-    ...queueRecord,
-    status: input.terminalStatus,
-    updatedAt: input.completedAt,
-    publicDiagnostics: {
-      ...queueRecord.publicDiagnostics,
-      status: input.terminalStatus,
-    },
-  });
+  const resolvedRoot = path.resolve(stateRoot);
+  const lockRoot = path.join(resolvedRoot, "lane-run-mutation-locks");
+  const lockPath = path.join(lockRoot, `${stableWorkItemId}.lock`);
+  const relativePath = path.relative(resolvedRoot, lockPath);
 
-  return completedLock;
+  if (relativePath.startsWith("..") || path.isAbsolute(relativePath)) {
+    throw new Error("Lane run mutation lock paths must stay inside the configured state root.");
+  }
+
+  return lockPath;
 }
 
 async function readOptionalLaneRunLock(
@@ -1833,7 +1920,11 @@ function parseLaneRunLock(value: unknown): LaneRunLock {
 
   const lock = value as unknown as LaneRunLock;
 
-  if ((lock.status === "active") !== lock.active || (lock.status !== "active" && lock.releasedAt === undefined)) {
+  if (
+    (lock.status === "active") !== lock.active ||
+    (lock.status === "active" && lock.releasedAt !== undefined) ||
+    (lock.status !== "active" && lock.releasedAt === undefined)
+  ) {
     throw new Error("Lane run lock is malformed.");
   }
 

--- a/test/lane-run-queue.test.ts
+++ b/test/lane-run-queue.test.ts
@@ -277,6 +277,32 @@ test("rejects attempts to rewrite a terminal lock", async () => {
   }
 });
 
+test("fails closed when the queue directory cannot be synced after atomic rename", async () => {
+  const stateRoot = await mkdtemp(path.join(os.tmpdir(), "ensen-loop-state-"));
+  const queueDirectory = path.join(stateRoot, "lane-run-queue");
+
+  try {
+    await mkdir(queueDirectory, { recursive: true });
+    await chmod(queueDirectory, 0o300);
+
+    await assert.rejects(
+      () =>
+        enqueueLaneRun(stateRoot, {
+          stableWorkItemId: "github-issue-110",
+          workItemId: "issue-110",
+          source: "github-issue",
+          laneId: "owner-dogfood",
+          repositoryClassification: "owner-controlled-dogfood",
+          queuedAt,
+        }),
+      (error: unknown) => error instanceof Error && "code" in error && error.code === "EACCES",
+    );
+  } finally {
+    await chmod(queueDirectory, 0o700).catch(() => undefined);
+    await rm(stateRoot, { recursive: true, force: true });
+  }
+});
+
 test("recovers a stale queue mutation lock before enqueueing", async () => {
   const stateRoot = await mkdtemp(path.join(os.tmpdir(), "ensen-loop-state-"));
 

--- a/test/lane-run-queue.test.ts
+++ b/test/lane-run-queue.test.ts
@@ -9,6 +9,7 @@ import {
   completeLaneRunLock,
   enqueueLaneRun,
   readLaneRunLock,
+  readLaneRunQueueRecord,
   resolveLaneRunLockPath,
 } from "../src/lane/index.js";
 
@@ -86,6 +87,49 @@ test("queues an issue work item and claims it exactly once while the lock is act
   }
 });
 
+test("serializes concurrent claims so only one active lock is created", async () => {
+  const stateRoot = await mkdtemp(path.join(os.tmpdir(), "ensen-loop-state-"));
+
+  try {
+    await enqueueLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-110",
+      workItemId: "issue-110",
+      source: "github-issue",
+      laneId: "owner-dogfood",
+      repositoryClassification: "owner-controlled-dogfood",
+      queuedAt,
+    });
+
+    const claims = await Promise.all([
+      claimQueuedLaneRun(stateRoot, {
+        stableWorkItemId: "github-issue-110",
+        laneRunId: "lane-run-110-a",
+        claimedBy: "local-supervisor",
+        claimedAt,
+      }),
+      claimQueuedLaneRun(stateRoot, {
+        stableWorkItemId: "github-issue-110",
+        laneRunId: "lane-run-110-b",
+        claimedBy: "local-supervisor",
+        claimedAt: "2026-05-21T05:01:01.000Z",
+      }),
+    ]);
+
+    const successfulClaims = claims.filter((claim) => claim.ok);
+    const rejectedClaims = claims.filter((claim) => !claim.ok);
+
+    assert.equal(successfulClaims.length, 1);
+    assert.equal(rejectedClaims.length, 1);
+    assert.match(rejectedClaims[0].reason, /already claimed by active lane run lane-run-110-[ab]/);
+
+    const durableLock = await readLaneRunLock(stateRoot, "github-issue-110");
+    assert.equal(durableLock.status, "active");
+    assert.equal(durableLock.laneRunId, successfulClaims[0].lock.laneRunId);
+  } finally {
+    await rm(stateRoot, { recursive: true, force: true });
+  }
+});
+
 test("distinguishes completed locks from active locks and allows a later claim", async () => {
   const stateRoot = await mkdtemp(path.join(os.tmpdir(), "ensen-loop-state-"));
 
@@ -141,6 +185,55 @@ test("distinguishes completed locks from active locks and allows a later claim",
   }
 });
 
+test("rejects attempts to rewrite a terminal lock", async () => {
+  const stateRoot = await mkdtemp(path.join(os.tmpdir(), "ensen-loop-state-"));
+
+  try {
+    await enqueueLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-110",
+      workItemId: "issue-110",
+      source: "github-issue",
+      laneId: "owner-dogfood",
+      repositoryClassification: "owner-controlled-dogfood",
+      queuedAt,
+    });
+
+    const claim = await claimQueuedLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-110",
+      laneRunId: "lane-run-110-a",
+      claimedBy: "local-supervisor",
+      claimedAt,
+    });
+    await completeLaneRunLock(stateRoot, {
+      stableWorkItemId: "github-issue-110",
+      laneRunId: claim.lock.laneRunId,
+      completedAt,
+      terminalStatus: "completed",
+    });
+
+    await assert.rejects(
+      () =>
+        completeLaneRunLock(stateRoot, {
+          stableWorkItemId: "github-issue-110",
+          laneRunId: claim.lock.laneRunId,
+          completedAt: "2026-05-21T05:03:00.000Z",
+          terminalStatus: "revoked",
+        }),
+      /Lane run lock is already terminal: completed/,
+    );
+
+    const durableLock = await readLaneRunLock(stateRoot, "github-issue-110");
+    const durableQueueRecord = await readLaneRunQueueRecord(stateRoot, "github-issue-110");
+
+    assert.equal(durableLock.status, "completed");
+    assert.equal(durableLock.releasedAt, completedAt);
+    assert.equal(durableQueueRecord.status, "completed");
+    assert.equal(durableQueueRecord.updatedAt, completedAt);
+  } finally {
+    await rm(stateRoot, { recursive: true, force: true });
+  }
+});
+
 test("fails closed when durable lock input is corrupted", async () => {
   const stateRoot = await mkdtemp(path.join(os.tmpdir(), "ensen-loop-state-"));
 
@@ -168,6 +261,56 @@ test("fails closed when durable lock input is corrupted", async () => {
         claimedBy: "local-supervisor",
         queueRecordId: "queue-github-issue-110",
         startsAgentExecution: true,
+      }),
+      "utf8",
+    );
+
+    await assert.rejects(
+      () =>
+        claimQueuedLaneRun(stateRoot, {
+          stableWorkItemId: "github-issue-110",
+          laneRunId: "lane-run-110-b",
+          claimedBy: "local-supervisor",
+          claimedAt: "2026-05-21T05:01:30.000Z",
+        }),
+      /Lane run lock is malformed/,
+    );
+  } finally {
+    await rm(stateRoot, { recursive: true, force: true });
+  }
+});
+
+test("fails closed when an active lock already has a release timestamp", async () => {
+  const stateRoot = await mkdtemp(path.join(os.tmpdir(), "ensen-loop-state-"));
+
+  try {
+    await enqueueLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-110",
+      workItemId: "issue-110",
+      source: "github-issue",
+      laneId: "owner-dogfood",
+      repositoryClassification: "owner-controlled-dogfood",
+      queuedAt,
+    });
+
+    const lockPath = resolveLaneRunLockPath(stateRoot, "github-issue-110");
+    await mkdir(path.dirname(lockPath), { recursive: true });
+    await writeFile(
+      lockPath,
+      JSON.stringify({
+        schemaVersion: "ensen.lane-run-lock.v1",
+        stableWorkItemId: "github-issue-110",
+        laneRunId: "lane-run-110-a",
+        laneId: "owner-dogfood",
+        source: "github-issue",
+        repositoryClassification: "owner-controlled-dogfood",
+        status: "active",
+        active: true,
+        claimedAt,
+        claimedBy: "local-supervisor",
+        releasedAt: completedAt,
+        queueRecordId: "queue-github-issue-110",
+        startsAgentExecution: false,
       }),
       "utf8",
     );

--- a/test/lane-run-queue.test.ts
+++ b/test/lane-run-queue.test.ts
@@ -35,6 +35,8 @@ test("queues an issue work item and claims it exactly once while the lock is act
     });
 
     assert.equal(queued.status, "queued");
+    assert.equal(queued.id, "queue-github-issue-110-1");
+    assert.equal(queued.enqueueSequence, 1);
     assert.equal(queued.startsAgentExecution, false);
     assert.deepEqual(queued.publicDiagnostics, {
       stableWorkItemId: "github-issue-110",
@@ -212,6 +214,8 @@ test("distinguishes completed locks from active locks and allows a later claim",
       queuedAt: "2026-05-21T05:02:30.000Z",
     });
     assert.equal(rediscovered.status, "queued");
+    assert.equal(rediscovered.id, "queue-github-issue-110-2");
+    assert.equal(rediscovered.enqueueSequence, 2);
 
     const secondClaim = await claimQueuedLaneRun(stateRoot, {
       stableWorkItemId: "github-issue-110",
@@ -223,6 +227,56 @@ test("distinguishes completed locks from active locks and allows a later claim",
     assert.equal(secondClaim.ok, true);
     assert.equal(secondClaim.lock.status, "active");
     assert.equal(secondClaim.lock.laneRunId, "lane-run-110-b");
+    assert.equal(secondClaim.lock.queueRecordId, rediscovered.id);
+  } finally {
+    await rm(stateRoot, { recursive: true, force: true });
+  }
+});
+
+test("uses internal enqueue sequence instead of source timestamps for stale terminal locks", async () => {
+  const stateRoot = await mkdtemp(path.join(os.tmpdir(), "ensen-loop-state-"));
+
+  try {
+    await enqueueLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-110",
+      workItemId: "issue-110",
+      source: "github-issue",
+      laneId: "owner-dogfood",
+      repositoryClassification: "owner-controlled-dogfood",
+      queuedAt,
+    });
+
+    const firstClaim = await claimQueuedLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-110",
+      laneRunId: "lane-run-110-a",
+      claimedBy: "local-supervisor",
+      claimedAt,
+    });
+    await completeLaneRunLock(stateRoot, {
+      stableWorkItemId: "github-issue-110",
+      laneRunId: firstClaim.lock.laneRunId,
+      completedAt,
+      terminalStatus: "completed",
+    });
+
+    const rediscovered = await enqueueLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-110",
+      workItemId: "issue-110",
+      source: "github-issue",
+      laneId: "owner-dogfood",
+      repositoryClassification: "owner-controlled-dogfood",
+      queuedAt: "2026-05-21T04:59:00.000Z",
+    });
+    const secondClaim = await claimQueuedLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-110",
+      laneRunId: "lane-run-110-b",
+      claimedBy: "local-supervisor",
+      claimedAt: "2026-05-21T05:03:00.000Z",
+    });
+
+    assert.equal(rediscovered.enqueueSequence, 2);
+    assert.equal(secondClaim.ok, true);
+    assert.equal(secondClaim.lock.queueRecordId, rediscovered.id);
   } finally {
     await rm(stateRoot, { recursive: true, force: true });
   }
@@ -277,7 +331,51 @@ test("rejects attempts to rewrite a terminal lock", async () => {
   }
 });
 
-test("fails closed when the queue directory cannot be synced after atomic rename", async () => {
+test("rejects completion timestamps outside the active claim window", async () => {
+  const stateRoot = await mkdtemp(path.join(os.tmpdir(), "ensen-loop-state-"));
+
+  try {
+    await enqueueLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-110",
+      workItemId: "issue-110",
+      source: "github-issue",
+      laneId: "owner-dogfood",
+      repositoryClassification: "owner-controlled-dogfood",
+      queuedAt,
+    });
+
+    const claim = await claimQueuedLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-110",
+      laneRunId: "lane-run-110-a",
+      claimedBy: "local-supervisor",
+      claimedAt,
+    });
+
+    for (const invalidCompletedAt of ["2026-05-21T05:00:59.999Z", "2026-05-29T05:01:00.001Z"]) {
+      await assert.rejects(
+        () =>
+          completeLaneRunLock(stateRoot, {
+            stableWorkItemId: "github-issue-110",
+            laneRunId: claim.lock.laneRunId,
+            completedAt: invalidCompletedAt,
+            terminalStatus: "completed",
+          }),
+        /completion timestamp must stay within the active claim window/,
+      );
+    }
+
+    const durableLock = await readLaneRunLock(stateRoot, "github-issue-110");
+    const durableQueueRecord = await readLaneRunQueueRecord(stateRoot, "github-issue-110");
+
+    assert.equal(durableLock.status, "active");
+    assert.equal(durableLock.active, true);
+    assert.equal(durableQueueRecord.status, "queued");
+  } finally {
+    await rm(stateRoot, { recursive: true, force: true });
+  }
+});
+
+test("keeps committed queue state when directory sync fails after atomic rename", async () => {
   const stateRoot = await mkdtemp(path.join(os.tmpdir(), "ensen-loop-state-"));
   const queueDirectory = path.join(stateRoot, "lane-run-queue");
 
@@ -285,18 +383,21 @@ test("fails closed when the queue directory cannot be synced after atomic rename
     await mkdir(queueDirectory, { recursive: true });
     await chmod(queueDirectory, 0o300);
 
-    await assert.rejects(
-      () =>
-        enqueueLaneRun(stateRoot, {
-          stableWorkItemId: "github-issue-110",
-          workItemId: "issue-110",
-          source: "github-issue",
-          laneId: "owner-dogfood",
-          repositoryClassification: "owner-controlled-dogfood",
-          queuedAt,
-        }),
-      (error: unknown) => error instanceof Error && "code" in error && error.code === "EACCES",
-    );
+    const queued = await enqueueLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-110",
+      workItemId: "issue-110",
+      source: "github-issue",
+      laneId: "owner-dogfood",
+      repositoryClassification: "owner-controlled-dogfood",
+      queuedAt,
+    });
+
+    await chmod(queueDirectory, 0o700);
+    const durableQueueRecord = await readLaneRunQueueRecord(stateRoot, "github-issue-110");
+
+    assert.equal(queued.status, "queued");
+    assert.equal(durableQueueRecord.id, queued.id);
+    assert.equal(durableQueueRecord.enqueueSequence, 1);
   } finally {
     await chmod(queueDirectory, 0o700).catch(() => undefined);
     await rm(stateRoot, { recursive: true, force: true });
@@ -595,7 +696,7 @@ test("fails closed when durable lock input is corrupted", async () => {
   const stateRoot = await mkdtemp(path.join(os.tmpdir(), "ensen-loop-state-"));
 
   try {
-    await enqueueLaneRun(stateRoot, {
+    const queued = await enqueueLaneRun(stateRoot, {
       stableWorkItemId: "github-issue-110",
       workItemId: "issue-110",
       source: "github-issue",
@@ -616,7 +717,7 @@ test("fails closed when durable lock input is corrupted", async () => {
         active: true,
         claimedAt,
         claimedBy: "local-supervisor",
-        queueRecordId: "queue-github-issue-110",
+        queueRecordId: queued.id,
         startsAgentExecution: true,
       }),
       "utf8",
@@ -685,7 +786,7 @@ test("fails closed when an active lock already has a release timestamp", async (
   const stateRoot = await mkdtemp(path.join(os.tmpdir(), "ensen-loop-state-"));
 
   try {
-    await enqueueLaneRun(stateRoot, {
+    const queued = await enqueueLaneRun(stateRoot, {
       stableWorkItemId: "github-issue-110",
       workItemId: "issue-110",
       source: "github-issue",
@@ -710,7 +811,7 @@ test("fails closed when an active lock already has a release timestamp", async (
         claimedAt,
         claimedBy: "local-supervisor",
         releasedAt: completedAt,
-        queueRecordId: "queue-github-issue-110",
+        queueRecordId: queued.id,
         startsAgentExecution: false,
       }),
       "utf8",

--- a/test/lane-run-queue.test.ts
+++ b/test/lane-run-queue.test.ts
@@ -770,6 +770,115 @@ test("fails closed when a terminal lock is newer than the queued record", async 
   }
 });
 
+test("fails closed when a terminal lock references a later queue record", async () => {
+  const stateRoot = await mkdtemp(path.join(os.tmpdir(), "ensen-loop-state-"));
+
+  try {
+    await enqueueLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-110",
+      workItemId: "issue-110",
+      source: "github-issue",
+      laneId: "owner-dogfood",
+      repositoryClassification: "owner-controlled-dogfood",
+      queuedAt,
+    });
+
+    const lockPath = resolveLaneRunLockPath(stateRoot, "github-issue-110");
+    await mkdir(path.dirname(lockPath), { recursive: true });
+    await writeFile(
+      lockPath,
+      JSON.stringify({
+        schemaVersion: "ensen.lane-run-lock.v1",
+        stableWorkItemId: "github-issue-110",
+        queueRecordId: "queue-github-issue-110-2",
+        laneRunId: "lane-run-110-b",
+        laneId: "owner-dogfood",
+        source: "github-issue",
+        repositoryClassification: "owner-controlled-dogfood",
+        status: "completed",
+        active: false,
+        claimedAt: "2026-05-21T05:03:00.000Z",
+        claimedBy: "local-supervisor",
+        releasedAt: "2026-05-21T05:04:00.000Z",
+        startsAgentExecution: false,
+      }),
+      "utf8",
+    );
+
+    const duplicate = await claimQueuedLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-110",
+      laneRunId: "lane-run-110-c",
+      claimedBy: "local-supervisor",
+      claimedAt: "2026-05-21T05:05:00.000Z",
+    });
+
+    assert.equal(duplicate.ok, false);
+    assert.match(duplicate.reason, /stale queued record for terminal lane run lane-run-110-b/);
+
+    const durableLock = await readLaneRunLock(stateRoot, "github-issue-110");
+    const durableQueueRecord = await readLaneRunQueueRecord(stateRoot, "github-issue-110");
+
+    assert.equal(durableLock.status, "completed");
+    assert.equal(durableQueueRecord.status, "queued");
+    assert.equal(durableQueueRecord.enqueueSequence, 1);
+  } finally {
+    await rm(stateRoot, { recursive: true, force: true });
+  }
+});
+
+test("fails closed when terminal lock queue record reference is malformed", async () => {
+  const stateRoot = await mkdtemp(path.join(os.tmpdir(), "ensen-loop-state-"));
+
+  try {
+    await enqueueLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-110",
+      workItemId: "issue-110",
+      source: "github-issue",
+      laneId: "owner-dogfood",
+      repositoryClassification: "owner-controlled-dogfood",
+      queuedAt,
+    });
+
+    const lockPath = resolveLaneRunLockPath(stateRoot, "github-issue-110");
+    await mkdir(path.dirname(lockPath), { recursive: true });
+    await writeFile(
+      lockPath,
+      JSON.stringify({
+        schemaVersion: "ensen.lane-run-lock.v1",
+        stableWorkItemId: "github-issue-110",
+        queueRecordId: "queue-other-work-item-2",
+        laneRunId: "lane-run-110-b",
+        laneId: "owner-dogfood",
+        source: "github-issue",
+        repositoryClassification: "owner-controlled-dogfood",
+        status: "completed",
+        active: false,
+        claimedAt: "2026-05-21T05:03:00.000Z",
+        claimedBy: "local-supervisor",
+        releasedAt: "2026-05-21T05:04:00.000Z",
+        startsAgentExecution: false,
+      }),
+      "utf8",
+    );
+
+    await assert.rejects(
+      () =>
+        claimQueuedLaneRun(stateRoot, {
+          stableWorkItemId: "github-issue-110",
+          laneRunId: "lane-run-110-c",
+          claimedBy: "local-supervisor",
+          claimedAt: "2026-05-21T05:05:00.000Z",
+        }),
+      /Lane run lock queue record reference is malformed/,
+    );
+
+    const durableQueueRecord = await readLaneRunQueueRecord(stateRoot, "github-issue-110");
+    assert.equal(durableQueueRecord.status, "queued");
+  } finally {
+    await rm(stateRoot, { recursive: true, force: true });
+  }
+});
+
 test("fails closed when durable lock input is corrupted", async () => {
   const stateRoot = await mkdtemp(path.join(os.tmpdir(), "ensen-loop-state-"));
 

--- a/test/lane-run-queue.test.ts
+++ b/test/lane-run-queue.test.ts
@@ -1,0 +1,188 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import {
+  claimQueuedLaneRun,
+  completeLaneRunLock,
+  enqueueLaneRun,
+  readLaneRunLock,
+  resolveLaneRunLockPath,
+} from "../src/lane/index.js";
+
+const queuedAt = "2026-05-21T05:00:00.000Z";
+const claimedAt = "2026-05-21T05:01:00.000Z";
+const completedAt = "2026-05-21T05:02:00.000Z";
+
+test("queues an issue work item and claims it exactly once while the lock is active", async () => {
+  const stateRoot = await mkdtemp(path.join(os.tmpdir(), "ensen-loop-state-"));
+
+  try {
+    const queued = await enqueueLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-110",
+      workItemId: "issue-110",
+      source: "github-issue",
+      laneId: "owner-dogfood",
+      repositoryClassification: "owner-controlled-dogfood",
+      queuedAt,
+      metadata: {
+        issueNumber: "110",
+      },
+    });
+
+    assert.equal(queued.status, "queued");
+    assert.equal(queued.startsAgentExecution, false);
+    assert.deepEqual(queued.publicDiagnostics, {
+      stableWorkItemId: "github-issue-110",
+      laneId: "owner-dogfood",
+      source: "github-issue",
+      repositoryClassification: "owner-controlled-dogfood",
+      status: "queued",
+    });
+
+    const claim = await claimQueuedLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-110",
+      laneRunId: "lane-run-110-a",
+      claimedBy: "local-supervisor",
+      claimedAt,
+    });
+
+    assert.equal(claim.ok, true);
+    assert.equal(claim.lock.status, "active");
+    assert.equal(claim.lock.queueRecordId, queued.id);
+    assert.equal(claim.lock.startsAgentExecution, false);
+    assert.deepEqual(claim.publicDiagnostics, {
+      stableWorkItemId: "github-issue-110",
+      laneId: "owner-dogfood",
+      source: "github-issue",
+      repositoryClassification: "owner-controlled-dogfood",
+      lockStatus: "active",
+      laneRunId: "lane-run-110-a",
+      reason: "claimed",
+    });
+
+    const duplicate = await claimQueuedLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-110",
+      laneRunId: "lane-run-110-b",
+      claimedBy: "local-supervisor",
+      claimedAt: "2026-05-21T05:01:30.000Z",
+    });
+
+    assert.equal(duplicate.ok, false);
+    assert.match(duplicate.reason, /already claimed by active lane run lane-run-110-a/);
+    assert.deepEqual(duplicate.publicDiagnostics, {
+      stableWorkItemId: "github-issue-110",
+      laneId: "owner-dogfood",
+      source: "github-issue",
+      repositoryClassification: "owner-controlled-dogfood",
+      lockStatus: "active",
+      laneRunId: "lane-run-110-a",
+      reason: "already claimed by active lane run lane-run-110-a",
+    });
+  } finally {
+    await rm(stateRoot, { recursive: true, force: true });
+  }
+});
+
+test("distinguishes completed locks from active locks and allows a later claim", async () => {
+  const stateRoot = await mkdtemp(path.join(os.tmpdir(), "ensen-loop-state-"));
+
+  try {
+    await enqueueLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-110",
+      workItemId: "issue-110",
+      source: "github-issue",
+      laneId: "owner-dogfood",
+      repositoryClassification: "owner-controlled-dogfood",
+      queuedAt,
+    });
+
+    const firstClaim = await claimQueuedLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-110",
+      laneRunId: "lane-run-110-a",
+      claimedBy: "local-supervisor",
+      claimedAt,
+    });
+    await completeLaneRunLock(stateRoot, {
+      stableWorkItemId: "github-issue-110",
+      laneRunId: firstClaim.lock.laneRunId,
+      completedAt,
+      terminalStatus: "completed",
+    });
+
+    const completed = await readLaneRunLock(stateRoot, "github-issue-110");
+    assert.equal(completed.status, "completed");
+    assert.equal(completed.active, false);
+
+    const rediscovered = await enqueueLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-110",
+      workItemId: "issue-110",
+      source: "github-issue",
+      laneId: "owner-dogfood",
+      repositoryClassification: "owner-controlled-dogfood",
+      queuedAt: "2026-05-21T05:02:30.000Z",
+    });
+    assert.equal(rediscovered.status, "queued");
+
+    const secondClaim = await claimQueuedLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-110",
+      laneRunId: "lane-run-110-b",
+      claimedBy: "local-supervisor",
+      claimedAt: "2026-05-21T05:03:00.000Z",
+    });
+
+    assert.equal(secondClaim.ok, true);
+    assert.equal(secondClaim.lock.status, "active");
+    assert.equal(secondClaim.lock.laneRunId, "lane-run-110-b");
+  } finally {
+    await rm(stateRoot, { recursive: true, force: true });
+  }
+});
+
+test("fails closed when durable lock input is corrupted", async () => {
+  const stateRoot = await mkdtemp(path.join(os.tmpdir(), "ensen-loop-state-"));
+
+  try {
+    await enqueueLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-110",
+      workItemId: "issue-110",
+      source: "github-issue",
+      laneId: "owner-dogfood",
+      repositoryClassification: "owner-controlled-dogfood",
+      queuedAt,
+    });
+
+    const lockPath = resolveLaneRunLockPath(stateRoot, "github-issue-110");
+    await mkdir(path.dirname(lockPath), { recursive: true });
+    await writeFile(
+      lockPath,
+      JSON.stringify({
+        schemaVersion: "ensen.lane-run-lock.v1",
+        stableWorkItemId: "github-issue-110",
+        laneRunId: "lane-run-110-a",
+        status: "active",
+        active: true,
+        claimedAt,
+        claimedBy: "local-supervisor",
+        queueRecordId: "queue-github-issue-110",
+        startsAgentExecution: true,
+      }),
+      "utf8",
+    );
+
+    await assert.rejects(
+      () =>
+        claimQueuedLaneRun(stateRoot, {
+          stableWorkItemId: "github-issue-110",
+          laneRunId: "lane-run-110-b",
+          claimedBy: "local-supervisor",
+          claimedAt: "2026-05-21T05:01:30.000Z",
+        }),
+      /Lane run lock is malformed/,
+    );
+  } finally {
+    await rm(stateRoot, { recursive: true, force: true });
+  }
+});

--- a/test/lane-run-queue.test.ts
+++ b/test/lane-run-queue.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { chmod, mkdir, mkdtemp, rm, utimes, writeFile } from "node:fs/promises";
+import { chmod, mkdir, mkdtemp, readFile, rm, utimes, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -305,6 +305,47 @@ test("recovers a stale queue mutation lock before enqueueing", async () => {
   }
 });
 
+test("does not recover a stale queue mutation lock while its owner process is alive", async () => {
+  const stateRoot = await mkdtemp(path.join(os.tmpdir(), "ensen-loop-state-"));
+
+  try {
+    const mutationLockPath = path.join(stateRoot, "lane-run-mutation-locks", "github-issue-110.lock");
+    const ownerPath = path.join(mutationLockPath, "owner.json");
+    await mkdir(mutationLockPath, { recursive: true });
+    await writeFile(
+      ownerPath,
+      JSON.stringify({
+        schemaVersion: "ensen.lane-run-mutation-lock-owner.v1",
+        token: "active-owner",
+        pid: process.pid,
+        acquiredAt: "2026-05-21T05:00:00.000Z",
+      }),
+      "utf8",
+    );
+
+    const staleTimestamp = new Date(Date.now() - 10 * 60 * 1000);
+    await utimes(ownerPath, staleTimestamp, staleTimestamp);
+    await utimes(mutationLockPath, staleTimestamp, staleTimestamp);
+
+    await assert.rejects(
+      () =>
+        enqueueLaneRun(stateRoot, {
+          stableWorkItemId: "github-issue-110",
+          workItemId: "issue-110",
+          source: "github-issue",
+          laneId: "owner-dogfood",
+          repositoryClassification: "owner-controlled-dogfood",
+          queuedAt,
+        }),
+      /currently being modified/,
+    );
+
+    assert.match(await readFile(ownerPath, "utf8"), /active-owner/);
+  } finally {
+    await rm(stateRoot, { recursive: true, force: true });
+  }
+});
+
 test("recovers a stale queue mutation lock before claiming", async () => {
   const stateRoot = await mkdtemp(path.join(os.tmpdir(), "ensen-loop-state-"));
 
@@ -398,7 +439,7 @@ test("keeps the active lock when queue completion cannot be persisted", async ()
       claimedAt,
     });
     const queuePath = resolveLaneRunQueueRecordPath(stateRoot, "github-issue-110");
-    await chmod(queuePath, 0o400);
+    await chmod(path.dirname(queuePath), 0o500);
 
     await assert.rejects(() =>
       completeLaneRunLock(stateRoot, {
@@ -416,6 +457,7 @@ test("keeps the active lock when queue completion cannot be persisted", async ()
     assert.equal(durableLock.active, true);
     assert.equal(durableQueueRecord.status, "queued");
   } finally {
+    await chmod(path.join(stateRoot, "lane-run-queue"), 0o700).catch(() => undefined);
     await rm(stateRoot, { recursive: true, force: true });
   }
 });
@@ -480,8 +522,31 @@ test("rejects stable work item identifiers with filename-unsafe colons", async (
           repositoryClassification: "owner-controlled-dogfood",
           queuedAt,
         }),
-      /Stable work item identifiers may only contain letters, numbers, dots, underscores, and hyphens/,
+      /Stable work item identifiers may only contain lowercase letters, numbers, dots, underscores, and hyphens/,
     );
+  } finally {
+    await rm(stateRoot, { recursive: true, force: true });
+  }
+});
+
+test("rejects non-canonical and reserved stable work item identifiers before filesystem mapping", async () => {
+  const stateRoot = await mkdtemp(path.join(os.tmpdir(), "ensen-loop-state-"));
+
+  try {
+    for (const stableWorkItemId of ["GitHub-issue-110", "con", "lpt1.audit"]) {
+      await assert.rejects(
+        () =>
+          enqueueLaneRun(stateRoot, {
+            stableWorkItemId,
+            workItemId: "issue-110",
+            source: "github-issue",
+            laneId: "owner-dogfood",
+            repositoryClassification: "owner-controlled-dogfood",
+            queuedAt,
+          }),
+        /reserved filenames/,
+      );
+    }
   } finally {
     await rm(stateRoot, { recursive: true, force: true });
   }

--- a/test/lane-run-queue.test.ts
+++ b/test/lane-run-queue.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { chmod, mkdir, mkdtemp, readFile, rm, utimes, writeFile } from "node:fs/promises";
+import { chmod, mkdir, mkdtemp, rm, utimes, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -305,7 +305,7 @@ test("recovers a stale queue mutation lock before enqueueing", async () => {
   }
 });
 
-test("does not recover a stale queue mutation lock while its owner process is alive", async () => {
+test("recovers a stale queue mutation lock even when owner pid is currently alive", async () => {
   const stateRoot = await mkdtemp(path.join(os.tmpdir(), "ensen-loop-state-"));
 
   try {
@@ -327,20 +327,44 @@ test("does not recover a stale queue mutation lock while its owner process is al
     await utimes(ownerPath, staleTimestamp, staleTimestamp);
     await utimes(mutationLockPath, staleTimestamp, staleTimestamp);
 
-    await assert.rejects(
-      () =>
-        enqueueLaneRun(stateRoot, {
-          stableWorkItemId: "github-issue-110",
-          workItemId: "issue-110",
-          source: "github-issue",
-          laneId: "owner-dogfood",
-          repositoryClassification: "owner-controlled-dogfood",
-          queuedAt,
-        }),
-      /currently being modified/,
-    );
+    const queued = await enqueueLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-110",
+      workItemId: "issue-110",
+      source: "github-issue",
+      laneId: "owner-dogfood",
+      repositoryClassification: "owner-controlled-dogfood",
+      queuedAt,
+    });
 
-    assert.match(await readFile(ownerPath, "utf8"), /active-owner/);
+    assert.equal(queued.status, "queued");
+  } finally {
+    await rm(stateRoot, { recursive: true, force: true });
+  }
+});
+
+test("recovers a stale queue mutation lock when owner metadata is malformed", async () => {
+  const stateRoot = await mkdtemp(path.join(os.tmpdir(), "ensen-loop-state-"));
+
+  try {
+    const mutationLockPath = path.join(stateRoot, "lane-run-mutation-locks", "github-issue-110.lock");
+    const ownerPath = path.join(mutationLockPath, "owner.json");
+    await mkdir(mutationLockPath, { recursive: true });
+    await writeFile(ownerPath, "{\"schemaVersion\":\"ensen.lane-run-mutation-lock-owner.v1\"", "utf8");
+
+    const staleTimestamp = new Date(Date.now() - 10 * 60 * 1000);
+    await utimes(ownerPath, staleTimestamp, staleTimestamp);
+    await utimes(mutationLockPath, staleTimestamp, staleTimestamp);
+
+    const queued = await enqueueLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-110",
+      workItemId: "issue-110",
+      source: "github-issue",
+      laneId: "owner-dogfood",
+      repositoryClassification: "owner-controlled-dogfood",
+      queuedAt,
+    });
+
+    assert.equal(queued.status, "queued");
   } finally {
     await rm(stateRoot, { recursive: true, force: true });
   }

--- a/test/lane-run-queue.test.ts
+++ b/test/lane-run-queue.test.ts
@@ -536,6 +536,61 @@ test("keeps the active lock when queue completion cannot be persisted", async ()
   }
 });
 
+test("fails closed when a terminal lock is newer than the queued record", async () => {
+  const stateRoot = await mkdtemp(path.join(os.tmpdir(), "ensen-loop-state-"));
+
+  try {
+    const queued = await enqueueLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-110",
+      workItemId: "issue-110",
+      source: "github-issue",
+      laneId: "owner-dogfood",
+      repositoryClassification: "owner-controlled-dogfood",
+      queuedAt,
+    });
+
+    const lockPath = resolveLaneRunLockPath(stateRoot, "github-issue-110");
+    await mkdir(path.dirname(lockPath), { recursive: true });
+    await writeFile(
+      lockPath,
+      JSON.stringify({
+        schemaVersion: "ensen.lane-run-lock.v1",
+        stableWorkItemId: "github-issue-110",
+        queueRecordId: queued.id,
+        laneRunId: "lane-run-110-a",
+        laneId: "owner-dogfood",
+        source: "github-issue",
+        repositoryClassification: "owner-controlled-dogfood",
+        status: "completed",
+        active: false,
+        claimedAt,
+        claimedBy: "local-supervisor",
+        releasedAt: completedAt,
+        startsAgentExecution: false,
+      }),
+      "utf8",
+    );
+
+    const duplicate = await claimQueuedLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-110",
+      laneRunId: "lane-run-110-b",
+      claimedBy: "local-supervisor",
+      claimedAt: "2026-05-21T05:03:00.000Z",
+    });
+
+    assert.equal(duplicate.ok, false);
+    assert.match(duplicate.reason, /stale queued record for terminal lane run lane-run-110-a/);
+
+    const durableLock = await readLaneRunLock(stateRoot, "github-issue-110");
+    const durableQueueRecord = await readLaneRunQueueRecord(stateRoot, "github-issue-110");
+
+    assert.equal(durableLock.status, "completed");
+    assert.equal(durableQueueRecord.status, "queued");
+  } finally {
+    await rm(stateRoot, { recursive: true, force: true });
+  }
+});
+
 test("fails closed when durable lock input is corrupted", async () => {
   const stateRoot = await mkdtemp(path.join(os.tmpdir(), "ensen-loop-state-"));
 

--- a/test/lane-run-queue.test.ts
+++ b/test/lane-run-queue.test.ts
@@ -305,6 +305,30 @@ test("recovers a stale queue mutation lock before enqueueing", async () => {
   }
 });
 
+test("does not reclaim a fresh queue mutation lock", async () => {
+  const stateRoot = await mkdtemp(path.join(os.tmpdir(), "ensen-loop-state-"));
+
+  try {
+    const mutationLockPath = path.join(stateRoot, "lane-run-mutation-locks", "github-issue-110.lock");
+    await mkdir(mutationLockPath, { recursive: true });
+
+    await assert.rejects(
+      () =>
+        enqueueLaneRun(stateRoot, {
+          stableWorkItemId: "github-issue-110",
+          workItemId: "issue-110",
+          source: "github-issue",
+          laneId: "owner-dogfood",
+          repositoryClassification: "owner-controlled-dogfood",
+          queuedAt,
+        }),
+      /currently being modified/,
+    );
+  } finally {
+    await rm(stateRoot, { recursive: true, force: true });
+  }
+});
+
 test("recovers a stale queue mutation lock even when owner pid is currently alive", async () => {
   const stateRoot = await mkdtemp(path.join(os.tmpdir(), "ensen-loop-state-"));
 

--- a/test/lane-run-queue.test.ts
+++ b/test/lane-run-queue.test.ts
@@ -3,6 +3,7 @@ import { chmod, mkdir, mkdtemp, rm, utimes, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
+import { setTimeout as delay } from "node:timers/promises";
 
 import {
   claimQueuedLaneRun,
@@ -375,6 +376,49 @@ test("rejects completion timestamps outside the active claim window", async () =
   }
 });
 
+test("rejects completion timestamps beyond the local clock tolerance", async () => {
+  const stateRoot = await mkdtemp(path.join(os.tmpdir(), "ensen-loop-state-"));
+
+  try {
+    await enqueueLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-110",
+      workItemId: "issue-110",
+      source: "github-issue",
+      laneId: "owner-dogfood",
+      repositoryClassification: "owner-controlled-dogfood",
+      queuedAt,
+    });
+
+    const claim = await claimQueuedLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-110",
+      laneRunId: "lane-run-110-a",
+      claimedBy: "local-supervisor",
+      claimedAt: "2099-05-21T05:01:00.000Z",
+    });
+
+    assert.equal(claim.ok, true);
+
+    await assert.rejects(
+      () =>
+        completeLaneRunLock(stateRoot, {
+          stableWorkItemId: "github-issue-110",
+          laneRunId: claim.lock.laneRunId,
+          completedAt: "2099-05-21T05:02:00.000Z",
+          terminalStatus: "completed",
+        }),
+      /completion timestamp must stay within the active claim window/,
+    );
+
+    const durableLock = await readLaneRunLock(stateRoot, "github-issue-110");
+    const durableQueueRecord = await readLaneRunQueueRecord(stateRoot, "github-issue-110");
+
+    assert.equal(durableLock.status, "active");
+    assert.equal(durableQueueRecord.status, "queued");
+  } finally {
+    await rm(stateRoot, { recursive: true, force: true });
+  }
+});
+
 test("keeps committed queue state when directory sync fails after atomic rename", async () => {
   const stateRoot = await mkdtemp(path.join(os.tmpdir(), "ensen-loop-state-"));
   const queueDirectory = path.join(stateRoot, "lane-run-queue");
@@ -451,6 +495,40 @@ test("does not reclaim a fresh queue mutation lock", async () => {
         }),
       /currently being modified/,
     );
+  } finally {
+    await rm(stateRoot, { recursive: true, force: true });
+  }
+});
+
+test("does not reclaim a stale-looking mutation lock that refreshes during recovery", async () => {
+  const stateRoot = await mkdtemp(path.join(os.tmpdir(), "ensen-loop-state-"));
+
+  try {
+    const mutationLockPath = path.join(stateRoot, "lane-run-mutation-locks", "github-issue-110.lock");
+    await mkdir(mutationLockPath, { recursive: true });
+
+    const staleTimestamp = new Date(Date.now() - 10 * 60 * 1000);
+    await utimes(mutationLockPath, staleTimestamp, staleTimestamp);
+
+    const refresh = delay(5).then(async () => {
+      const refreshedAt = new Date();
+      await utimes(mutationLockPath, refreshedAt, refreshedAt);
+    });
+
+    await assert.rejects(
+      () =>
+        enqueueLaneRun(stateRoot, {
+          stableWorkItemId: "github-issue-110",
+          workItemId: "issue-110",
+          source: "github-issue",
+          laneId: "owner-dogfood",
+          repositoryClassification: "owner-controlled-dogfood",
+          queuedAt,
+        }),
+      /currently being modified/,
+    );
+
+    await refresh;
   } finally {
     await rm(stateRoot, { recursive: true, force: true });
   }

--- a/test/lane-run-queue.test.ts
+++ b/test/lane-run-queue.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdir, mkdtemp, rm, utimes, writeFile } from "node:fs/promises";
+import { chmod, mkdir, mkdtemp, rm, utimes, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -11,6 +11,7 @@ import {
   readLaneRunLock,
   readLaneRunQueueRecord,
   resolveLaneRunLockPath,
+  resolveLaneRunQueueRecordPath,
 } from "../src/lane/index.js";
 
 const queuedAt = "2026-05-21T05:00:00.000Z";
@@ -299,6 +300,121 @@ test("recovers a stale queue mutation lock before enqueueing", async () => {
 
     const durableQueueRecord = await readLaneRunQueueRecord(stateRoot, "github-issue-110");
     assert.equal(durableQueueRecord.stableWorkItemId, "github-issue-110");
+  } finally {
+    await rm(stateRoot, { recursive: true, force: true });
+  }
+});
+
+test("recovers a stale queue mutation lock before claiming", async () => {
+  const stateRoot = await mkdtemp(path.join(os.tmpdir(), "ensen-loop-state-"));
+
+  try {
+    await enqueueLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-110",
+      workItemId: "issue-110",
+      source: "github-issue",
+      laneId: "owner-dogfood",
+      repositoryClassification: "owner-controlled-dogfood",
+      queuedAt,
+    });
+
+    const mutationLockPath = path.join(stateRoot, "lane-run-mutation-locks", "github-issue-110.lock");
+    await mkdir(mutationLockPath, { recursive: true });
+
+    const staleTimestamp = new Date(Date.now() - 10 * 60 * 1000);
+    await utimes(mutationLockPath, staleTimestamp, staleTimestamp);
+
+    const claim = await claimQueuedLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-110",
+      laneRunId: "lane-run-110-a",
+      claimedBy: "local-supervisor",
+      claimedAt,
+    });
+
+    assert.equal(claim.ok, true);
+    assert.equal(claim.lock.status, "active");
+  } finally {
+    await rm(stateRoot, { recursive: true, force: true });
+  }
+});
+
+test("recovers a stale queue mutation lock before completing", async () => {
+  const stateRoot = await mkdtemp(path.join(os.tmpdir(), "ensen-loop-state-"));
+
+  try {
+    await enqueueLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-110",
+      workItemId: "issue-110",
+      source: "github-issue",
+      laneId: "owner-dogfood",
+      repositoryClassification: "owner-controlled-dogfood",
+      queuedAt,
+    });
+
+    const claim = await claimQueuedLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-110",
+      laneRunId: "lane-run-110-a",
+      claimedBy: "local-supervisor",
+      claimedAt,
+    });
+
+    const mutationLockPath = path.join(stateRoot, "lane-run-mutation-locks", "github-issue-110.lock");
+    await mkdir(mutationLockPath, { recursive: true });
+
+    const staleTimestamp = new Date(Date.now() - 10 * 60 * 1000);
+    await utimes(mutationLockPath, staleTimestamp, staleTimestamp);
+
+    await completeLaneRunLock(stateRoot, {
+      stableWorkItemId: "github-issue-110",
+      laneRunId: claim.lock.laneRunId,
+      completedAt,
+      terminalStatus: "completed",
+    });
+
+    const durableLock = await readLaneRunLock(stateRoot, "github-issue-110");
+    assert.equal(durableLock.status, "completed");
+  } finally {
+    await rm(stateRoot, { recursive: true, force: true });
+  }
+});
+
+test("keeps the active lock when queue completion cannot be persisted", async () => {
+  const stateRoot = await mkdtemp(path.join(os.tmpdir(), "ensen-loop-state-"));
+
+  try {
+    await enqueueLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-110",
+      workItemId: "issue-110",
+      source: "github-issue",
+      laneId: "owner-dogfood",
+      repositoryClassification: "owner-controlled-dogfood",
+      queuedAt,
+    });
+
+    const claim = await claimQueuedLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-110",
+      laneRunId: "lane-run-110-a",
+      claimedBy: "local-supervisor",
+      claimedAt,
+    });
+    const queuePath = resolveLaneRunQueueRecordPath(stateRoot, "github-issue-110");
+    await chmod(queuePath, 0o400);
+
+    await assert.rejects(() =>
+      completeLaneRunLock(stateRoot, {
+        stableWorkItemId: "github-issue-110",
+        laneRunId: claim.lock.laneRunId,
+        completedAt,
+        terminalStatus: "completed",
+      }),
+    );
+
+    const durableLock = await readLaneRunLock(stateRoot, "github-issue-110");
+    const durableQueueRecord = await readLaneRunQueueRecord(stateRoot, "github-issue-110");
+
+    assert.equal(durableLock.status, "active");
+    assert.equal(durableLock.active, true);
+    assert.equal(durableQueueRecord.status, "queued");
   } finally {
     await rm(stateRoot, { recursive: true, force: true });
   }

--- a/test/lane-run-queue.test.ts
+++ b/test/lane-run-queue.test.ts
@@ -380,6 +380,9 @@ test("rejects completion timestamps beyond the local clock tolerance", async () 
   const stateRoot = await mkdtemp(path.join(os.tmpdir(), "ensen-loop-state-"));
 
   try {
+    const localClaimedAt = new Date().toISOString();
+    const futureCompletedAt = new Date(Date.now() + 10 * 60 * 1000).toISOString();
+
     await enqueueLaneRun(stateRoot, {
       stableWorkItemId: "github-issue-110",
       workItemId: "issue-110",
@@ -393,7 +396,7 @@ test("rejects completion timestamps beyond the local clock tolerance", async () 
       stableWorkItemId: "github-issue-110",
       laneRunId: "lane-run-110-a",
       claimedBy: "local-supervisor",
-      claimedAt: "2099-05-21T05:01:00.000Z",
+      claimedAt: localClaimedAt,
     });
 
     assert.equal(claim.ok, true);
@@ -403,7 +406,7 @@ test("rejects completion timestamps beyond the local clock tolerance", async () 
         completeLaneRunLock(stateRoot, {
           stableWorkItemId: "github-issue-110",
           laneRunId: claim.lock.laneRunId,
-          completedAt: "2099-05-21T05:02:00.000Z",
+          completedAt: futureCompletedAt,
           terminalStatus: "completed",
         }),
       /completion timestamp must stay within the active claim window/,
@@ -413,6 +416,37 @@ test("rejects completion timestamps beyond the local clock tolerance", async () 
     const durableQueueRecord = await readLaneRunQueueRecord(stateRoot, "github-issue-110");
 
     assert.equal(durableLock.status, "active");
+    assert.equal(durableQueueRecord.status, "queued");
+  } finally {
+    await rm(stateRoot, { recursive: true, force: true });
+  }
+});
+
+test("rejects claim timestamps beyond the local clock tolerance", async () => {
+  const stateRoot = await mkdtemp(path.join(os.tmpdir(), "ensen-loop-state-"));
+
+  try {
+    await enqueueLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-110",
+      workItemId: "issue-110",
+      source: "github-issue",
+      laneId: "owner-dogfood",
+      repositoryClassification: "owner-controlled-dogfood",
+      queuedAt,
+    });
+
+    await assert.rejects(
+      () =>
+        claimQueuedLaneRun(stateRoot, {
+          stableWorkItemId: "github-issue-110",
+          laneRunId: "lane-run-110-a",
+          claimedBy: "local-supervisor",
+          claimedAt: new Date(Date.now() + 10 * 60 * 1000).toISOString(),
+        }),
+      /claim timestamp must stay within the local clock tolerance/,
+    );
+
+    const durableQueueRecord = await readLaneRunQueueRecord(stateRoot, "github-issue-110");
     assert.equal(durableQueueRecord.status, "queued");
   } finally {
     await rm(stateRoot, { recursive: true, force: true });
@@ -715,6 +749,60 @@ test("keeps the active lock when queue completion cannot be persisted", async ()
   }
 });
 
+test("fails closed when completion sees a queue record that does not match the active lock", async () => {
+  const stateRoot = await mkdtemp(path.join(os.tmpdir(), "ensen-loop-state-"));
+
+  try {
+    const queued = await enqueueLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-110",
+      workItemId: "issue-110",
+      source: "github-issue",
+      laneId: "owner-dogfood",
+      repositoryClassification: "owner-controlled-dogfood",
+      queuedAt,
+    });
+
+    const claim = await claimQueuedLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-110",
+      laneRunId: "lane-run-110-a",
+      claimedBy: "local-supervisor",
+      claimedAt,
+    });
+
+    assert.equal(claim.ok, true);
+
+    await writeFile(
+      resolveLaneRunQueueRecordPath(stateRoot, "github-issue-110"),
+      JSON.stringify({
+        ...queued,
+        id: "queue-github-issue-110-2",
+        enqueueSequence: 2,
+      }),
+      "utf8",
+    );
+
+    await assert.rejects(
+      () =>
+        completeLaneRunLock(stateRoot, {
+          stableWorkItemId: "github-issue-110",
+          laneRunId: claim.lock.laneRunId,
+          completedAt,
+          terminalStatus: "completed",
+        }),
+      /queue record does not match the active lane run lock/,
+    );
+
+    const durableLock = await readLaneRunLock(stateRoot, "github-issue-110");
+    const durableQueueRecord = await readLaneRunQueueRecord(stateRoot, "github-issue-110");
+
+    assert.equal(durableLock.status, "active");
+    assert.equal(durableQueueRecord.status, "queued");
+    assert.equal(durableQueueRecord.id, "queue-github-issue-110-2");
+  } finally {
+    await rm(stateRoot, { recursive: true, force: true });
+  }
+});
+
 test("fails closed when a terminal lock is newer than the queued record", async () => {
   const stateRoot = await mkdtemp(path.join(os.tmpdir(), "ensen-loop-state-"));
 
@@ -919,6 +1007,43 @@ test("fails closed when durable lock input is corrupted", async () => {
           claimedAt: "2026-05-21T05:01:30.000Z",
         }),
       /Lane run lock is malformed/,
+    );
+  } finally {
+    await rm(stateRoot, { recursive: true, force: true });
+  }
+});
+
+test("fails closed when durable queue record id is not canonical", async () => {
+  const stateRoot = await mkdtemp(path.join(os.tmpdir(), "ensen-loop-state-"));
+
+  try {
+    const queued = await enqueueLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-110",
+      workItemId: "issue-110",
+      source: "github-issue",
+      laneId: "owner-dogfood",
+      repositoryClassification: "owner-controlled-dogfood",
+      queuedAt,
+    });
+
+    await writeFile(
+      resolveLaneRunQueueRecordPath(stateRoot, "github-issue-110"),
+      JSON.stringify({
+        ...queued,
+        id: "queue-other-work-item-1",
+      }),
+      "utf8",
+    );
+
+    await assert.rejects(
+      () =>
+        claimQueuedLaneRun(stateRoot, {
+          stableWorkItemId: "github-issue-110",
+          laneRunId: "lane-run-110-a",
+          claimedBy: "local-supervisor",
+          claimedAt,
+        }),
+      /Lane run queue record is malformed/,
     );
   } finally {
     await rm(stateRoot, { recursive: true, force: true });

--- a/test/lane-run-queue.test.ts
+++ b/test/lane-run-queue.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, utimes, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -130,6 +130,48 @@ test("serializes concurrent claims so only one active lock is created", async ()
   }
 });
 
+test("rejects enqueue while an active lock exists for the same work item", async () => {
+  const stateRoot = await mkdtemp(path.join(os.tmpdir(), "ensen-loop-state-"));
+
+  try {
+    await enqueueLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-110",
+      workItemId: "issue-110-a",
+      source: "github-issue",
+      laneId: "owner-dogfood",
+      repositoryClassification: "owner-controlled-dogfood",
+      queuedAt,
+    });
+
+    const claim = await claimQueuedLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-110",
+      laneRunId: "lane-run-110-a",
+      claimedBy: "local-supervisor",
+      claimedAt,
+    });
+    assert.equal(claim.ok, true);
+
+    await assert.rejects(
+      () =>
+        enqueueLaneRun(stateRoot, {
+          stableWorkItemId: "github-issue-110",
+          workItemId: "issue-110-b",
+          source: "github-issue",
+          laneId: "owner-dogfood",
+          repositoryClassification: "owner-controlled-dogfood",
+          queuedAt: "2026-05-21T05:01:30.000Z",
+        }),
+      /already claimed by active lane run lane-run-110-a/,
+    );
+
+    const durableQueueRecord = await readLaneRunQueueRecord(stateRoot, "github-issue-110");
+    assert.equal(durableQueueRecord.workItemId, "issue-110-a");
+    assert.equal(durableQueueRecord.status, "queued");
+  } finally {
+    await rm(stateRoot, { recursive: true, force: true });
+  }
+});
+
 test("distinguishes completed locks from active locks and allows a later claim", async () => {
   const stateRoot = await mkdtemp(path.join(os.tmpdir(), "ensen-loop-state-"));
 
@@ -234,6 +276,34 @@ test("rejects attempts to rewrite a terminal lock", async () => {
   }
 });
 
+test("recovers a stale queue mutation lock before enqueueing", async () => {
+  const stateRoot = await mkdtemp(path.join(os.tmpdir(), "ensen-loop-state-"));
+
+  try {
+    const mutationLockPath = path.join(stateRoot, "lane-run-mutation-locks", "github-issue-110.lock");
+    await mkdir(mutationLockPath, { recursive: true });
+
+    const staleTimestamp = new Date(Date.now() - 10 * 60 * 1000);
+    await utimes(mutationLockPath, staleTimestamp, staleTimestamp);
+
+    const queued = await enqueueLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-110",
+      workItemId: "issue-110",
+      source: "github-issue",
+      laneId: "owner-dogfood",
+      repositoryClassification: "owner-controlled-dogfood",
+      queuedAt,
+    });
+
+    assert.equal(queued.status, "queued");
+
+    const durableQueueRecord = await readLaneRunQueueRecord(stateRoot, "github-issue-110");
+    assert.equal(durableQueueRecord.stableWorkItemId, "github-issue-110");
+  } finally {
+    await rm(stateRoot, { recursive: true, force: true });
+  }
+});
+
 test("fails closed when durable lock input is corrupted", async () => {
   const stateRoot = await mkdtemp(path.join(os.tmpdir(), "ensen-loop-state-"));
 
@@ -274,6 +344,27 @@ test("fails closed when durable lock input is corrupted", async () => {
           claimedAt: "2026-05-21T05:01:30.000Z",
         }),
       /Lane run lock is malformed/,
+    );
+  } finally {
+    await rm(stateRoot, { recursive: true, force: true });
+  }
+});
+
+test("rejects stable work item identifiers with filename-unsafe colons", async () => {
+  const stateRoot = await mkdtemp(path.join(os.tmpdir(), "ensen-loop-state-"));
+
+  try {
+    await assert.rejects(
+      () =>
+        enqueueLaneRun(stateRoot, {
+          stableWorkItemId: "github:issue-110",
+          workItemId: "issue-110",
+          source: "github-issue",
+          laneId: "owner-dogfood",
+          repositoryClassification: "owner-controlled-dogfood",
+          queuedAt,
+        }),
+      /Stable work item identifiers may only contain letters, numbers, dots, underscores, and hyphens/,
     );
   } finally {
     await rm(stateRoot, { recursive: true, force: true });


### PR DESCRIPTION
## Summary
- add durable lane run queue records keyed by stable work item id
- add active lane run locks with sanitized public diagnostics and terminal release state
- cover queue insert, active claim, duplicate rejection, completed lock release, and corrupted lock fail-closed behavior

## Verification
- npm ci
- npm run typecheck
- npm run build
- npm test

Closes #110