### PR TITLE
LOOP-051: Add lane run status and explain commands

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -14,6 +14,8 @@ import {
 } from "../executor/index.js";
 import type { LocalFakeExecutorOutcome } from "../executor/index.js";
 import {
+  explainLaneRun,
+  getLaneRunStatus,
   prepareLocalLaneWorkspace,
 } from "../lane/index.js";
 import {
@@ -246,6 +248,36 @@ async function main(): Promise<number> {
     return runResult.status === "succeeded" ? 0 : 1;
   }
 
+  if (command === "status") {
+    const options = parseStatusArgs(args);
+
+    if (options === undefined) {
+      console.error("Usage: ensen-loop status --state-root <state-root>");
+      return 1;
+    }
+
+    const status = await getLaneRunStatus(options.stateRoot);
+
+    printJson(status);
+    return status.state === "ok" ? 0 : 1;
+  }
+
+  if (command === "explain") {
+    const options = parseExplainArgs(args);
+
+    if (options === undefined) {
+      console.error("Usage: ensen-loop explain --state-root <state-root> [--issue <stable-work-item-id>]");
+      return 1;
+    }
+
+    const explanation = await explainLaneRun(options.stateRoot, {
+      stableWorkItemId: options.stableWorkItemId,
+    });
+
+    printJson(explanation);
+    return explanation.state === "ok" ? 0 : 1;
+  }
+
   if (command === undefined) {
     console.log(describeProduct());
     return 0;
@@ -260,6 +292,8 @@ async function main(): Promise<number> {
   console.error(
     "Usage: ensen-loop x-gate3-smoke <run-request-json-file> --workspace-root <workspace-root> --state-root <state-root> [--fixture succeeded|failed|blocked]",
   );
+  console.error("Usage: ensen-loop status --state-root <state-root>");
+  console.error("Usage: ensen-loop explain --state-root <state-root> [--issue <stable-work-item-id>]");
   return 1;
 }
 
@@ -366,6 +400,50 @@ function parseXGate3SmokeArgs(args: readonly string[]): XGate3SmokeOptions | und
     workspaceRoot,
     stateRoot,
     fixture,
+  };
+}
+
+interface StatusOptions {
+  readonly stateRoot: string;
+}
+
+function parseStatusArgs(args: readonly string[]): StatusOptions | undefined {
+  if (args.length !== 2 || args[0] !== "--state-root" || args[1] === undefined) {
+    return undefined;
+  }
+
+  return {
+    stateRoot: args[1],
+  };
+}
+
+interface ExplainOptions {
+  readonly stateRoot: string;
+  readonly stableWorkItemId?: string;
+}
+
+function parseExplainArgs(args: readonly string[]): ExplainOptions | undefined {
+  if (args.length !== 2 && args.length !== 4) {
+    return undefined;
+  }
+
+  if (args[0] !== "--state-root" || args[1] === undefined) {
+    return undefined;
+  }
+
+  if (args.length === 2) {
+    return {
+      stateRoot: args[1],
+    };
+  }
+
+  if (args[2] !== "--issue" || args[3] === undefined) {
+    return undefined;
+  }
+
+  return {
+    stateRoot: args[1],
+    stableWorkItemId: args[3],
   };
 }
 

--- a/src/lane/index.ts
+++ b/src/lane/index.ts
@@ -907,6 +907,7 @@ export async function getLaneRunStatus(stateRoot: string): Promise<LaneRunOperat
 
   try {
     queueRecords = await readLaneRunQueueRecords(stateRoot);
+    await assertLaneRunLocksAreReferencedByQueue(stateRoot, queueRecords);
   } catch (error) {
     if (isMalformedLaneRunStateError(error)) {
       return createMalformedLaneRunStatus();
@@ -966,6 +967,7 @@ export async function explainLaneRun(
 
     try {
       const queueRecords = await readLaneRunQueueRecords(stateRoot);
+      await assertLaneRunLocksAreReferencedByQueue(stateRoot, queueRecords);
       const record = queueRecords.find(
         (candidate) => candidate.stableWorkItemId === input.stableWorkItemId,
       );
@@ -1552,6 +1554,64 @@ async function readLaneRunQueueRecords(stateRoot: string): Promise<readonly Lane
   });
 
   return records;
+}
+
+async function assertLaneRunLocksAreReferencedByQueue(
+  stateRoot: string,
+  queueRecords: readonly LaneRunQueueRecord[],
+): Promise<void> {
+  const queuedStableWorkItemIds = new Set(queueRecords.map((record) => record.stableWorkItemId));
+
+  for (const stableWorkItemId of await readLaneRunLockStableWorkItemIds(stateRoot)) {
+    await readLaneRunLock(stateRoot, stableWorkItemId);
+
+    if (!queuedStableWorkItemIds.has(stableWorkItemId)) {
+      throw new Error("Lane run lock entry is malformed.");
+    }
+  }
+}
+
+async function readLaneRunLockStableWorkItemIds(stateRoot: string): Promise<readonly string[]> {
+  const resolvedRoot = path.resolve(stateRoot);
+  const realRoot = await resolveCanonicalStateRoot(stateRoot);
+  const lockRoot = path.join(resolvedRoot, "lane-run-locks");
+
+  await assertExistingPathSafe(realRoot, lockRoot, "directory");
+
+  const entries = await readdir(lockRoot, { withFileTypes: true }).catch((error: unknown) => {
+    if (isNodeError(error) && error.code === "ENOENT") {
+      return [];
+    }
+
+    throw error;
+  });
+  const stableWorkItemIds: string[] = [];
+
+  for (const entry of entries) {
+    if (!entry.name.endsWith(".json")) {
+      continue;
+    }
+
+    const stableWorkItemId = entry.name.slice(0, -".json".length);
+
+    if (!isSafeStableWorkItemId(stableWorkItemId)) {
+      throw new Error("Lane run lock entry is malformed.");
+    }
+
+    const lockPath = path.join(lockRoot, entry.name);
+
+    if (!entry.isFile()) {
+      const stats = await lstat(lockPath);
+
+      if (!stats.isFile()) {
+        throw new Error("Lane run lock entry is malformed.");
+      }
+    }
+
+    stableWorkItemIds.push(stableWorkItemId);
+  }
+
+  return stableWorkItemIds;
 }
 
 function compareIsoDateTimeInstants(left: string, right: string): number {

--- a/src/lane/index.ts
+++ b/src/lane/index.ts
@@ -1556,13 +1556,14 @@ async function createLaneRunOperatorStatusItem(
   stateRoot: string,
   record: LaneRunQueueRecord,
 ): Promise<LaneRunOperatorStatusItem> {
-  const lock = resolveOperatorProjectionLock(
+  const effectiveLock = resolveOperatorEffectiveLock(
     record,
     await readOptionalLaneRunLock(stateRoot, record.stableWorkItemId),
   );
   const blockerReason = publicSafeDiagnosticText(record.metadata.blockerReason);
-  const verificationState = resolveOperatorVerificationState(record, lock, blockerReason);
-  const laneState = blockerReason === undefined ? resolveOperatorLaneState(record, lock) : "blocked";
+  const verificationState = resolveOperatorVerificationState(record, effectiveLock, blockerReason);
+  const laneState =
+    blockerReason === undefined ? resolveOperatorLaneState(record, effectiveLock) : "blocked";
 
   return {
     selectedIssue: resolveSelectedIssue(record),
@@ -1571,13 +1572,13 @@ async function createLaneRunOperatorStatusItem(
     laneState,
     verificationState,
     blockerReason,
-    nextOperatorAction: resolveNextOperatorAction(record, lock, blockerReason),
+    nextOperatorAction: resolveNextOperatorAction(record, effectiveLock, blockerReason),
     activeLock:
-      lock === undefined
+      effectiveLock === undefined
         ? undefined
         : {
-            laneRunId: lock.laneRunId,
-            status: lock.status,
+            laneRunId: effectiveLock.laneRunId,
+            status: effectiveLock.status,
           },
   };
 }
@@ -1607,7 +1608,7 @@ function resolveOperatorLaneState(
   return record.status;
 }
 
-function resolveOperatorProjectionLock(
+function resolveOperatorEffectiveLock(
   record: LaneRunQueueRecord,
   lock: LaneRunLock | undefined,
 ): LaneRunLock | undefined {
@@ -1615,7 +1616,11 @@ function resolveOperatorProjectionLock(
     return lock;
   }
 
-  return isStaleQueueRecordForTerminalLock(record, lock) ? lock : undefined;
+  if (isStaleQueueRecordForTerminalLock(record, lock)) {
+    return lock;
+  }
+
+  return undefined;
 }
 
 function resolveOperatorVerificationState(
@@ -1790,6 +1795,14 @@ function isMalformedLaneRunStateError(error: unknown): boolean {
     return false;
   }
 
+  if (
+    isNodeError(error) &&
+    typeof error.code === "string" &&
+    malformedLaneRunStateErrorCodes.has(error.code)
+  ) {
+    return true;
+  }
+
   return (
     /Lane run .*malformed|Unexpected end of JSON|not valid JSON/.test(error.message) ||
     /^Configured state root must (?:exist|be a real directory)/.test(error.message) ||
@@ -1797,6 +1810,8 @@ function isMalformedLaneRunStateError(error: unknown): boolean {
     /^Lane run (?:durable )?state file (?:path must|changed during access)/.test(error.message)
   );
 }
+
+const malformedLaneRunStateErrorCodes = new Set(["EISDIR", "ENOTDIR"]);
 
 async function readOptionalLaneRunQueueRecord(
   stateRoot: string,

--- a/src/lane/index.ts
+++ b/src/lane/index.ts
@@ -1500,6 +1500,9 @@ async function readLaneRunQueueRecords(stateRoot: string): Promise<readonly Lane
   const resolvedRoot = path.resolve(stateRoot);
   const realRoot = await resolveCanonicalStateRoot(stateRoot);
   const queueRoot = path.join(resolvedRoot, "lane-run-queue");
+
+  await assertExistingPathSafe(realRoot, queueRoot, "directory");
+
   const entries = await readdir(queueRoot, { withFileTypes: true }).catch((error: unknown) => {
     if (isNodeError(error) && error.code === "ENOENT") {
       return [];
@@ -1509,17 +1512,19 @@ async function readLaneRunQueueRecords(stateRoot: string): Promise<readonly Lane
   });
   const records: LaneRunQueueRecord[] = [];
 
-  await assertExistingPathSafe(realRoot, queueRoot, "directory");
-
   for (const entry of entries) {
-    if (!entry.isFile() || !entry.name.endsWith(".json")) {
+    if (!entry.name.endsWith(".json")) {
       continue;
+    }
+
+    if (!entry.isFile()) {
+      throw new Error("Lane run queue entry is malformed.");
     }
 
     const stableWorkItemId = entry.name.slice(0, -".json".length);
 
     if (!isSafeStableWorkItemId(stableWorkItemId)) {
-      continue;
+      throw new Error("Lane run queue entry is malformed.");
     }
 
     records.push(await readLaneRunQueueRecord(stateRoot, stableWorkItemId));
@@ -1744,9 +1749,19 @@ function createMalformedLaneRunExplanation(
 }
 
 function isMalformedLaneRunStateError(error: unknown): boolean {
+  if (error instanceof SyntaxError) {
+    return true;
+  }
+
+  if (!(error instanceof Error)) {
+    return false;
+  }
+
   return (
-    error instanceof SyntaxError ||
-    (error instanceof Error && /Lane run .*malformed|Unexpected end of JSON|not valid JSON/.test(error.message))
+    /Lane run .*malformed|Unexpected end of JSON|not valid JSON/.test(error.message) ||
+    /^Configured state root must (?:exist|be a real directory)/.test(error.message) ||
+    /^Lane run state (?:paths|directory path|file path) must /.test(error.message) ||
+    /^Lane run (?:durable )?state file (?:path must|changed during access)/.test(error.message)
   );
 }
 

--- a/src/lane/index.ts
+++ b/src/lane/index.ts
@@ -938,14 +938,14 @@ export async function getLaneRunStatus(stateRoot: string): Promise<LaneRunOperat
 
     throw error;
   }
-  const blockedItem = queue.find((item) => item.laneState === "blocked");
+  const blockedItem = queue.find((item) => isBlockedOperatorStatusItem(item));
 
   if (blockedItem !== undefined) {
     return {
       schemaVersion: "ensen.lane-run-status.v1",
       state: "blocked",
       queue,
-      blockerReason: blockedItem.blockerReason ?? "one or more lane runs are blocked",
+      blockerReason: resolveBlockedOperatorStatusReason(blockedItem),
       nextOperatorAction: blockedItem.nextOperatorAction,
     };
   }
@@ -962,14 +962,23 @@ export async function explainLaneRun(
   input: ExplainLaneRunInput = {},
 ): Promise<LaneRunOperatorExplanation> {
   if (input.stableWorkItemId !== undefined) {
+    assertSafeStableWorkItemId(input.stableWorkItemId);
+
     try {
-      assertSafeStableWorkItemId(input.stableWorkItemId);
-      const record = await readLaneRunQueueRecord(stateRoot, input.stableWorkItemId);
+      const queueRecords = await readLaneRunQueueRecords(stateRoot);
+      const record = queueRecords.find(
+        (candidate) => candidate.stableWorkItemId === input.stableWorkItemId,
+      );
+
+      if (record === undefined) {
+        return createRequestedIssueNotFoundExplanation(input.stableWorkItemId);
+      }
+
       const item = await createLaneRunOperatorStatusItem(stateRoot, record);
 
       return {
         schemaVersion: "ensen.lane-run-explain.v1",
-        state: item.laneState === "blocked" ? "blocked" : "ok",
+        state: isBlockedOperatorStatusItem(item) ? "blocked" : "ok",
         selectedIssue: item.selectedIssue,
         stableWorkItemId: item.stableWorkItemId,
         laneId: item.laneId,
@@ -982,10 +991,6 @@ export async function explainLaneRun(
     } catch (error) {
       if (isMalformedLaneRunStateError(error)) {
         return createMalformedLaneRunExplanation(input.stableWorkItemId);
-      }
-
-      if (isNodeError(error) && error.code === "ENOENT") {
-        return createRequestedIssueNotFoundExplanation(input.stableWorkItemId);
       }
 
       throw error;
@@ -1003,7 +1008,7 @@ export async function explainLaneRun(
 
   return {
     schemaVersion: "ensen.lane-run-explain.v1",
-    state: selected.laneState === "blocked" ? "blocked" : "ok",
+    state: isBlockedOperatorStatusItem(selected) ? "blocked" : "ok",
     selectedIssue: selected.selectedIssue,
     stableWorkItemId: selected.stableWorkItemId,
     laneId: selected.laneId,
@@ -1531,7 +1536,7 @@ async function readLaneRunQueueRecords(stateRoot: string): Promise<readonly Lane
   }
 
   records.sort((left, right) => {
-    const queuedComparison = left.queuedAt.localeCompare(right.queuedAt);
+    const queuedComparison = compareIsoDateTimeInstants(left.queuedAt, right.queuedAt);
 
     if (queuedComparison !== 0) {
       return queuedComparison;
@@ -1541,6 +1546,10 @@ async function readLaneRunQueueRecords(stateRoot: string): Promise<readonly Lane
   });
 
   return records;
+}
+
+function compareIsoDateTimeInstants(left: string, right: string): number {
+  return Date.parse(left) - Date.parse(right);
 }
 
 async function createLaneRunOperatorStatusItem(
@@ -1677,10 +1686,34 @@ function selectDefaultLaneRunExplanationItem(
   queue: readonly LaneRunOperatorStatusItem[],
 ): LaneRunOperatorStatusItem | undefined {
   return (
-    queue.find((item) => item.laneState === "blocked") ??
+    queue.find((item) => isBlockedOperatorStatusItem(item)) ??
     queue.find((item) => item.nextOperatorAction !== "no action required") ??
     queue[0]
   );
+}
+
+function isBlockedOperatorStatusItem(item: LaneRunOperatorStatusItem): boolean {
+  return (
+    item.laneState === "blocked" ||
+    item.laneState === "revoked" ||
+    item.laneState === "superseded"
+  );
+}
+
+function resolveBlockedOperatorStatusReason(item: LaneRunOperatorStatusItem): string {
+  if (item.blockerReason !== undefined) {
+    return item.blockerReason;
+  }
+
+  if (item.laneState === "revoked") {
+    return "lane run was revoked";
+  }
+
+  if (item.laneState === "superseded") {
+    return "lane run was superseded";
+  }
+
+  return "one or more lane runs are blocked";
 }
 
 function publicSafeDiagnosticText(value: string | undefined): string | undefined {

--- a/src/lane/index.ts
+++ b/src/lane/index.ts
@@ -903,7 +903,17 @@ export async function readLaneRunLock(stateRoot: string, stableWorkItemId: strin
 }
 
 export async function getLaneRunStatus(stateRoot: string): Promise<LaneRunOperatorStatus> {
-  const queueRecords = await readLaneRunQueueRecords(stateRoot);
+  let queueRecords: readonly LaneRunQueueRecord[];
+
+  try {
+    queueRecords = await readLaneRunQueueRecords(stateRoot);
+  } catch (error) {
+    if (isMalformedLaneRunStateError(error)) {
+      return createMalformedLaneRunStatus();
+    }
+
+    throw error;
+  }
 
   if (queueRecords.length === 0) {
     return {
@@ -915,12 +925,35 @@ export async function getLaneRunStatus(stateRoot: string): Promise<LaneRunOperat
     };
   }
 
+  let queue: readonly LaneRunOperatorStatusItem[];
+
+  try {
+    queue = await Promise.all(
+      queueRecords.map(async (record) => createLaneRunOperatorStatusItem(stateRoot, record)),
+    );
+  } catch (error) {
+    if (isMalformedLaneRunStateError(error)) {
+      return createMalformedLaneRunStatus();
+    }
+
+    throw error;
+  }
+  const blockedItem = queue.find((item) => item.laneState === "blocked");
+
+  if (blockedItem !== undefined) {
+    return {
+      schemaVersion: "ensen.lane-run-status.v1",
+      state: "blocked",
+      queue,
+      blockerReason: blockedItem.blockerReason ?? "one or more lane runs are blocked",
+      nextOperatorAction: blockedItem.nextOperatorAction,
+    };
+  }
+
   return {
     schemaVersion: "ensen.lane-run-status.v1",
     state: "ok",
-    queue: await Promise.all(
-      queueRecords.map(async (record) => createLaneRunOperatorStatusItem(stateRoot, record)),
-    ),
+    queue,
   };
 }
 
@@ -960,10 +993,12 @@ export async function explainLaneRun(
   }
 
   const status = await getLaneRunStatus(stateRoot);
-  const selected = status.queue[0];
+  const selected = selectDefaultLaneRunExplanationItem(status.queue);
 
   if (selected === undefined) {
-    return createNoSelectedIssueExplanation();
+    return status.blockerReason === "lane run state is malformed"
+      ? createMalformedLaneRunExplanation(undefined)
+      : createNoSelectedIssueExplanation();
   }
 
   return {
@@ -1592,6 +1627,18 @@ function resolveNextOperatorAction(
     return `wait for active lane run ${lock.laneRunId} to finish`;
   }
 
+  if (lock?.status === "completed") {
+    return "no action required";
+  }
+
+  if (lock?.status === "revoked") {
+    return "inspect revocation before rediscovery";
+  }
+
+  if (lock?.status === "superseded") {
+    return "enqueue a fresh lane run if this issue is still selected";
+  }
+
   if (record.status === "queued") {
     return "claim queued lane run when ready";
   }
@@ -1605,6 +1652,12 @@ function resolveNextOperatorAction(
   }
 
   return "enqueue a fresh lane run if this issue is still selected";
+}
+
+function selectDefaultLaneRunExplanationItem(
+  queue: readonly LaneRunOperatorStatusItem[],
+): LaneRunOperatorStatusItem | undefined {
+  return queue.find((item) => item.nextOperatorAction !== "no action required") ?? queue[0];
 }
 
 function publicSafeDiagnosticText(value: string | undefined): string | undefined {
@@ -1635,6 +1688,16 @@ function createNoSelectedIssueExplanation(): LaneRunOperatorExplanation {
   };
 }
 
+function createMalformedLaneRunStatus(): LaneRunOperatorStatus {
+  return {
+    schemaVersion: "ensen.lane-run-status.v1",
+    state: "blocked",
+    queue: [],
+    blockerReason: "lane run state is malformed",
+    nextOperatorAction: "repair or remove malformed lane state before continuing",
+  };
+}
+
 function createMalformedLaneRunExplanation(
   stableWorkItemId: string | undefined,
 ): LaneRunOperatorExplanation {
@@ -1650,7 +1713,10 @@ function createMalformedLaneRunExplanation(
 }
 
 function isMalformedLaneRunStateError(error: unknown): boolean {
-  return error instanceof Error && /Lane run .*malformed|Unexpected end of JSON|not valid JSON/.test(error.message);
+  return (
+    error instanceof SyntaxError ||
+    (error instanceof Error && /Lane run .*malformed|Unexpected end of JSON|not valid JSON/.test(error.message))
+  );
 }
 
 async function readOptionalLaneRunQueueRecord(

--- a/src/lane/index.ts
+++ b/src/lane/index.ts
@@ -1,7 +1,7 @@
 import { constants } from "node:fs";
 import type { Stats } from "node:fs";
 import { randomUUID } from "node:crypto";
-import { lstat, mkdir, open, realpath, rename, rm, rmdir, utimes } from "node:fs/promises";
+import { lstat, mkdir, open, readdir, realpath, rename, rm, rmdir, utimes } from "node:fs/promises";
 import type { FileHandle } from "node:fs/promises";
 import path from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
@@ -14,6 +14,7 @@ import {
 } from "../core/index.js";
 import type { LaneEvidenceRefs } from "../evidence/index.js";
 import type { EvidenceBundleRef } from "../protocol/index.js";
+import { containsUnsafePublicArtifactText, sanitizePublicDiagnosticMessage } from "../safety/public-artifact.js";
 import { sampleLocalWorkItem } from "../work-item/index.js";
 
 export type LaneRunStatus =
@@ -152,6 +153,55 @@ export interface LaneRunLock {
   readonly claimedBy: string;
   readonly releasedAt?: string;
   readonly startsAgentExecution: false;
+}
+
+export type LaneRunOperatorVerificationState =
+  | "not-started"
+  | "running"
+  | "blocked"
+  | "succeeded"
+  | "unknown";
+
+export interface LaneRunOperatorStatusItem {
+  readonly selectedIssue?: string;
+  readonly stableWorkItemId: string;
+  readonly laneId?: string;
+  readonly laneState: LaneRunQueueStatus | LaneRunLockStatus | "blocked";
+  readonly verificationState: LaneRunOperatorVerificationState;
+  readonly blockerReason?: string;
+  readonly nextOperatorAction: string;
+  readonly activeLock?: {
+    readonly laneRunId: string;
+    readonly status: LaneRunLockStatus;
+  };
+}
+
+export interface LaneRunOperatorStatus {
+  readonly schemaVersion: "ensen.lane-run-status.v1";
+  readonly state: "ok" | "blocked";
+  readonly queue: readonly LaneRunOperatorStatusItem[];
+  readonly blockerReason?: string;
+  readonly nextOperatorAction?: string;
+}
+
+export interface ExplainLaneRunInput {
+  readonly stableWorkItemId?: string;
+}
+
+export interface LaneRunOperatorExplanation {
+  readonly schemaVersion: "ensen.lane-run-explain.v1";
+  readonly state: "ok" | "blocked";
+  readonly selectedIssue?: string;
+  readonly stableWorkItemId?: string;
+  readonly laneId?: string;
+  readonly laneState: LaneRunQueueStatus | LaneRunLockStatus | "blocked";
+  readonly verificationState: LaneRunOperatorVerificationState;
+  readonly blockerReason?: string;
+  readonly nextOperatorAction: string;
+  readonly activeLock?: {
+    readonly laneRunId: string;
+    readonly status: LaneRunLockStatus;
+  };
 }
 
 export interface EnqueueLaneRunInput {
@@ -852,6 +902,84 @@ export async function readLaneRunLock(stateRoot: string, stableWorkItemId: strin
   return lock;
 }
 
+export async function getLaneRunStatus(stateRoot: string): Promise<LaneRunOperatorStatus> {
+  const queueRecords = await readLaneRunQueueRecords(stateRoot);
+
+  if (queueRecords.length === 0) {
+    return {
+      schemaVersion: "ensen.lane-run-status.v1",
+      state: "blocked",
+      queue: [],
+      blockerReason: "no selected issue",
+      nextOperatorAction: "select or enqueue a lane run before claiming readiness",
+    };
+  }
+
+  return {
+    schemaVersion: "ensen.lane-run-status.v1",
+    state: "ok",
+    queue: await Promise.all(
+      queueRecords.map(async (record) => createLaneRunOperatorStatusItem(stateRoot, record)),
+    ),
+  };
+}
+
+export async function explainLaneRun(
+  stateRoot: string,
+  input: ExplainLaneRunInput = {},
+): Promise<LaneRunOperatorExplanation> {
+  if (input.stableWorkItemId !== undefined) {
+    try {
+      assertSafeStableWorkItemId(input.stableWorkItemId);
+      const record = await readLaneRunQueueRecord(stateRoot, input.stableWorkItemId);
+      const item = await createLaneRunOperatorStatusItem(stateRoot, record);
+
+      return {
+        schemaVersion: "ensen.lane-run-explain.v1",
+        state: item.laneState === "blocked" ? "blocked" : "ok",
+        selectedIssue: item.selectedIssue,
+        stableWorkItemId: item.stableWorkItemId,
+        laneId: item.laneId,
+        laneState: item.laneState,
+        verificationState: item.verificationState,
+        blockerReason: item.blockerReason,
+        nextOperatorAction: item.nextOperatorAction,
+        activeLock: item.activeLock,
+      };
+    } catch (error) {
+      if (isMalformedLaneRunStateError(error)) {
+        return createMalformedLaneRunExplanation(input.stableWorkItemId);
+      }
+
+      if (isNodeError(error) && error.code === "ENOENT") {
+        return createNoSelectedIssueExplanation();
+      }
+
+      throw error;
+    }
+  }
+
+  const status = await getLaneRunStatus(stateRoot);
+  const selected = status.queue[0];
+
+  if (selected === undefined) {
+    return createNoSelectedIssueExplanation();
+  }
+
+  return {
+    schemaVersion: "ensen.lane-run-explain.v1",
+    state: selected.laneState === "blocked" ? "blocked" : "ok",
+    selectedIssue: selected.selectedIssue,
+    stableWorkItemId: selected.stableWorkItemId,
+    laneId: selected.laneId,
+    laneState: selected.laneState,
+    verificationState: selected.verificationState,
+    blockerReason: selected.blockerReason,
+    nextOperatorAction: selected.nextOperatorAction,
+    activeLock: selected.activeLock,
+  };
+}
+
 export async function completeLaneRunLock(
   stateRoot: string,
   input: CompleteLaneRunLockInput,
@@ -1331,6 +1459,198 @@ async function readOptionalLaneRunLock(
 
     throw error;
   }
+}
+
+async function readLaneRunQueueRecords(stateRoot: string): Promise<readonly LaneRunQueueRecord[]> {
+  const resolvedRoot = path.resolve(stateRoot);
+  const realRoot = await resolveCanonicalStateRoot(stateRoot);
+  const queueRoot = path.join(resolvedRoot, "lane-run-queue");
+  const entries = await readdir(queueRoot, { withFileTypes: true }).catch((error: unknown) => {
+    if (isNodeError(error) && error.code === "ENOENT") {
+      return [];
+    }
+
+    throw error;
+  });
+  const records: LaneRunQueueRecord[] = [];
+
+  await assertExistingPathSafe(realRoot, queueRoot, "directory");
+
+  for (const entry of entries) {
+    if (!entry.isFile() || !entry.name.endsWith(".json")) {
+      continue;
+    }
+
+    const stableWorkItemId = entry.name.slice(0, -".json".length);
+
+    if (!isSafeStableWorkItemId(stableWorkItemId)) {
+      continue;
+    }
+
+    records.push(await readLaneRunQueueRecord(stateRoot, stableWorkItemId));
+  }
+
+  records.sort((left, right) => {
+    const queuedComparison = left.queuedAt.localeCompare(right.queuedAt);
+
+    if (queuedComparison !== 0) {
+      return queuedComparison;
+    }
+
+    return left.stableWorkItemId.localeCompare(right.stableWorkItemId);
+  });
+
+  return records;
+}
+
+async function createLaneRunOperatorStatusItem(
+  stateRoot: string,
+  record: LaneRunQueueRecord,
+): Promise<LaneRunOperatorStatusItem> {
+  const lock = await readOptionalLaneRunLock(stateRoot, record.stableWorkItemId);
+  const blockerReason = publicSafeDiagnosticText(record.metadata.blockerReason);
+  const verificationState = resolveOperatorVerificationState(record, lock, blockerReason);
+  const laneState = blockerReason === undefined ? resolveOperatorLaneState(record, lock) : "blocked";
+
+  return {
+    selectedIssue: resolveSelectedIssue(record),
+    stableWorkItemId: record.stableWorkItemId,
+    laneId: record.laneId,
+    laneState,
+    verificationState,
+    blockerReason,
+    nextOperatorAction: resolveNextOperatorAction(record, lock, blockerReason),
+    activeLock:
+      lock === undefined
+        ? undefined
+        : {
+            laneRunId: lock.laneRunId,
+            status: lock.status,
+          },
+  };
+}
+
+function resolveSelectedIssue(record: LaneRunQueueRecord): string {
+  const issueNumber = record.metadata.issueNumber;
+
+  if (issueNumber !== undefined && /^[1-9][0-9]{0,8}$/.test(issueNumber)) {
+    return `#${issueNumber}`;
+  }
+
+  return record.stableWorkItemId;
+}
+
+function resolveOperatorLaneState(
+  record: LaneRunQueueRecord,
+  lock: LaneRunLock | undefined,
+): LaneRunQueueStatus | LaneRunLockStatus {
+  if (lock?.active === true) {
+    return "active";
+  }
+
+  if (lock !== undefined && lock.status !== "active") {
+    return lock.status;
+  }
+
+  return record.status;
+}
+
+function resolveOperatorVerificationState(
+  record: LaneRunQueueRecord,
+  lock: LaneRunLock | undefined,
+  blockerReason: string | undefined,
+): LaneRunOperatorVerificationState {
+  if (blockerReason !== undefined) {
+    return "blocked";
+  }
+
+  if (lock?.status === "completed" || record.status === "completed") {
+    return "succeeded";
+  }
+
+  if (lock?.active === true) {
+    return "running";
+  }
+
+  if (record.status === "queued") {
+    return "not-started";
+  }
+
+  return "unknown";
+}
+
+function resolveNextOperatorAction(
+  record: LaneRunQueueRecord,
+  lock: LaneRunLock | undefined,
+  blockerReason: string | undefined,
+): string {
+  if (blockerReason !== undefined) {
+    return "resolve blocker before claiming or running the lane";
+  }
+
+  if (lock?.active === true) {
+    return `wait for active lane run ${lock.laneRunId} to finish`;
+  }
+
+  if (record.status === "queued") {
+    return "claim queued lane run when ready";
+  }
+
+  if (record.status === "completed") {
+    return "no action required";
+  }
+
+  if (record.status === "revoked") {
+    return "inspect revocation before rediscovery";
+  }
+
+  return "enqueue a fresh lane run if this issue is still selected";
+}
+
+function publicSafeDiagnosticText(value: string | undefined): string | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  const sanitized = sanitizePublicDiagnosticMessage(value).replaceAll(
+    "<secret-like-value>",
+    "<redacted>",
+  );
+
+  if (containsUnsafePublicArtifactText(sanitized)) {
+    return "<redacted>";
+  }
+
+  return sanitized;
+}
+
+function createNoSelectedIssueExplanation(): LaneRunOperatorExplanation {
+  return {
+    schemaVersion: "ensen.lane-run-explain.v1",
+    state: "blocked",
+    laneState: "blocked",
+    verificationState: "unknown",
+    blockerReason: "no selected issue",
+    nextOperatorAction: "select or enqueue a lane run before claiming readiness",
+  };
+}
+
+function createMalformedLaneRunExplanation(
+  stableWorkItemId: string | undefined,
+): LaneRunOperatorExplanation {
+  return {
+    schemaVersion: "ensen.lane-run-explain.v1",
+    state: "blocked",
+    stableWorkItemId,
+    laneState: "blocked",
+    verificationState: "unknown",
+    blockerReason: "lane run state is malformed",
+    nextOperatorAction: "repair or remove malformed lane state before continuing",
+  };
+}
+
+function isMalformedLaneRunStateError(error: unknown): boolean {
+  return error instanceof Error && /Lane run .*malformed|Unexpected end of JSON|not valid JSON/.test(error.message);
 }
 
 async function readOptionalLaneRunQueueRecord(

--- a/src/lane/index.ts
+++ b/src/lane/index.ts
@@ -985,7 +985,7 @@ export async function explainLaneRun(
       }
 
       if (isNodeError(error) && error.code === "ENOENT") {
-        return createNoSelectedIssueExplanation();
+        return createRequestedIssueNotFoundExplanation(input.stableWorkItemId);
       }
 
       throw error;
@@ -1542,7 +1542,10 @@ async function createLaneRunOperatorStatusItem(
   stateRoot: string,
   record: LaneRunQueueRecord,
 ): Promise<LaneRunOperatorStatusItem> {
-  const lock = await readOptionalLaneRunLock(stateRoot, record.stableWorkItemId);
+  const lock = resolveOperatorProjectionLock(
+    record,
+    await readOptionalLaneRunLock(stateRoot, record.stableWorkItemId),
+  );
   const blockerReason = publicSafeDiagnosticText(record.metadata.blockerReason);
   const verificationState = resolveOperatorVerificationState(record, lock, blockerReason);
   const laneState = blockerReason === undefined ? resolveOperatorLaneState(record, lock) : "blocked";
@@ -1588,6 +1591,17 @@ function resolveOperatorLaneState(
   }
 
   return record.status;
+}
+
+function resolveOperatorProjectionLock(
+  record: LaneRunQueueRecord,
+  lock: LaneRunLock | undefined,
+): LaneRunLock | undefined {
+  if (lock === undefined || lock.active === true) {
+    return lock;
+  }
+
+  return isStaleQueueRecordForTerminalLock(record, lock) ? lock : undefined;
 }
 
 function resolveOperatorVerificationState(
@@ -1657,7 +1671,11 @@ function resolveNextOperatorAction(
 function selectDefaultLaneRunExplanationItem(
   queue: readonly LaneRunOperatorStatusItem[],
 ): LaneRunOperatorStatusItem | undefined {
-  return queue.find((item) => item.nextOperatorAction !== "no action required") ?? queue[0];
+  return (
+    queue.find((item) => item.laneState === "blocked") ??
+    queue.find((item) => item.nextOperatorAction !== "no action required") ??
+    queue[0]
+  );
 }
 
 function publicSafeDiagnosticText(value: string | undefined): string | undefined {
@@ -1685,6 +1703,19 @@ function createNoSelectedIssueExplanation(): LaneRunOperatorExplanation {
     verificationState: "unknown",
     blockerReason: "no selected issue",
     nextOperatorAction: "select or enqueue a lane run before claiming readiness",
+  };
+}
+
+function createRequestedIssueNotFoundExplanation(stableWorkItemId: string): LaneRunOperatorExplanation {
+  return {
+    schemaVersion: "ensen.lane-run-explain.v1",
+    state: "blocked",
+    selectedIssue: stableWorkItemId,
+    stableWorkItemId,
+    laneState: "blocked",
+    verificationState: "unknown",
+    blockerReason: "requested issue is not queued",
+    nextOperatorAction: "select an existing lane run or enqueue the requested issue before claiming readiness",
   };
 }
 

--- a/src/lane/index.ts
+++ b/src/lane/index.ts
@@ -1522,14 +1522,20 @@ async function readLaneRunQueueRecords(stateRoot: string): Promise<readonly Lane
       continue;
     }
 
-    if (!entry.isFile()) {
-      throw new Error("Lane run queue entry is malformed.");
-    }
-
     const stableWorkItemId = entry.name.slice(0, -".json".length);
 
     if (!isSafeStableWorkItemId(stableWorkItemId)) {
       throw new Error("Lane run queue entry is malformed.");
+    }
+
+    const queuePath = path.join(queueRoot, entry.name);
+
+    if (!entry.isFile()) {
+      const stats = await lstat(queuePath);
+
+      if (!stats.isFile()) {
+        throw new Error("Lane run queue entry is malformed.");
+      }
     }
 
     records.push(await readLaneRunQueueRecord(stateRoot, stableWorkItemId));
@@ -1542,7 +1548,7 @@ async function readLaneRunQueueRecords(stateRoot: string): Promise<readonly Lane
       return queuedComparison;
     }
 
-    return left.stableWorkItemId.localeCompare(right.stableWorkItemId);
+    return compareStableWorkItemIds(left.stableWorkItemId, right.stableWorkItemId);
   });
 
   return records;
@@ -1550,6 +1556,18 @@ async function readLaneRunQueueRecords(stateRoot: string): Promise<readonly Lane
 
 function compareIsoDateTimeInstants(left: string, right: string): number {
   return Date.parse(left) - Date.parse(right);
+}
+
+function compareStableWorkItemIds(left: string, right: string): number {
+  if (left < right) {
+    return -1;
+  }
+
+  if (left > right) {
+    return 1;
+  }
+
+  return 0;
 }
 
 async function createLaneRunOperatorStatusItem(
@@ -1805,6 +1823,10 @@ function isMalformedLaneRunStateError(error: unknown): boolean {
 
   return (
     /Lane run .*malformed|Unexpected end of JSON|not valid JSON/.test(error.message) ||
+    /^Lane run (?:queue record|lock|state) identifiers do not match the requested (?:work item|lane run)\.$/.test(
+      error.message,
+    ) ||
+    /^Lane run queue record diagnostics do not match authoritative queue state\.$/.test(error.message) ||
     /^Configured state root must (?:exist|be a real directory)/.test(error.message) ||
     /^Lane run state (?:paths|directory path|file path) must /.test(error.message) ||
     /^Lane run (?:durable )?state file (?:path must|changed during access)/.test(error.message)

--- a/test/lane-run-status-explain.test.ts
+++ b/test/lane-run-status-explain.test.ts
@@ -1,0 +1,171 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { promisify } from "node:util";
+
+import {
+  claimQueuedLaneRun,
+  enqueueLaneRun,
+  explainLaneRun,
+  getLaneRunStatus,
+  resolveLaneRunQueueRecordPath,
+} from "../src/lane/index.js";
+
+const execFileAsync = promisify(execFile);
+const queuedAt = "2026-05-22T00:00:00.000Z";
+const claimedAt = "2026-05-22T00:01:00.000Z";
+
+async function withStateRoot(callback: (stateRoot: string) => Promise<void>): Promise<void> {
+  const stateRoot = await mkdtemp(path.join(os.tmpdir(), "ensen-loop-state-"));
+
+  try {
+    await callback(stateRoot);
+  } finally {
+    await rm(stateRoot, { recursive: true, force: true });
+  }
+}
+
+test("status shows queued and active lock state without leaking local paths", async () => {
+  await withStateRoot(async (stateRoot) => {
+    await enqueueLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-111",
+      workItemId: "issue-111",
+      source: "github-issue",
+      laneId: "owner-dogfood",
+      repositoryClassification: "owner-controlled-dogfood",
+      queuedAt,
+      metadata: {
+        issueNumber: "111",
+      },
+    });
+    await claimQueuedLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-111",
+      laneRunId: "lane-run-111-a",
+      claimedBy: "operator-token=ghp_sampleSecretValue",
+      claimedAt,
+    });
+
+    const status = await getLaneRunStatus(stateRoot);
+
+    assert.deepEqual(status, {
+      schemaVersion: "ensen.lane-run-status.v1",
+      state: "ok",
+      queue: [
+        {
+          selectedIssue: "#111",
+          stableWorkItemId: "github-issue-111",
+          laneId: "owner-dogfood",
+          laneState: "active",
+          verificationState: "running",
+          blockerReason: undefined,
+          nextOperatorAction: "wait for active lane run lane-run-111-a to finish",
+          activeLock: {
+            laneRunId: "lane-run-111-a",
+            status: "active",
+          },
+        },
+      ],
+    });
+    assert.equal(JSON.stringify(status).includes(stateRoot), false);
+    assert.equal(JSON.stringify(status).includes("ghp_sampleSecretValue"), false);
+  });
+});
+
+test("explain fails closed when no selected issue exists", async () => {
+  await withStateRoot(async (stateRoot) => {
+    const explanation = await explainLaneRun(stateRoot);
+
+    assert.equal(explanation.state, "blocked");
+    assert.equal(explanation.laneState, "blocked");
+    assert.equal(explanation.verificationState, "unknown");
+    assert.equal(explanation.blockerReason, "no selected issue");
+    assert.equal(explanation.nextOperatorAction, "select or enqueue a lane run before claiming readiness");
+  });
+});
+
+test("explain identifies blocked active lane run and safe next action", async () => {
+  await withStateRoot(async (stateRoot) => {
+    await enqueueLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-111",
+      workItemId: "issue-111",
+      source: "github-issue",
+      laneId: "owner-dogfood",
+      repositoryClassification: "owner-controlled-dogfood",
+      queuedAt,
+      metadata: {
+        issueNumber: "111",
+        blockerReason: "verification token=ghp_sampleSecretValue failed",
+      },
+    });
+
+    const explanation = await explainLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-111",
+    });
+
+    assert.equal(explanation.selectedIssue, "#111");
+    assert.equal(explanation.laneState, "blocked");
+    assert.equal(explanation.verificationState, "blocked");
+    assert.equal(explanation.blockerReason, "verification <redacted> failed");
+    assert.equal(explanation.nextOperatorAction, "resolve blocker before claiming or running the lane");
+    assert.equal(JSON.stringify(explanation).includes("ghp_sampleSecretValue"), false);
+  });
+});
+
+test("malformed queue state is reported as blocked instead of ready", async () => {
+  await withStateRoot(async (stateRoot) => {
+    const queuePath = resolveLaneRunQueueRecordPath(stateRoot, "github-issue-111");
+    await mkdir(path.dirname(queuePath), { recursive: true });
+    await writeFile(queuePath, "{\"schemaVersion\":\"ensen.lane-run-queue.v1\"}\n", {
+      encoding: "utf8",
+    });
+
+    const explanation = await explainLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-111",
+    });
+
+    assert.equal(explanation.state, "blocked");
+    assert.equal(explanation.laneState, "blocked");
+    assert.equal(explanation.verificationState, "unknown");
+    assert.equal(explanation.blockerReason, "lane run state is malformed");
+    assert.equal(explanation.nextOperatorAction, "repair or remove malformed lane state before continuing");
+  });
+});
+
+test("CLI status and explain emit deterministic public-safe JSON", async () => {
+  await withStateRoot(async (stateRoot) => {
+    await enqueueLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-111",
+      workItemId: "issue-111",
+      source: "github-issue",
+      laneId: "owner-dogfood",
+      repositoryClassification: "owner-controlled-dogfood",
+      queuedAt,
+      metadata: {
+        issueNumber: "111",
+      },
+    });
+
+    const status = await execFileAsync(process.execPath, [
+      "dist/src/cli/index.js",
+      "status",
+      "--state-root",
+      stateRoot,
+    ]);
+    const explain = await execFileAsync(process.execPath, [
+      "dist/src/cli/index.js",
+      "explain",
+      "--state-root",
+      stateRoot,
+      "--issue",
+      "github-issue-111",
+    ]);
+
+    assert.equal(status.stderr, "");
+    assert.equal(explain.stderr, "");
+    assert.equal(JSON.stringify(JSON.parse(status.stdout)).includes(stateRoot), false);
+    assert.equal(JSON.parse(explain.stdout).nextOperatorAction, "claim queued lane run when ready");
+  });
+});

--- a/test/lane-run-status-explain.test.ts
+++ b/test/lane-run-status-explain.test.ts
@@ -332,6 +332,120 @@ test("CLI status returns structured blocked output for malformed queue shape", a
   });
 });
 
+test("issue-scoped explain fails closed when any queue record is malformed", async () => {
+  await withStateRoot(async (stateRoot) => {
+    await enqueueLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-111",
+      workItemId: "issue-111",
+      source: "github-issue",
+      laneId: "owner-dogfood",
+      repositoryClassification: "owner-controlled-dogfood",
+      queuedAt,
+      metadata: {
+        issueNumber: "111",
+      },
+    });
+    await writeFile(path.join(stateRoot, "lane-run-queue", "Github-Issue-112.json"), "{}\n", {
+      encoding: "utf8",
+    });
+
+    const explanation = await explainLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-111",
+    });
+
+    assert.equal(explanation.state, "blocked");
+    assert.equal(explanation.laneState, "blocked");
+    assert.equal(explanation.blockerReason, "lane run state is malformed");
+    assert.equal(explanation.nextOperatorAction, "repair or remove malformed lane state before continuing");
+  });
+});
+
+test("invalid issue-scoped explain input is not reported as malformed state", async () => {
+  await withStateRoot(async (stateRoot) => {
+    await assert.rejects(
+      () =>
+        explainLaneRun(stateRoot, {
+          stableWorkItemId: "Github-Issue-111",
+        }),
+      /Stable work item identifiers may only contain lowercase letters/,
+    );
+  });
+});
+
+test("status treats revoked and superseded queue states as blocked", async () => {
+  for (const terminalStatus of ["revoked", "superseded"] as const) {
+    await withStateRoot(async (stateRoot) => {
+      await enqueueLaneRun(stateRoot, {
+        stableWorkItemId: `github-issue-${terminalStatus}`,
+        workItemId: `issue-${terminalStatus}`,
+        source: "github-issue",
+        laneId: "owner-dogfood",
+        repositoryClassification: "owner-controlled-dogfood",
+        queuedAt,
+      });
+      const claim = await claimQueuedLaneRun(stateRoot, {
+        stableWorkItemId: `github-issue-${terminalStatus}`,
+        laneRunId: `lane-run-${terminalStatus}-a`,
+        claimedBy: "local-supervisor",
+        claimedAt,
+      });
+      await completeLaneRunLock(stateRoot, {
+        stableWorkItemId: `github-issue-${terminalStatus}`,
+        laneRunId: claim.lock.laneRunId,
+        completedAt: "2026-05-22T00:02:00.000Z",
+        terminalStatus,
+      });
+
+      const status = await getLaneRunStatus(stateRoot);
+      const explanation = await explainLaneRun(stateRoot, {
+        stableWorkItemId: `github-issue-${terminalStatus}`,
+      });
+
+      assert.equal(status.state, "blocked");
+      assert.equal(status.queue[0]?.laneState, terminalStatus);
+      assert.equal(status.blockerReason, `lane run was ${terminalStatus}`);
+      assert.equal(explanation.state, "blocked");
+      assert.equal(explanation.laneState, terminalStatus);
+    });
+  }
+});
+
+test("status orders queue records by timestamp instant before stable id", async () => {
+  await withStateRoot(async (stateRoot) => {
+    await enqueueLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-112",
+      workItemId: "issue-112",
+      source: "github-issue",
+      laneId: "owner-dogfood",
+      repositoryClassification: "owner-controlled-dogfood",
+      queuedAt: "2026-05-22T00:00:00Z",
+      metadata: {
+        issueNumber: "112",
+      },
+    });
+    await enqueueLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-111",
+      workItemId: "issue-111",
+      source: "github-issue",
+      laneId: "owner-dogfood",
+      repositoryClassification: "owner-controlled-dogfood",
+      queuedAt: "2026-05-22T00:30:00+01:00",
+      metadata: {
+        issueNumber: "111",
+      },
+    });
+
+    const status = await getLaneRunStatus(stateRoot);
+    const explanation = await explainLaneRun(stateRoot);
+
+    assert.deepEqual(
+      status.queue.map((item) => item.selectedIssue),
+      ["#111", "#112"],
+    );
+    assert.equal(explanation.selectedIssue, "#111");
+  });
+});
+
 test("explain without issue prefers blocked queue items over runnable work", async () => {
   await withStateRoot(async (stateRoot) => {
     await enqueueLaneRun(stateRoot, {

--- a/test/lane-run-status-explain.test.ts
+++ b/test/lane-run-status-explain.test.ts
@@ -194,6 +194,61 @@ test("syntactically invalid queue JSON is reported as malformed status and expla
   });
 });
 
+test("unsafe queue filenames are reported as malformed status and explanation", async () => {
+  await withStateRoot(async (stateRoot) => {
+    const queueRoot = path.join(stateRoot, "lane-run-queue");
+    await mkdir(queueRoot, { recursive: true });
+    await writeFile(path.join(queueRoot, "Github-Issue-111.json"), "{}\n", {
+      encoding: "utf8",
+    });
+
+    const status = await getLaneRunStatus(stateRoot);
+    const explanation = await explainLaneRun(stateRoot);
+
+    assert.equal(status.state, "blocked");
+    assert.equal(status.queue.length, 0);
+    assert.equal(status.blockerReason, "lane run state is malformed");
+    assert.equal(explanation.state, "blocked");
+    assert.equal(explanation.blockerReason, "lane run state is malformed");
+    assert.equal(explanation.nextOperatorAction, "repair or remove malformed lane state before continuing");
+  });
+});
+
+test("non-regular queue JSON entries are reported as malformed status and explanation", async () => {
+  await withStateRoot(async (stateRoot) => {
+    const queueRoot = path.join(stateRoot, "lane-run-queue");
+    await mkdir(path.join(queueRoot, "github-issue-111.json"), { recursive: true });
+
+    const status = await getLaneRunStatus(stateRoot);
+    const explanation = await explainLaneRun(stateRoot);
+
+    assert.equal(status.state, "blocked");
+    assert.equal(status.queue.length, 0);
+    assert.equal(status.blockerReason, "lane run state is malformed");
+    assert.equal(explanation.state, "blocked");
+    assert.equal(explanation.blockerReason, "lane run state is malformed");
+    assert.equal(explanation.nextOperatorAction, "repair or remove malformed lane state before continuing");
+  });
+});
+
+test("queue filesystem shape errors are reported as malformed status and explanation", async () => {
+  await withStateRoot(async (stateRoot) => {
+    await writeFile(path.join(stateRoot, "lane-run-queue"), "not a directory\n", {
+      encoding: "utf8",
+    });
+
+    const status = await getLaneRunStatus(stateRoot);
+    const explanation = await explainLaneRun(stateRoot);
+
+    assert.equal(status.state, "blocked");
+    assert.equal(status.queue.length, 0);
+    assert.equal(status.blockerReason, "lane run state is malformed");
+    assert.equal(explanation.state, "blocked");
+    assert.equal(explanation.blockerReason, "lane run state is malformed");
+    assert.equal(explanation.nextOperatorAction, "repair or remove malformed lane state before continuing");
+  });
+});
+
 test("explain without issue prefers blocked queue items over runnable work", async () => {
   await withStateRoot(async (stateRoot) => {
     await enqueueLaneRun(stateRoot, {

--- a/test/lane-run-status-explain.test.ts
+++ b/test/lane-run-status-explain.test.ts
@@ -311,6 +311,26 @@ test("queue filesystem shape errors are reported as malformed status and explana
   });
 });
 
+test("state root filesystem shape errors are reported as malformed status and explanation", async () => {
+  await withStateRoot(async (stateRoot) => {
+    const stateRootFile = path.join(stateRoot, "state-root-file");
+    await writeFile(stateRootFile, "not a directory\n", {
+      encoding: "utf8",
+    });
+    const malformedStateRoot = path.join(stateRootFile, "child");
+
+    const status = await getLaneRunStatus(malformedStateRoot);
+    const explanation = await explainLaneRun(malformedStateRoot);
+
+    assert.equal(status.state, "blocked");
+    assert.equal(status.queue.length, 0);
+    assert.equal(status.blockerReason, "lane run state is malformed");
+    assert.equal(explanation.state, "blocked");
+    assert.equal(explanation.blockerReason, "lane run state is malformed");
+    assert.equal(explanation.nextOperatorAction, "repair or remove malformed lane state before continuing");
+  });
+});
+
 test("CLI status returns structured blocked output for malformed queue shape", async () => {
   await withStateRoot(async (stateRoot) => {
     await writeFile(path.join(stateRoot, "lane-run-queue"), "not a directory\n", {

--- a/test/lane-run-status-explain.test.ts
+++ b/test/lane-run-status-explain.test.ts
@@ -19,6 +19,12 @@ const execFileAsync = promisify(execFile);
 const queuedAt = "2026-05-22T00:00:00.000Z";
 const claimedAt = "2026-05-22T00:01:00.000Z";
 
+interface CliResult {
+  readonly stdout: string;
+  readonly stderr: string;
+  readonly exitCode: number;
+}
+
 async function withStateRoot(callback: (stateRoot: string) => Promise<void>): Promise<void> {
   const stateRoot = await mkdtemp(path.join(os.tmpdir(), "ensen-loop-state-"));
 
@@ -27,6 +33,37 @@ async function withStateRoot(callback: (stateRoot: string) => Promise<void>): Pr
   } finally {
     await rm(stateRoot, { recursive: true, force: true });
   }
+}
+
+async function execCli(args: readonly string[]): Promise<CliResult> {
+  try {
+    const result = await execFileAsync(process.execPath, ["dist/src/cli/index.js", ...args]);
+
+    return {
+      stdout: result.stdout,
+      stderr: result.stderr,
+      exitCode: 0,
+    };
+  } catch (error) {
+    if (isCliExitError(error)) {
+      return {
+        stdout: error.stdout,
+        stderr: error.stderr,
+        exitCode: error.code,
+      };
+    }
+
+    throw error;
+  }
+}
+
+function isCliExitError(error: unknown): error is Error & { readonly code: number; readonly stdout: string; readonly stderr: string } {
+  return (
+    error instanceof Error &&
+    typeof (error as { readonly code?: unknown }).code === "number" &&
+    typeof (error as { readonly stdout?: unknown }).stdout === "string" &&
+    typeof (error as { readonly stderr?: unknown }).stderr === "string"
+  );
 }
 
 test("status shows queued and active lock state without leaking local paths", async () => {
@@ -150,6 +187,31 @@ test("explain identifies blocked active lane run and safe next action", async ()
   });
 });
 
+test("CLI status exits blocked for queued blocker diagnostics", async () => {
+  await withStateRoot(async (stateRoot) => {
+    await enqueueLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-111",
+      workItemId: "issue-111",
+      source: "github-issue",
+      laneId: "owner-dogfood",
+      repositoryClassification: "owner-controlled-dogfood",
+      queuedAt,
+      metadata: {
+        issueNumber: "111",
+        blockerReason: "required review evidence is missing",
+      },
+    });
+
+    const result = await execCli(["status", "--state-root", stateRoot]);
+    const status = JSON.parse(result.stdout) as { readonly state?: unknown; readonly blockerReason?: unknown };
+
+    assert.equal(result.stderr, "");
+    assert.equal(result.exitCode, 1);
+    assert.equal(status.state, "blocked");
+    assert.equal(status.blockerReason, "required review evidence is missing");
+  });
+});
+
 test("malformed queue state is reported as blocked instead of ready", async () => {
   await withStateRoot(async (stateRoot) => {
     const queuePath = resolveLaneRunQueueRecordPath(stateRoot, "github-issue-111");
@@ -246,6 +308,27 @@ test("queue filesystem shape errors are reported as malformed status and explana
     assert.equal(explanation.state, "blocked");
     assert.equal(explanation.blockerReason, "lane run state is malformed");
     assert.equal(explanation.nextOperatorAction, "repair or remove malformed lane state before continuing");
+  });
+});
+
+test("CLI status returns structured blocked output for malformed queue shape", async () => {
+  await withStateRoot(async (stateRoot) => {
+    await writeFile(path.join(stateRoot, "lane-run-queue"), "not a directory\n", {
+      encoding: "utf8",
+    });
+
+    const result = await execCli(["status", "--state-root", stateRoot]);
+    const status = JSON.parse(result.stdout) as {
+      readonly state?: unknown;
+      readonly blockerReason?: unknown;
+      readonly nextOperatorAction?: unknown;
+    };
+
+    assert.equal(result.stderr, "");
+    assert.equal(result.exitCode, 1);
+    assert.equal(status.state, "blocked");
+    assert.equal(status.blockerReason, "lane run state is malformed");
+    assert.equal(status.nextOperatorAction, "repair or remove malformed lane state before continuing");
   });
 });
 
@@ -417,7 +500,11 @@ test("terminal locks drive next action even when the queue record is stale queue
     const explanation = await explainLaneRun(stateRoot, {
       stableWorkItemId: "github-issue-111",
     });
+    const status = await getLaneRunStatus(stateRoot);
 
+    assert.equal(status.queue[0]?.laneState, "completed");
+    assert.equal(status.queue[0]?.verificationState, "succeeded");
+    assert.equal(status.queue[0]?.nextOperatorAction, "no action required");
     assert.equal(explanation.laneState, "completed");
     assert.equal(explanation.verificationState, "succeeded");
     assert.equal(explanation.nextOperatorAction, "no action required");
@@ -438,23 +525,13 @@ test("CLI status and explain emit deterministic public-safe JSON", async () => {
       },
     });
 
-    const status = await execFileAsync(process.execPath, [
-      "dist/src/cli/index.js",
-      "status",
-      "--state-root",
-      stateRoot,
-    ]);
-    const explain = await execFileAsync(process.execPath, [
-      "dist/src/cli/index.js",
-      "explain",
-      "--state-root",
-      stateRoot,
-      "--issue",
-      "github-issue-111",
-    ]);
+    const status = await execCli(["status", "--state-root", stateRoot]);
+    const explain = await execCli(["explain", "--state-root", stateRoot, "--issue", "github-issue-111"]);
 
     assert.equal(status.stderr, "");
     assert.equal(explain.stderr, "");
+    assert.equal(status.exitCode, 0);
+    assert.equal(explain.exitCode, 0);
     assert.equal(JSON.stringify(JSON.parse(status.stdout)).includes(stateRoot), false);
     assert.equal(JSON.parse(explain.stdout).nextOperatorAction, "claim queued lane run when ready");
   });

--- a/test/lane-run-status-explain.test.ts
+++ b/test/lane-run-status-explain.test.ts
@@ -1,3 +1,4 @@
+import { Dirent } from "node:fs";
 import assert from "node:assert/strict";
 import { execFile } from "node:child_process";
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
@@ -12,6 +13,7 @@ import {
   enqueueLaneRun,
   explainLaneRun,
   getLaneRunStatus,
+  resolveLaneRunLockPath,
   resolveLaneRunQueueRecordPath,
 } from "../src/lane/index.js";
 
@@ -463,6 +465,128 @@ test("status orders queue records by timestamp instant before stable id", async 
       ["#111", "#112"],
     );
     assert.equal(explanation.selectedIssue, "#111");
+  });
+});
+
+test("status orders equal-time queue records by locale-independent stable id", async () => {
+  await withStateRoot(async (stateRoot) => {
+    for (const stableWorkItemId of [
+      "github_issue_111",
+      "github.issue.111",
+      "github-issue-111",
+    ]) {
+      await enqueueLaneRun(stateRoot, {
+        stableWorkItemId,
+        workItemId: stableWorkItemId,
+        source: "github-issue",
+        laneId: "owner-dogfood",
+        repositoryClassification: "owner-controlled-dogfood",
+        queuedAt,
+      });
+    }
+
+    const status = await getLaneRunStatus(stateRoot);
+
+    assert.deepEqual(
+      status.queue.map((item) => item.stableWorkItemId),
+      ["github-issue-111", "github.issue.111", "github_issue_111"],
+    );
+  });
+});
+
+test("queue scan falls back to file stats when dirent file type is unknown", async () => {
+  await withStateRoot(async (stateRoot) => {
+    await enqueueLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-111",
+      workItemId: "issue-111",
+      source: "github-issue",
+      laneId: "owner-dogfood",
+      repositoryClassification: "owner-controlled-dogfood",
+      queuedAt,
+    });
+    const originalIsFile = Dirent.prototype.isFile;
+    Dirent.prototype.isFile = function isUnknownFileType() {
+      return false;
+    };
+
+    try {
+      const status = await getLaneRunStatus(stateRoot);
+
+      assert.equal(status.state, "ok");
+      assert.equal(status.queue[0]?.stableWorkItemId, "github-issue-111");
+    } finally {
+      Dirent.prototype.isFile = originalIsFile;
+    }
+  });
+});
+
+test("queue filename and content id mismatches are reported as malformed state", async () => {
+  await withStateRoot(async (stateRoot) => {
+    const queued = await enqueueLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-112",
+      workItemId: "issue-112",
+      source: "github-issue",
+      laneId: "owner-dogfood",
+      repositoryClassification: "owner-controlled-dogfood",
+      queuedAt,
+    });
+    const mismatchedQueuePath = resolveLaneRunQueueRecordPath(stateRoot, "github-issue-111");
+    await writeFile(mismatchedQueuePath, `${JSON.stringify(queued)}\n`, {
+      encoding: "utf8",
+    });
+
+    const status = await getLaneRunStatus(stateRoot);
+    const explanation = await explainLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-111",
+    });
+
+    assert.equal(status.state, "blocked");
+    assert.equal(status.blockerReason, "lane run state is malformed");
+    assert.equal(explanation.state, "blocked");
+    assert.equal(explanation.blockerReason, "lane run state is malformed");
+  });
+});
+
+test("lock filename and content id mismatches are reported as malformed state", async () => {
+  await withStateRoot(async (stateRoot) => {
+    const queued = await enqueueLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-111",
+      workItemId: "issue-111",
+      source: "github-issue",
+      laneId: "owner-dogfood",
+      repositoryClassification: "owner-controlled-dogfood",
+      queuedAt,
+    });
+    const lockPath = resolveLaneRunLockPath(stateRoot, "github-issue-111");
+    await mkdir(path.dirname(lockPath), { recursive: true });
+    await writeFile(
+      lockPath,
+      `${JSON.stringify({
+        schemaVersion: "ensen.lane-run-lock.v1",
+        stableWorkItemId: "github-issue-112",
+        queueRecordId: queued.id,
+        laneRunId: "lane-run-111-a",
+        laneId: "owner-dogfood",
+        source: "github-issue",
+        repositoryClassification: "owner-controlled-dogfood",
+        status: "active",
+        active: true,
+        claimedAt,
+        claimedBy: "local-supervisor",
+        startsAgentExecution: false,
+      })}\n`,
+      { encoding: "utf8" },
+    );
+
+    const status = await getLaneRunStatus(stateRoot);
+    const explanation = await explainLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-111",
+    });
+
+    assert.equal(status.state, "blocked");
+    assert.equal(status.blockerReason, "lane run state is malformed");
+    assert.equal(explanation.state, "blocked");
+    assert.equal(explanation.blockerReason, "lane run state is malformed");
   });
 });
 

--- a/test/lane-run-status-explain.test.ts
+++ b/test/lane-run-status-explain.test.ts
@@ -8,6 +8,7 @@ import { promisify } from "node:util";
 
 import {
   claimQueuedLaneRun,
+  completeLaneRunLock,
   enqueueLaneRun,
   explainLaneRun,
   getLaneRunStatus,
@@ -101,10 +102,14 @@ test("explain identifies blocked active lane run and safe next action", async ()
       },
     });
 
+    const status = await getLaneRunStatus(stateRoot);
     const explanation = await explainLaneRun(stateRoot, {
       stableWorkItemId: "github-issue-111",
     });
 
+    assert.equal(status.state, "blocked");
+    assert.equal(status.blockerReason, "verification <redacted> failed");
+    assert.equal(status.nextOperatorAction, "resolve blocker before claiming or running the lane");
     assert.equal(explanation.selectedIssue, "#111");
     assert.equal(explanation.laneState, "blocked");
     assert.equal(explanation.verificationState, "blocked");
@@ -122,15 +127,123 @@ test("malformed queue state is reported as blocked instead of ready", async () =
       encoding: "utf8",
     });
 
+    const status = await getLaneRunStatus(stateRoot);
     const explanation = await explainLaneRun(stateRoot, {
       stableWorkItemId: "github-issue-111",
     });
 
+    assert.equal(status.state, "blocked");
+    assert.equal(status.queue.length, 0);
+    assert.equal(status.blockerReason, "lane run state is malformed");
+    assert.equal(status.nextOperatorAction, "repair or remove malformed lane state before continuing");
     assert.equal(explanation.state, "blocked");
     assert.equal(explanation.laneState, "blocked");
     assert.equal(explanation.verificationState, "unknown");
     assert.equal(explanation.blockerReason, "lane run state is malformed");
     assert.equal(explanation.nextOperatorAction, "repair or remove malformed lane state before continuing");
+  });
+});
+
+test("syntactically invalid queue JSON is reported as malformed status and explanation", async () => {
+  await withStateRoot(async (stateRoot) => {
+    const queuePath = resolveLaneRunQueueRecordPath(stateRoot, "github-issue-111");
+    await mkdir(path.dirname(queuePath), { recursive: true });
+    await writeFile(queuePath, "{ nope\n", {
+      encoding: "utf8",
+    });
+
+    const status = await getLaneRunStatus(stateRoot);
+    const explanation = await explainLaneRun(stateRoot);
+
+    assert.equal(status.state, "blocked");
+    assert.equal(status.blockerReason, "lane run state is malformed");
+    assert.equal(explanation.state, "blocked");
+    assert.equal(explanation.blockerReason, "lane run state is malformed");
+    assert.equal(explanation.nextOperatorAction, "repair or remove malformed lane state before continuing");
+  });
+});
+
+test("explain without issue prefers actionable queue items over terminal history", async () => {
+  await withStateRoot(async (stateRoot) => {
+    await enqueueLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-110",
+      workItemId: "issue-110",
+      source: "github-issue",
+      laneId: "owner-dogfood",
+      repositoryClassification: "owner-controlled-dogfood",
+      queuedAt: "2026-05-22T00:00:00.000Z",
+      metadata: {
+        issueNumber: "110",
+      },
+    });
+    const claim = await claimQueuedLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-110",
+      laneRunId: "lane-run-110-a",
+      claimedBy: "local-supervisor",
+      claimedAt: "2026-05-22T00:01:00.000Z",
+    });
+    await completeLaneRunLock(stateRoot, {
+      stableWorkItemId: "github-issue-110",
+      laneRunId: claim.lock.laneRunId,
+      completedAt: "2026-05-22T00:02:00.000Z",
+      terminalStatus: "completed",
+    });
+    await enqueueLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-111",
+      workItemId: "issue-111",
+      source: "github-issue",
+      laneId: "owner-dogfood",
+      repositoryClassification: "owner-controlled-dogfood",
+      queuedAt: "2026-05-22T00:03:00.000Z",
+      metadata: {
+        issueNumber: "111",
+      },
+    });
+
+    const explanation = await explainLaneRun(stateRoot);
+
+    assert.equal(explanation.selectedIssue, "#111");
+    assert.equal(explanation.laneState, "queued");
+    assert.equal(explanation.nextOperatorAction, "claim queued lane run when ready");
+  });
+});
+
+test("terminal locks drive next action even when the queue record is stale queued", async () => {
+  await withStateRoot(async (stateRoot) => {
+    const queued = await enqueueLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-111",
+      workItemId: "issue-111",
+      source: "github-issue",
+      laneId: "owner-dogfood",
+      repositoryClassification: "owner-controlled-dogfood",
+      queuedAt,
+      metadata: {
+        issueNumber: "111",
+      },
+    });
+    const claim = await claimQueuedLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-111",
+      laneRunId: "lane-run-111-a",
+      claimedBy: "local-supervisor",
+      claimedAt,
+    });
+    await completeLaneRunLock(stateRoot, {
+      stableWorkItemId: "github-issue-111",
+      laneRunId: claim.lock.laneRunId,
+      completedAt: "2026-05-22T00:02:00.000Z",
+      terminalStatus: "completed",
+    });
+    await writeFile(resolveLaneRunQueueRecordPath(stateRoot, "github-issue-111"), `${JSON.stringify(queued)}\n`, {
+      encoding: "utf8",
+    });
+
+    const explanation = await explainLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-111",
+    });
+
+    assert.equal(explanation.laneState, "completed");
+    assert.equal(explanation.verificationState, "succeeded");
+    assert.equal(explanation.nextOperatorAction, "no action required");
   });
 });
 

--- a/test/lane-run-status-explain.test.ts
+++ b/test/lane-run-status-explain.test.ts
@@ -590,6 +590,86 @@ test("lock filename and content id mismatches are reported as malformed state", 
   });
 });
 
+test("orphaned lock without a queued record is reported as malformed state", async () => {
+  await withStateRoot(async (stateRoot) => {
+    const lockPath = resolveLaneRunLockPath(stateRoot, "github-issue-111");
+    await mkdir(path.dirname(lockPath), { recursive: true });
+    await writeFile(
+      lockPath,
+      `${JSON.stringify({
+        schemaVersion: "ensen.lane-run-lock.v1",
+        stableWorkItemId: "github-issue-111",
+        queueRecordId: "queue-github-issue-111-1",
+        laneRunId: "lane-run-111-a",
+        laneId: "owner-dogfood",
+        source: "github-issue",
+        repositoryClassification: "owner-controlled-dogfood",
+        status: "active",
+        active: true,
+        claimedAt,
+        claimedBy: "local-supervisor",
+        startsAgentExecution: false,
+      })}\n`,
+      { encoding: "utf8" },
+    );
+
+    const status = await getLaneRunStatus(stateRoot);
+    const explanation = await explainLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-111",
+    });
+
+    assert.equal(status.state, "blocked");
+    assert.equal(status.queue.length, 0);
+    assert.equal(status.blockerReason, "lane run state is malformed");
+    assert.equal(explanation.state, "blocked");
+    assert.equal(explanation.blockerReason, "lane run state is malformed");
+    assert.equal(explanation.nextOperatorAction, "repair or remove malformed lane state before continuing");
+  });
+});
+
+test("unreferenced lock records for other issues are reported as malformed state", async () => {
+  await withStateRoot(async (stateRoot) => {
+    await enqueueLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-111",
+      workItemId: "issue-111",
+      source: "github-issue",
+      laneId: "owner-dogfood",
+      repositoryClassification: "owner-controlled-dogfood",
+      queuedAt,
+    });
+    const lockPath = resolveLaneRunLockPath(stateRoot, "github-issue-112");
+    await mkdir(path.dirname(lockPath), { recursive: true });
+    await writeFile(
+      lockPath,
+      `${JSON.stringify({
+        schemaVersion: "ensen.lane-run-lock.v1",
+        stableWorkItemId: "github-issue-112",
+        queueRecordId: "queue-github-issue-112-1",
+        laneRunId: "lane-run-112-a",
+        laneId: "owner-dogfood",
+        source: "github-issue",
+        repositoryClassification: "owner-controlled-dogfood",
+        status: "active",
+        active: true,
+        claimedAt,
+        claimedBy: "local-supervisor",
+        startsAgentExecution: false,
+      })}\n`,
+      { encoding: "utf8" },
+    );
+
+    const status = await getLaneRunStatus(stateRoot);
+    const explanation = await explainLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-111",
+    });
+
+    assert.equal(status.state, "blocked");
+    assert.equal(status.blockerReason, "lane run state is malformed");
+    assert.equal(explanation.state, "blocked");
+    assert.equal(explanation.blockerReason, "lane run state is malformed");
+  });
+});
+
 test("explain without issue prefers blocked queue items over runnable work", async () => {
   await withStateRoot(async (stateRoot) => {
     await enqueueLaneRun(stateRoot, {

--- a/test/lane-run-status-explain.test.ts
+++ b/test/lane-run-status-explain.test.ts
@@ -87,6 +87,37 @@ test("explain fails closed when no selected issue exists", async () => {
   });
 });
 
+test("explain reports unknown requested issue separately from non-empty queue", async () => {
+  await withStateRoot(async (stateRoot) => {
+    await enqueueLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-111",
+      workItemId: "issue-111",
+      source: "github-issue",
+      laneId: "owner-dogfood",
+      repositoryClassification: "owner-controlled-dogfood",
+      queuedAt,
+      metadata: {
+        issueNumber: "111",
+      },
+    });
+
+    const explanation = await explainLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-112",
+    });
+
+    assert.equal(explanation.state, "blocked");
+    assert.equal(explanation.selectedIssue, "github-issue-112");
+    assert.equal(explanation.stableWorkItemId, "github-issue-112");
+    assert.equal(explanation.laneState, "blocked");
+    assert.equal(explanation.verificationState, "unknown");
+    assert.equal(explanation.blockerReason, "requested issue is not queued");
+    assert.equal(
+      explanation.nextOperatorAction,
+      "select an existing lane run or enqueue the requested issue before claiming readiness",
+    );
+  });
+});
+
 test("explain identifies blocked active lane run and safe next action", async () => {
   await withStateRoot(async (stateRoot) => {
     await enqueueLaneRun(stateRoot, {
@@ -163,6 +194,43 @@ test("syntactically invalid queue JSON is reported as malformed status and expla
   });
 });
 
+test("explain without issue prefers blocked queue items over runnable work", async () => {
+  await withStateRoot(async (stateRoot) => {
+    await enqueueLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-110",
+      workItemId: "issue-110",
+      source: "github-issue",
+      laneId: "owner-dogfood",
+      repositoryClassification: "owner-controlled-dogfood",
+      queuedAt: "2026-05-22T00:00:00.000Z",
+      metadata: {
+        issueNumber: "110",
+      },
+    });
+    await enqueueLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-111",
+      workItemId: "issue-111",
+      source: "github-issue",
+      laneId: "owner-dogfood",
+      repositoryClassification: "owner-controlled-dogfood",
+      queuedAt: "2026-05-22T00:01:00.000Z",
+      metadata: {
+        issueNumber: "111",
+        blockerReason: "required review evidence is missing",
+      },
+    });
+
+    const status = await getLaneRunStatus(stateRoot);
+    const explanation = await explainLaneRun(stateRoot);
+
+    assert.equal(status.state, "blocked");
+    assert.equal(explanation.state, "blocked");
+    assert.equal(explanation.selectedIssue, "#111");
+    assert.equal(explanation.laneState, "blocked");
+    assert.equal(explanation.blockerReason, "required review evidence is missing");
+  });
+});
+
 test("explain without issue prefers actionable queue items over terminal history", async () => {
   await withStateRoot(async (stateRoot) => {
     await enqueueLaneRun(stateRoot, {
@@ -205,6 +273,60 @@ test("explain without issue prefers actionable queue items over terminal history
     assert.equal(explanation.selectedIssue, "#111");
     assert.equal(explanation.laneState, "queued");
     assert.equal(explanation.nextOperatorAction, "claim queued lane run when ready");
+  });
+});
+
+test("operator projection ignores obsolete terminal lock for newer queued record", async () => {
+  await withStateRoot(async (stateRoot) => {
+    await enqueueLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-111",
+      workItemId: "issue-111",
+      source: "github-issue",
+      laneId: "owner-dogfood",
+      repositoryClassification: "owner-controlled-dogfood",
+      queuedAt,
+      metadata: {
+        issueNumber: "111",
+      },
+    });
+    const claim = await claimQueuedLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-111",
+      laneRunId: "lane-run-111-a",
+      claimedBy: "local-supervisor",
+      claimedAt,
+    });
+    await completeLaneRunLock(stateRoot, {
+      stableWorkItemId: "github-issue-111",
+      laneRunId: claim.lock.laneRunId,
+      completedAt: "2026-05-22T00:02:00.000Z",
+      terminalStatus: "completed",
+    });
+    await enqueueLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-111",
+      workItemId: "issue-111",
+      source: "github-issue",
+      laneId: "owner-dogfood",
+      repositoryClassification: "owner-controlled-dogfood",
+      queuedAt: "2026-05-22T00:03:00.000Z",
+      metadata: {
+        issueNumber: "111",
+      },
+    });
+
+    const status = await getLaneRunStatus(stateRoot);
+    const explanation = await explainLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-111",
+    });
+
+    assert.equal(status.state, "ok");
+    assert.equal(status.queue[0]?.laneState, "queued");
+    assert.equal(status.queue[0]?.verificationState, "not-started");
+    assert.equal(status.queue[0]?.nextOperatorAction, "claim queued lane run when ready");
+    assert.equal(status.queue[0]?.activeLock, undefined);
+    assert.equal(explanation.laneState, "queued");
+    assert.equal(explanation.verificationState, "not-started");
+    assert.equal(explanation.nextOperatorAction, "claim queued lane run when ready");
+    assert.equal(explanation.activeLock, undefined);
   });
 });
 


### PR DESCRIPTION
## Summary
- Add read-only lane run status and explain projections over queue and lock state
- Wire CLI `status --state-root` and `explain --state-root [--issue]`
- Cover active, empty, blocked, malformed, CLI, and public-safe rendering cases

## Verification
- `npm ci`
- `npm run typecheck`
- `npm run build`
- `node --test dist/test/lane-run-status-explain.test.js`
- `npm test`

Closes #111