### PR TITLE
LOOP-052 add stop retry requeue operator actions

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -21,6 +21,7 @@ import {
   retryLaneRun,
   stopLaneRun,
 } from "../lane/index.js";
+import type { LaneRunOperatorActionResult } from "../lane/index.js";
 import {
   createBlockedRunResultFromValidationIssues,
   createBlockedRunStatusSnapshotFromValidationIssues,
@@ -42,6 +43,22 @@ const [, , command, ...args] = process.argv;
 
 function printJson(value: unknown): void {
   console.log(`${JSON.stringify(value, null, 2)}\n`);
+}
+
+function projectLaneRunOperatorActionCliResult(result: LaneRunOperatorActionResult): unknown {
+  return {
+    ok: result.ok,
+    action: result.action,
+    stableWorkItemId: result.stableWorkItemId,
+    laneRunId: result.laneRunId,
+    publicDiagnostics: result.publicDiagnostics,
+    lineage: {
+      relationship: result.lineage.relationship,
+      previousLaneRunId: result.lineage.previousLaneRunId,
+      newQueueRecordId: result.lineage.newQueueRecordId,
+      preservedEvidenceRefCount: result.lineage.preservedEvidenceRefs.length,
+    },
+  };
 }
 
 async function readJsonFile(filePath: string): Promise<unknown> {
@@ -314,7 +331,7 @@ async function main(): Promise<number> {
               actedAt,
             });
 
-    printJson(result);
+    printJson(projectLaneRunOperatorActionCliResult(result));
     return result.ok ? 0 : 1;
   }
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -17,6 +17,9 @@ import {
   explainLaneRun,
   getLaneRunStatus,
   prepareLocalLaneWorkspace,
+  requeueLaneRun,
+  retryLaneRun,
+  stopLaneRun,
 } from "../lane/index.js";
 import {
   createBlockedRunResultFromValidationIssues,
@@ -278,6 +281,43 @@ async function main(): Promise<number> {
     return explanation.state === "ok" ? 0 : 1;
   }
 
+  if (command === "stop" || command === "retry" || command === "requeue") {
+    const options = parseOperatorActionArgs(args);
+
+    if (options === undefined) {
+      console.error(
+        `Usage: ensen-loop ${command} --state-root <state-root> --issue <stable-work-item-id> --lane-run <lane-run-id> --reason <public-reason>`,
+      );
+      return 1;
+    }
+
+    const actedAt = new Date().toISOString();
+    const result =
+      command === "stop"
+        ? await stopLaneRun(options.stateRoot, {
+            stableWorkItemId: options.stableWorkItemId,
+            laneRunId: options.laneRunId,
+            reason: options.reason,
+            actedAt,
+          })
+        : command === "retry"
+          ? await retryLaneRun(options.stateRoot, {
+              stableWorkItemId: options.stableWorkItemId,
+              laneRunId: options.laneRunId,
+              reason: options.reason,
+              actedAt,
+            })
+          : await requeueLaneRun(options.stateRoot, {
+              stableWorkItemId: options.stableWorkItemId,
+              laneRunId: options.laneRunId,
+              reason: options.reason,
+              actedAt,
+            });
+
+    printJson(result);
+    return result.ok ? 0 : 1;
+  }
+
   if (command === undefined) {
     console.log(describeProduct());
     return 0;
@@ -294,6 +334,9 @@ async function main(): Promise<number> {
   );
   console.error("Usage: ensen-loop status --state-root <state-root>");
   console.error("Usage: ensen-loop explain --state-root <state-root> [--issue <stable-work-item-id>]");
+  console.error(
+    "Usage: ensen-loop stop|retry|requeue --state-root <state-root> --issue <stable-work-item-id> --lane-run <lane-run-id> --reason <public-reason>",
+  );
   return 1;
 }
 
@@ -444,6 +487,54 @@ function parseExplainArgs(args: readonly string[]): ExplainOptions | undefined {
   return {
     stateRoot: args[1],
     stableWorkItemId: args[3],
+  };
+}
+
+interface OperatorActionOptions {
+  readonly stateRoot: string;
+  readonly stableWorkItemId: string;
+  readonly laneRunId: string;
+  readonly reason: string;
+}
+
+function parseOperatorActionArgs(args: readonly string[]): OperatorActionOptions | undefined {
+  if (args.length !== 8) {
+    return undefined;
+  }
+
+  const values = new Map<string, string>();
+
+  for (let index = 0; index < args.length; index += 2) {
+    const flag = args[index];
+    const value = args[index + 1];
+
+    if (flag === undefined || value === undefined || !flag.startsWith("--")) {
+      return undefined;
+    }
+
+    values.set(flag, value);
+  }
+
+  const stateRoot = values.get("--state-root");
+  const stableWorkItemId = values.get("--issue");
+  const laneRunId = values.get("--lane-run");
+  const reason = values.get("--reason");
+
+  if (
+    stateRoot === undefined ||
+    stableWorkItemId === undefined ||
+    laneRunId === undefined ||
+    reason === undefined ||
+    values.size !== 4
+  ) {
+    return undefined;
+  }
+
+  return {
+    stateRoot,
+    stableWorkItemId,
+    laneRunId,
+    reason,
   };
 }
 

--- a/src/lane/index.ts
+++ b/src/lane/index.ts
@@ -244,6 +244,13 @@ export interface LaneRunOperatorActionLineage {
 
 export type LaneRunOperatorAction = "stop" | "retry" | "requeue";
 
+const blockedLaneRunMetadataKeys = ["blockerReason"] as const;
+const linkedAttemptVolatileMetadataKeys = [
+  "blockerReason",
+  "preservedEvidenceRefCount",
+  "preservedEvidenceRefs",
+] as const;
+
 export type LaneRunOperatorActionResult =
   | {
       readonly ok: true;
@@ -1124,7 +1131,7 @@ export async function stopLaneRun(
     const queueRecord = await readOptionalLaneRunQueueRecord(stateRoot, input.stableWorkItemId);
     const existingLock = await readOptionalLaneRunLock(stateRoot, input.stableWorkItemId);
     const sanitizedReason = publicSafeDiagnosticText(input.reason) ?? "operator requested stop";
-    const metadataReason = toLaneRunQueueMetadataValue(sanitizedReason);
+    const metadataReason = toBoundedLaneRunQueueMetadataValue(sanitizedReason);
 
     if (queueRecord === undefined) {
       return createBlockedLaneRunOperatorActionResult("stop", input, undefined, "requested issue is not queued");
@@ -1163,7 +1170,7 @@ export async function stopLaneRun(
         status: "revoked",
         updatedAt: input.actedAt,
         metadata: {
-          ...copyQueueMetadataWithout(queueRecord.metadata, ["blockerReason"]),
+          ...copyQueueMetadataWithout(queueRecord.metadata, blockedLaneRunMetadataKeys),
           operatorAction: "stop",
           operatorReason: metadataReason,
           revokedByOperatorAt: input.actedAt,
@@ -1232,7 +1239,7 @@ export async function stopLaneRun(
       status: "revoked",
       updatedAt: input.actedAt,
       metadata: {
-        ...copyQueueMetadataWithout(queueRecord.metadata, ["blockerReason"]),
+        ...copyQueueMetadataWithout(queueRecord.metadata, blockedLaneRunMetadataKeys),
         operatorAction: "stop",
         operatorReason: metadataReason,
         revokedByOperatorAt: input.actedAt,
@@ -1389,12 +1396,8 @@ async function createLinkedQueuedOperatorAttempt(
     const preservedEvidenceRefs = await readLaneRunEvidenceRefs(stateRoot, input.laneRunId);
     const enqueueSequence = queueRecord.enqueueSequence + 1;
     const sanitizedReason = publicSafeDiagnosticText(input.reason) ?? `operator requested ${action}`;
-    const metadataReason = toLaneRunQueueMetadataValue(sanitizedReason);
-    const linkedMetadata = copyQueueMetadataWithout(queueRecord.metadata, [
-      "blockerReason",
-      "preservedEvidenceRefCount",
-      "preservedEvidenceRefs",
-    ]);
+    const metadataReason = toBoundedLaneRunQueueMetadataValue(sanitizedReason);
+    const linkedMetadata = copyQueueMetadataWithout(queueRecord.metadata, linkedAttemptVolatileMetadataKeys);
     const operatorMetadata = {
       ...linkedMetadata,
       operatorAction: action,
@@ -1580,7 +1583,7 @@ function createPreservedEvidenceQueueMetadata(
       };
 }
 
-function toLaneRunQueueMetadataValue(value: string): string {
+function toBoundedLaneRunQueueMetadataValue(value: string): string {
   return value.length <= 256 ? value : `${value.slice(0, 253)}...`;
 }
 

--- a/src/lane/index.ts
+++ b/src/lane/index.ts
@@ -228,6 +228,42 @@ export interface CompleteLaneRunLockInput {
   readonly terminalStatus: Exclude<LaneRunLockStatus, "active">;
 }
 
+export interface LaneRunOperatorActionInput {
+  readonly stableWorkItemId: string;
+  readonly laneRunId: string;
+  readonly reason: string;
+  readonly actedAt: string;
+}
+
+export interface LaneRunOperatorActionLineage {
+  readonly relationship: "revoked" | "retried" | "requeued";
+  readonly previousLaneRunId?: string;
+  readonly newQueueRecordId?: string;
+  readonly preservedEvidenceRefs: readonly string[];
+}
+
+export type LaneRunOperatorAction = "stop" | "retry" | "requeue";
+
+export type LaneRunOperatorActionResult =
+  | {
+      readonly ok: true;
+      readonly action: LaneRunOperatorAction;
+      readonly stableWorkItemId: string;
+      readonly laneRunId: string;
+      readonly queueRecord?: LaneRunQueueRecord;
+      readonly lock?: LaneRunLock;
+      readonly publicDiagnostics: LaneRunLockDiagnostics;
+      readonly lineage: LaneRunOperatorActionLineage;
+    }
+  | {
+      readonly ok: false;
+      readonly action: LaneRunOperatorAction;
+      readonly stableWorkItemId: string;
+      readonly laneRunId: string;
+      readonly publicDiagnostics: LaneRunLockDiagnostics;
+      readonly lineage: LaneRunOperatorActionLineage;
+    };
+
 export type ClaimQueuedLaneRunResult =
   | {
       readonly ok: true;
@@ -1078,6 +1114,148 @@ export async function completeLaneRunLock(
   });
 }
 
+export async function stopLaneRun(
+  stateRoot: string,
+  input: LaneRunOperatorActionInput,
+): Promise<LaneRunOperatorActionResult> {
+  validateLaneRunOperatorActionInput(input);
+
+  return withLaneRunMutationLock(stateRoot, input.stableWorkItemId, async () => {
+    const queueRecord = await readOptionalLaneRunQueueRecord(stateRoot, input.stableWorkItemId);
+    const existingLock = await readOptionalLaneRunLock(stateRoot, input.stableWorkItemId);
+    const sanitizedReason = publicSafeDiagnosticText(input.reason) ?? "operator requested stop";
+
+    if (queueRecord === undefined) {
+      return createBlockedLaneRunOperatorActionResult("stop", input, undefined, "requested issue is not queued");
+    }
+
+    if (existingLock !== undefined && existingLock.laneRunId !== input.laneRunId) {
+      return createBlockedLaneRunOperatorActionResult(
+        "stop",
+        input,
+        existingLock,
+        "operator action target does not match the selected lane run",
+      );
+    }
+
+    if (existingLock?.active === true) {
+      assertLaneRunCompletionTimestamp(existingLock.claimedAt, input.actedAt);
+
+      const revokedLock = toSerializableLaneRunLock({
+        ...existingLock,
+        status: "revoked",
+        active: false,
+        releasedAt: input.actedAt,
+      });
+      const revokedQueueRecord = toSerializableLaneRunQueueRecord({
+        ...queueRecord,
+        status: "revoked",
+        updatedAt: input.actedAt,
+        metadata: {
+          ...queueRecord.metadata,
+          operatorAction: "stop",
+          operatorReason: sanitizedReason,
+          revokedByOperatorAt: input.actedAt,
+          revokedLaneRunId: existingLock.laneRunId,
+        },
+        publicDiagnostics: {
+          ...queueRecord.publicDiagnostics,
+          status: "revoked",
+        },
+      });
+
+      await persistCompletedLaneRunState(stateRoot, existingLock, revokedLock, revokedQueueRecord);
+
+      return {
+        ok: true,
+        action: "stop",
+        stableWorkItemId: input.stableWorkItemId,
+        laneRunId: input.laneRunId,
+        queueRecord: revokedQueueRecord,
+        lock: revokedLock,
+        publicDiagnostics: createLaneRunLockDiagnostics(revokedLock, sanitizedReason),
+        lineage: {
+          relationship: "revoked",
+          previousLaneRunId: existingLock.laneRunId,
+          preservedEvidenceRefs: await readLaneRunEvidenceRefs(stateRoot, existingLock.laneRunId),
+        },
+      };
+    }
+
+    if (existingLock !== undefined) {
+      return createBlockedLaneRunOperatorActionResult(
+        "stop",
+        input,
+        existingLock,
+        `lane run is already terminal: ${existingLock.status}`,
+      );
+    }
+
+    if (queueRecord.status !== "queued" || queueRecord.metadata.blockerReason === undefined) {
+      return createBlockedLaneRunOperatorActionResult(
+        "stop",
+        input,
+        createDiagnosticsLockFromQueueRecord(queueRecord, input.laneRunId, "active"),
+        "only active or blocked lane runs can be stopped",
+      );
+    }
+
+    const revokedQueueRecord = toSerializableLaneRunQueueRecord({
+      ...queueRecord,
+      status: "revoked",
+      updatedAt: input.actedAt,
+      metadata: {
+        ...queueRecord.metadata,
+        operatorAction: "stop",
+        operatorReason: sanitizedReason,
+        revokedByOperatorAt: input.actedAt,
+        revokedLaneRunId: input.laneRunId,
+      },
+      publicDiagnostics: {
+        ...queueRecord.publicDiagnostics,
+        status: "revoked",
+      },
+    });
+
+    await writeLaneRunQueueRecord(stateRoot, revokedQueueRecord);
+
+    return {
+      ok: true,
+      action: "stop",
+      stableWorkItemId: input.stableWorkItemId,
+      laneRunId: input.laneRunId,
+      queueRecord: revokedQueueRecord,
+      publicDiagnostics: createLaneRunLockDiagnostics(
+        createDiagnosticsLockFromQueueRecord(revokedQueueRecord, input.laneRunId, "revoked", input.actedAt),
+        sanitizedReason,
+      ),
+      lineage: {
+        relationship: "revoked",
+        previousLaneRunId: input.laneRunId,
+        preservedEvidenceRefs: await readLaneRunEvidenceRefs(stateRoot, input.laneRunId),
+      },
+    };
+  });
+}
+
+export async function retryLaneRun(
+  stateRoot: string,
+  input: LaneRunOperatorActionInput,
+): Promise<LaneRunOperatorActionResult> {
+  validateLaneRunOperatorActionInput(input);
+
+  return createLinkedQueuedOperatorAttempt(stateRoot, input, "retry");
+}
+
+export async function requeueLaneRun(
+  stateRoot: string,
+  input: LaneRunOperatorActionInput,
+): Promise<LaneRunOperatorActionResult> {
+  validateLaneRunOperatorActionInput(input);
+
+  return createLinkedQueuedOperatorAttempt(stateRoot, input, "requeue");
+}
+
 async function persistCompletedLaneRunState(
   stateRoot: string,
   previousLock: LaneRunLock,
@@ -1093,6 +1271,230 @@ async function persistCompletedLaneRunState(
       await writeLaneRunLock(stateRoot, previousLock);
     } catch (rollbackError) {
       throw new AggregateError([error, rollbackError], "Lane run completion failed and lock rollback failed.");
+    }
+
+    throw error;
+  }
+}
+
+async function createLinkedQueuedOperatorAttempt(
+  stateRoot: string,
+  input: LaneRunOperatorActionInput,
+  action: "retry" | "requeue",
+): Promise<LaneRunOperatorActionResult> {
+  return withLaneRunMutationLock(stateRoot, input.stableWorkItemId, async () => {
+    const queueRecord = await readOptionalLaneRunQueueRecord(stateRoot, input.stableWorkItemId);
+    const existingLock = await readOptionalLaneRunLock(stateRoot, input.stableWorkItemId);
+    const relationship = action === "retry" ? "retried" : "requeued";
+
+    if (queueRecord === undefined) {
+      return createBlockedLaneRunOperatorActionResult(action, input, undefined, "requested issue is not queued");
+    }
+
+    const diagnosticsLock = existingLock ?? createDiagnosticsLockFromQueueRecord(queueRecord, input.laneRunId, "active");
+
+    if (existingLock === undefined) {
+      const eligibleBlockedQueue = action === "requeue" && queueRecord.status === "revoked";
+
+      if (!eligibleBlockedQueue) {
+        return createBlockedLaneRunOperatorActionResult(
+          action,
+          input,
+          diagnosticsLock,
+          "operator action requires a terminal lane run record",
+        );
+      }
+    }
+
+    if (existingLock !== undefined && existingLock.laneRunId !== input.laneRunId) {
+      return createBlockedLaneRunOperatorActionResult(
+        action,
+        input,
+        existingLock,
+        "operator action target does not match the selected lane run",
+      );
+    }
+
+    if (existingLock?.active === true) {
+      return createBlockedLaneRunOperatorActionResult(
+        action,
+        input,
+        existingLock,
+        `cannot ${action} an active lane run; stop it first`,
+      );
+    }
+
+    if (action === "requeue" && queueRecord.status !== "revoked" && queueRecord.status !== "superseded") {
+      return createBlockedLaneRunOperatorActionResult(
+        action,
+        input,
+        diagnosticsLock,
+        "only revoked or superseded lane runs can be requeued",
+      );
+    }
+
+    const preservedEvidenceRefs = await readLaneRunEvidenceRefs(stateRoot, input.laneRunId);
+    const enqueueSequence = queueRecord.enqueueSequence + 1;
+    const sanitizedReason = publicSafeDiagnosticText(input.reason) ?? `operator requested ${action}`;
+    const { blockerReason: _blockedReason, ...linkedMetadata } = queueRecord.metadata;
+    const operatorMetadata = {
+      ...linkedMetadata,
+      operatorAction: action,
+      operatorReason: sanitizedReason,
+      previousQueueRecordId: queueRecord.id,
+      previousQueueStatus: queueRecord.status,
+      [`${action}OfLaneRunId`]: input.laneRunId,
+      ...(preservedEvidenceRefs.length > 0
+        ? { preservedEvidenceRefs: preservedEvidenceRefs.join(",") }
+        : {}),
+    };
+    const nextQueueRecord = toSerializableLaneRunQueueRecord({
+      schemaVersion: "ensen.lane-run-queue.v1",
+      id: `queue-${input.stableWorkItemId}-${enqueueSequence}`,
+      enqueueSequence,
+      stableWorkItemId: queueRecord.stableWorkItemId,
+      workItemId: queueRecord.workItemId,
+      source: queueRecord.source,
+      laneId: queueRecord.laneId,
+      repositoryClassification: queueRecord.repositoryClassification,
+      status: "queued",
+      queuedAt: input.actedAt,
+      updatedAt: input.actedAt,
+      startsAgentExecution: false,
+      metadata: operatorMetadata,
+      publicDiagnostics: {
+        stableWorkItemId: queueRecord.stableWorkItemId,
+        laneId: queueRecord.laneId,
+        source: queueRecord.source,
+        repositoryClassification: queueRecord.repositoryClassification,
+        status: "queued",
+      },
+    });
+
+    await writeLaneRunQueueRecord(stateRoot, nextQueueRecord);
+
+    return {
+      ok: true,
+      action,
+      stableWorkItemId: input.stableWorkItemId,
+      laneRunId: input.laneRunId,
+      queueRecord: nextQueueRecord,
+      lock: existingLock,
+      publicDiagnostics: createLaneRunLockDiagnostics(diagnosticsLock, sanitizedReason),
+      lineage: {
+        relationship,
+        previousLaneRunId: input.laneRunId,
+        newQueueRecordId: nextQueueRecord.id,
+        preservedEvidenceRefs,
+      },
+    };
+  });
+}
+
+function validateLaneRunOperatorActionInput(input: LaneRunOperatorActionInput): void {
+  assertSafeStableWorkItemId(input.stableWorkItemId);
+
+  if (!isLaneRunId(input.laneRunId) || !isNonEmptyString(input.reason) || !isIsoDateTime(input.actedAt)) {
+    throw new Error("Lane run operator action input is malformed.");
+  }
+
+  assertLaneRunClaimTimestamp(input.actedAt);
+}
+
+function createBlockedLaneRunOperatorActionResult(
+  action: LaneRunOperatorAction,
+  input: LaneRunOperatorActionInput,
+  lock: LaneRunLock | undefined,
+  reason: string,
+): LaneRunOperatorActionResult {
+  const diagnosticsLock =
+    lock ??
+    createDiagnosticsLockFromQueueRecord(
+      {
+        schemaVersion: "ensen.lane-run-queue.v1",
+        id: `queue-${input.stableWorkItemId}-1`,
+        enqueueSequence: 1,
+        stableWorkItemId: input.stableWorkItemId,
+        workItemId: input.stableWorkItemId,
+        source: "unknown",
+        laneId: "unknown",
+        repositoryClassification: "owner-controlled-dogfood",
+        status: "queued",
+        queuedAt: input.actedAt,
+        updatedAt: input.actedAt,
+        startsAgentExecution: false,
+        metadata: {},
+        publicDiagnostics: {
+          stableWorkItemId: input.stableWorkItemId,
+          laneId: "unknown",
+          source: "unknown",
+          repositoryClassification: "owner-controlled-dogfood",
+          status: "queued",
+        },
+      },
+      input.laneRunId,
+      "active",
+    );
+
+  return {
+    ok: false,
+    action,
+    stableWorkItemId: input.stableWorkItemId,
+    laneRunId: input.laneRunId,
+    publicDiagnostics: createLaneRunLockDiagnostics(diagnosticsLock, publicSafeDiagnosticText(reason) ?? reason),
+    lineage: {
+      relationship: action === "stop" ? "revoked" : action === "retry" ? "retried" : "requeued",
+      previousLaneRunId: input.laneRunId,
+      preservedEvidenceRefs: [],
+    },
+  };
+}
+
+function createDiagnosticsLockFromQueueRecord(
+  record: LaneRunQueueRecord,
+  laneRunId: string,
+  status: LaneRunLockStatus,
+  releasedAt?: string,
+): LaneRunLock {
+  const active = status === "active";
+  const base = {
+    schemaVersion: "ensen.lane-run-lock.v1",
+    stableWorkItemId: record.stableWorkItemId,
+    queueRecordId: record.id,
+    laneRunId,
+    laneId: record.laneId,
+    source: record.source,
+    repositoryClassification: record.repositoryClassification,
+    status,
+    active,
+    claimedAt: record.updatedAt,
+    claimedBy: "operator",
+    startsAgentExecution: false,
+  } satisfies Omit<LaneRunLock, "releasedAt">;
+
+  return releasedAt === undefined || active
+    ? base
+    : {
+        ...base,
+        releasedAt,
+      };
+}
+
+async function readLaneRunEvidenceRefs(stateRoot: string, laneRunId: string): Promise<readonly string[]> {
+  const state = await readOptionalLaneRunState(stateRoot, laneRunId);
+
+  return state?.evidence.bundleRefs ?? [];
+}
+
+async function readOptionalLaneRunState(
+  stateRoot: string,
+  laneRunId: string,
+): Promise<LaneRunState | undefined> {
+  try {
+    return await readLaneRunState(stateRoot, laneRunId);
+  } catch (error) {
+    if (isNodeError(error) && error.code === "ENOENT") {
+      return undefined;
     }
 
     throw error;

--- a/src/lane/index.ts
+++ b/src/lane/index.ts
@@ -1162,7 +1162,8 @@ export async function stopLaneRun(
 
       assertLaneRunCompletionTimestamp(existingLock.claimedAt, input.actedAt);
 
-      const preservedEvidenceRefs = await readLaneRunEvidenceRefs(stateRoot, existingLock.laneRunId);
+      const verifiedLaneRunId = existingLock.laneRunId;
+      const preservedEvidenceRefs = await readLaneRunEvidenceRefs(stateRoot, verifiedLaneRunId);
       const revokedLock = toSerializableLaneRunLock({
         ...existingLock,
         status: "revoked",
@@ -1178,7 +1179,7 @@ export async function stopLaneRun(
           operatorAction: "stop",
           operatorReason: metadataReason,
           revokedByOperatorAt: input.actedAt,
-          revokedLaneRunId: existingLock.laneRunId,
+          revokedLaneRunId: verifiedLaneRunId,
         },
         publicDiagnostics: {
           ...queueRecord.publicDiagnostics,
@@ -1198,7 +1199,7 @@ export async function stopLaneRun(
         publicDiagnostics: createLaneRunLockDiagnostics(revokedLock, sanitizedReason),
         lineage: {
           relationship: "revoked",
-          previousLaneRunId: existingLock.laneRunId,
+          previousLaneRunId: verifiedLaneRunId,
           preservedEvidenceRefs,
         },
       };
@@ -1325,6 +1326,8 @@ async function createLinkedQueuedOperatorAttempt(
     const queueRecord = await readOptionalLaneRunQueueRecord(stateRoot, input.stableWorkItemId);
     const existingLock = await readOptionalLaneRunLock(stateRoot, input.stableWorkItemId);
     const relationship = action === "retry" ? "retried" : "requeued";
+    let verifiedLaneRunId = input.laneRunId;
+    let verifiedEvidenceRefs: readonly string[] | undefined;
 
     if (queueRecord === undefined) {
       return createBlockedLaneRunOperatorActionResult(action, input, undefined, "requested issue is not queued");
@@ -1366,6 +1369,9 @@ async function createLinkedQueuedOperatorAttempt(
           "operator action target requires verified terminal lane run state",
         );
       }
+
+      verifiedLaneRunId = verifiedTarget.state.id;
+      verifiedEvidenceRefs = verifiedTarget.evidenceRefs;
     }
 
     if (existingLock !== undefined && existingLock.laneRunId !== input.laneRunId) {
@@ -1375,6 +1381,10 @@ async function createLinkedQueuedOperatorAttempt(
         existingLock,
         "operator action target does not match the selected lane run",
       );
+    }
+
+    if (existingLock !== undefined) {
+      verifiedLaneRunId = existingLock.laneRunId;
     }
 
     if (existingLock?.active === true) {
@@ -1395,7 +1405,7 @@ async function createLinkedQueuedOperatorAttempt(
       );
     }
 
-    const preservedEvidenceRefs = await readLaneRunEvidenceRefs(stateRoot, input.laneRunId);
+    const preservedEvidenceRefs = verifiedEvidenceRefs ?? (await readLaneRunEvidenceRefs(stateRoot, verifiedLaneRunId));
     const enqueueSequence = queueRecord.enqueueSequence + 1;
     const sanitizedReason = publicSafeDiagnosticText(input.reason) ?? `operator requested ${action}`;
     const metadataReason = toBoundedLaneRunQueueMetadataValue(sanitizedReason);
@@ -1406,7 +1416,7 @@ async function createLinkedQueuedOperatorAttempt(
       operatorReason: metadataReason,
       previousQueueRecordId: queueRecord.id,
       previousQueueStatus: queueRecord.status,
-      [`${action}OfLaneRunId`]: input.laneRunId,
+      [`${action}OfLaneRunId`]: verifiedLaneRunId,
       ...createPreservedEvidenceQueueMetadata(preservedEvidenceRefs),
     };
     const nextQueueRecord = toSerializableLaneRunQueueRecord({
@@ -1438,13 +1448,13 @@ async function createLinkedQueuedOperatorAttempt(
       ok: true,
       action,
       stableWorkItemId: input.stableWorkItemId,
-      laneRunId: input.laneRunId,
+      laneRunId: verifiedLaneRunId,
       queueRecord: nextQueueRecord,
       lock: existingLock,
       publicDiagnostics: createLaneRunLockDiagnostics(diagnosticsLock, sanitizedReason),
       lineage: {
         relationship,
-        previousLaneRunId: input.laneRunId,
+        previousLaneRunId: verifiedLaneRunId,
         newQueueRecordId: nextQueueRecord.id,
         preservedEvidenceRefs,
       },

--- a/src/lane/index.ts
+++ b/src/lane/index.ts
@@ -1111,7 +1111,7 @@ export async function completeLaneRunLock(
       updatedAt: input.completedAt,
       metadata: {
         ...queueRecord.metadata,
-        [`${input.terminalStatus}LaneRunId`]: input.laneRunId,
+        [`${input.terminalStatus}LaneRunId`]: toBoundedLaneRunQueueMetadataValue(input.laneRunId),
       },
       publicDiagnostics: {
         ...queueRecord.publicDiagnostics,
@@ -1160,7 +1160,7 @@ export async function stopLaneRun(
         );
       }
 
-      assertLaneRunCompletionTimestamp(existingLock.claimedAt, input.actedAt);
+      assertLaneRunOperatorActionTimestamp(existingLock.claimedAt, input.actedAt);
 
       const verifiedLaneRunId = existingLock.laneRunId;
       const preservedEvidenceRefs = await readLaneRunEvidenceRefs(stateRoot, verifiedLaneRunId);
@@ -1835,6 +1835,15 @@ function assertLaneRunCompletionTimestamp(claimedAt: string, completedAt: string
     completedAtMs - Date.now() > laneRunCompletionClockSkewMs
   ) {
     throw new Error("Lane run lock completion timestamp must stay within the active claim window.");
+  }
+}
+
+function assertLaneRunOperatorActionTimestamp(claimedAt: string, actedAt: string): void {
+  const claimedAtMs = Date.parse(claimedAt);
+  const actedAtMs = Date.parse(actedAt);
+
+  if (actedAtMs < claimedAtMs || actedAtMs - Date.now() > laneRunCompletionClockSkewMs) {
+    throw new Error("Lane run operator action timestamp must not predate the active claim or exceed local clock tolerance.");
   }
 }
 

--- a/src/lane/index.ts
+++ b/src/lane/index.ts
@@ -1141,6 +1141,7 @@ export async function stopLaneRun(
     if (existingLock?.active === true) {
       assertLaneRunCompletionTimestamp(existingLock.claimedAt, input.actedAt);
 
+      const preservedEvidenceRefs = await readLaneRunEvidenceRefs(stateRoot, existingLock.laneRunId);
       const revokedLock = toSerializableLaneRunLock({
         ...existingLock,
         status: "revoked",
@@ -1177,7 +1178,7 @@ export async function stopLaneRun(
         lineage: {
           relationship: "revoked",
           previousLaneRunId: existingLock.laneRunId,
-          preservedEvidenceRefs: await readLaneRunEvidenceRefs(stateRoot, existingLock.laneRunId),
+          preservedEvidenceRefs,
         },
       };
     }
@@ -1197,6 +1198,22 @@ export async function stopLaneRun(
         input,
         createDiagnosticsLockFromQueueRecord(queueRecord, input.laneRunId, "active"),
         "only active or blocked lane runs can be stopped",
+      );
+    }
+
+    const verifiedTarget = await readVerifiedQueuedLaneRunOperatorTarget(
+      stateRoot,
+      queueRecord,
+      input.laneRunId,
+      "blocked",
+    );
+
+    if (verifiedTarget === undefined) {
+      return createBlockedLaneRunOperatorActionResult(
+        "stop",
+        input,
+        createDiagnosticsLockFromQueueRecord(queueRecord, input.laneRunId, "active"),
+        "operator action target requires verified blocked lane run state",
       );
     }
 
@@ -1232,7 +1249,7 @@ export async function stopLaneRun(
       lineage: {
         relationship: "revoked",
         previousLaneRunId: input.laneRunId,
-        preservedEvidenceRefs: await readLaneRunEvidenceRefs(stateRoot, input.laneRunId),
+        preservedEvidenceRefs: verifiedTarget.evidenceRefs,
       },
     };
   });
@@ -1304,6 +1321,22 @@ async function createLinkedQueuedOperatorAttempt(
           "operator action requires a terminal lane run record",
         );
       }
+
+      const verifiedTarget = await readVerifiedQueuedLaneRunOperatorTarget(
+        stateRoot,
+        queueRecord,
+        input.laneRunId,
+        undefined,
+      );
+
+      if (verifiedTarget === undefined || queueRecord.metadata.revokedLaneRunId !== input.laneRunId) {
+        return createBlockedLaneRunOperatorActionResult(
+          action,
+          input,
+          diagnosticsLock,
+          "operator action target requires verified revoked lane run state",
+        );
+      }
     }
 
     if (existingLock !== undefined && existingLock.laneRunId !== input.laneRunId) {
@@ -1344,9 +1377,7 @@ async function createLinkedQueuedOperatorAttempt(
       previousQueueRecordId: queueRecord.id,
       previousQueueStatus: queueRecord.status,
       [`${action}OfLaneRunId`]: input.laneRunId,
-      ...(preservedEvidenceRefs.length > 0
-        ? { preservedEvidenceRefs: preservedEvidenceRefs.join(",") }
-        : {}),
+      ...createPreservedEvidenceQueueMetadata(preservedEvidenceRefs),
     };
     const nextQueueRecord = toSerializableLaneRunQueueRecord({
       schemaVersion: "ensen.lane-run-queue.v1",
@@ -1484,6 +1515,38 @@ async function readLaneRunEvidenceRefs(stateRoot: string, laneRunId: string): Pr
   const state = await readOptionalLaneRunState(stateRoot, laneRunId);
 
   return state?.evidence.bundleRefs ?? [];
+}
+
+async function readVerifiedQueuedLaneRunOperatorTarget(
+  stateRoot: string,
+  queueRecord: LaneRunQueueRecord,
+  laneRunId: string,
+  expectedStatus: LaneRunStatus | undefined,
+): Promise<{ readonly state: LaneRunState; readonly evidenceRefs: readonly string[] } | undefined> {
+  const state = await readOptionalLaneRunState(stateRoot, laneRunId);
+
+  if (state === undefined || state.workItemId !== queueRecord.workItemId) {
+    return undefined;
+  }
+
+  if (expectedStatus !== undefined && state.status !== expectedStatus) {
+    return undefined;
+  }
+
+  return {
+    state,
+    evidenceRefs: state.evidence.bundleRefs,
+  };
+}
+
+function createPreservedEvidenceQueueMetadata(
+  preservedEvidenceRefs: readonly string[],
+): Record<string, string> {
+  return preservedEvidenceRefs.length === 0
+    ? {}
+    : {
+        preservedEvidenceRefCount: String(preservedEvidenceRefs.length),
+      };
 }
 
 async function readOptionalLaneRunState(

--- a/src/lane/index.ts
+++ b/src/lane/index.ts
@@ -1,6 +1,6 @@
 import { constants } from "node:fs";
 import type { Stats } from "node:fs";
-import { randomUUID } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import { lstat, mkdir, open, readdir, realpath, rename, rm, rmdir, utimes } from "node:fs/promises";
 import type { FileHandle } from "node:fs/promises";
 import path from "node:path";
@@ -1111,7 +1111,7 @@ export async function completeLaneRunLock(
       updatedAt: input.completedAt,
       metadata: {
         ...queueRecord.metadata,
-        [`${input.terminalStatus}LaneRunId`]: toBoundedLaneRunQueueMetadataValue(input.laneRunId),
+        ...createLaneRunIdQueueMetadata(input.terminalStatus, input.laneRunId),
       },
       publicDiagnostics: {
         ...queueRecord.publicDiagnostics,
@@ -1179,7 +1179,7 @@ export async function stopLaneRun(
           operatorAction: "stop",
           operatorReason: metadataReason,
           revokedByOperatorAt: input.actedAt,
-          revokedLaneRunId: verifiedLaneRunId,
+          ...createLaneRunIdQueueMetadata("revoked", verifiedLaneRunId),
         },
         publicDiagnostics: {
           ...queueRecord.publicDiagnostics,
@@ -1249,7 +1249,7 @@ export async function stopLaneRun(
         operatorAction: "stop",
         operatorReason: metadataReason,
         revokedByOperatorAt: input.actedAt,
-        revokedLaneRunId: verifiedLaneRunId,
+        ...createLaneRunIdQueueMetadata("revoked", verifiedLaneRunId),
       },
       publicDiagnostics: {
         ...queueRecord.publicDiagnostics,
@@ -1416,7 +1416,7 @@ async function createLinkedQueuedOperatorAttempt(
       operatorReason: metadataReason,
       previousQueueRecordId: queueRecord.id,
       previousQueueStatus: queueRecord.status,
-      [`${action}OfLaneRunId`]: verifiedLaneRunId,
+      ...createLaneRunIdQueueMetadata(`${action}Of`, verifiedLaneRunId),
       ...createPreservedEvidenceQueueMetadata(preservedEvidenceRefs),
     };
     const nextQueueRecord = toSerializableLaneRunQueueRecord({
@@ -1597,14 +1597,38 @@ function createPreservedEvidenceQueueMetadata(
 
 function isTerminalQueueRecordLinkedToLaneRun(record: LaneRunQueueRecord, laneRunId: string): boolean {
   if (record.status === "revoked") {
-    return record.metadata.revokedLaneRunId === laneRunId;
+    return isLaneRunIdMetadataMatch(record.metadata, "revoked", laneRunId);
   }
 
   if (record.status === "superseded") {
-    return record.metadata.supersededLaneRunId === laneRunId;
+    return isLaneRunIdMetadataMatch(record.metadata, "superseded", laneRunId);
   }
 
   return false;
+}
+
+function createLaneRunIdQueueMetadata(prefix: string, laneRunId: string): Record<string, string> {
+  return {
+    [`${prefix}LaneRunId`]: toBoundedLaneRunQueueMetadataValue(laneRunId),
+    [`${prefix}LaneRunIdSha256`]: createLaneRunIdDigest(laneRunId),
+  };
+}
+
+function isLaneRunIdMetadataMatch(
+  metadata: Record<string, string>,
+  prefix: string,
+  laneRunId: string,
+): boolean {
+  const projectedLaneRunId = metadata[`${prefix}LaneRunId`];
+
+  return (
+    projectedLaneRunId === laneRunId ||
+    (projectedLaneRunId !== undefined && metadata[`${prefix}LaneRunIdSha256`] === createLaneRunIdDigest(laneRunId))
+  );
+}
+
+function createLaneRunIdDigest(laneRunId: string): string {
+  return createHash("sha256").update(laneRunId).digest("hex");
 }
 
 function toBoundedLaneRunQueueMetadataValue(value: string): string {

--- a/src/lane/index.ts
+++ b/src/lane/index.ts
@@ -1396,6 +1396,15 @@ async function createLinkedQueuedOperatorAttempt(
       );
     }
 
+    if (action === "retry" && queueRecord.status === "queued") {
+      return createBlockedLaneRunOperatorActionResult(
+        action,
+        input,
+        diagnosticsLock,
+        "operator action requires a terminal lane run record",
+      );
+    }
+
     if (action === "requeue" && queueRecord.status !== "revoked" && queueRecord.status !== "superseded") {
       return createBlockedLaneRunOperatorActionResult(
         action,

--- a/src/lane/index.ts
+++ b/src/lane/index.ts
@@ -1109,6 +1109,10 @@ export async function completeLaneRunLock(
       ...queueRecord,
       status: input.terminalStatus,
       updatedAt: input.completedAt,
+      metadata: {
+        ...queueRecord.metadata,
+        [`${input.terminalStatus}LaneRunId`]: input.laneRunId,
+      },
       publicDiagnostics: {
         ...queueRecord.publicDiagnostics,
         status: input.terminalStatus,
@@ -1234,6 +1238,7 @@ export async function stopLaneRun(
       );
     }
 
+    const verifiedLaneRunId = verifiedTarget.state.id;
     const revokedQueueRecord = toSerializableLaneRunQueueRecord({
       ...queueRecord,
       status: "revoked",
@@ -1243,7 +1248,7 @@ export async function stopLaneRun(
         operatorAction: "stop",
         operatorReason: metadataReason,
         revokedByOperatorAt: input.actedAt,
-        revokedLaneRunId: input.laneRunId,
+        revokedLaneRunId: verifiedLaneRunId,
       },
       publicDiagnostics: {
         ...queueRecord.publicDiagnostics,
@@ -1260,12 +1265,12 @@ export async function stopLaneRun(
       laneRunId: input.laneRunId,
       queueRecord: revokedQueueRecord,
       publicDiagnostics: createLaneRunLockDiagnostics(
-        createDiagnosticsLockFromQueueRecord(revokedQueueRecord, input.laneRunId, "revoked", input.actedAt),
+        createDiagnosticsLockFromQueueRecord(revokedQueueRecord, verifiedLaneRunId, "revoked", input.actedAt),
         sanitizedReason,
       ),
       lineage: {
         relationship: "revoked",
-        previousLaneRunId: input.laneRunId,
+        previousLaneRunId: verifiedLaneRunId,
         preservedEvidenceRefs: verifiedTarget.evidenceRefs,
       },
     };
@@ -1353,15 +1358,12 @@ async function createLinkedQueuedOperatorAttempt(
         undefined,
       );
 
-      if (
-        verifiedTarget === undefined ||
-        (queueRecord.status === "revoked" && queueRecord.metadata.revokedLaneRunId !== input.laneRunId)
-      ) {
+      if (verifiedTarget === undefined || !isTerminalQueueRecordLinkedToLaneRun(queueRecord, verifiedTarget.state.id)) {
         return createBlockedLaneRunOperatorActionResult(
           action,
           input,
           diagnosticsLock,
-          "operator action target requires verified revoked lane run state",
+          "operator action target requires verified terminal lane run state",
         );
       }
     }
@@ -1581,6 +1583,18 @@ function createPreservedEvidenceQueueMetadata(
     : {
         preservedEvidenceRefCount: String(preservedEvidenceRefs.length),
       };
+}
+
+function isTerminalQueueRecordLinkedToLaneRun(record: LaneRunQueueRecord, laneRunId: string): boolean {
+  if (record.status === "revoked") {
+    return record.metadata.revokedLaneRunId === laneRunId;
+  }
+
+  if (record.status === "superseded") {
+    return record.metadata.supersededLaneRunId === laneRunId;
+  }
+
+  return false;
 }
 
 function toBoundedLaneRunQueueMetadataValue(value: string): string {

--- a/src/lane/index.ts
+++ b/src/lane/index.ts
@@ -1124,6 +1124,7 @@ export async function stopLaneRun(
     const queueRecord = await readOptionalLaneRunQueueRecord(stateRoot, input.stableWorkItemId);
     const existingLock = await readOptionalLaneRunLock(stateRoot, input.stableWorkItemId);
     const sanitizedReason = publicSafeDiagnosticText(input.reason) ?? "operator requested stop";
+    const metadataReason = toLaneRunQueueMetadataValue(sanitizedReason);
 
     if (queueRecord === undefined) {
       return createBlockedLaneRunOperatorActionResult("stop", input, undefined, "requested issue is not queued");
@@ -1162,9 +1163,9 @@ export async function stopLaneRun(
         status: "revoked",
         updatedAt: input.actedAt,
         metadata: {
-          ...queueRecord.metadata,
+          ...copyQueueMetadataWithout(queueRecord.metadata, ["blockerReason"]),
           operatorAction: "stop",
-          operatorReason: sanitizedReason,
+          operatorReason: metadataReason,
           revokedByOperatorAt: input.actedAt,
           revokedLaneRunId: existingLock.laneRunId,
         },
@@ -1233,7 +1234,7 @@ export async function stopLaneRun(
       metadata: {
         ...copyQueueMetadataWithout(queueRecord.metadata, ["blockerReason"]),
         operatorAction: "stop",
-        operatorReason: sanitizedReason,
+        operatorReason: metadataReason,
         revokedByOperatorAt: input.actedAt,
         revokedLaneRunId: input.laneRunId,
       },
@@ -1317,12 +1318,19 @@ async function createLinkedQueuedOperatorAttempt(
       return createBlockedLaneRunOperatorActionResult(action, input, undefined, "requested issue is not queued");
     }
 
-    const diagnosticsLock = existingLock ?? createDiagnosticsLockFromQueueRecord(queueRecord, input.laneRunId, "active");
+    const diagnosticsLock =
+      existingLock ??
+      createDiagnosticsLockFromQueueRecord(
+        queueRecord,
+        input.laneRunId,
+        toQueueRecordDiagnosticsLockStatus(queueRecord),
+      );
 
     if (existingLock === undefined) {
-      const eligibleBlockedQueue = action === "requeue" && queueRecord.status === "revoked";
+      const eligibleTerminalQueue =
+        action === "requeue" && (queueRecord.status === "revoked" || queueRecord.status === "superseded");
 
-      if (!eligibleBlockedQueue) {
+      if (!eligibleTerminalQueue) {
         return createBlockedLaneRunOperatorActionResult(
           action,
           input,
@@ -1338,7 +1346,10 @@ async function createLinkedQueuedOperatorAttempt(
         undefined,
       );
 
-      if (verifiedTarget === undefined || queueRecord.metadata.revokedLaneRunId !== input.laneRunId) {
+      if (
+        verifiedTarget === undefined ||
+        (queueRecord.status === "revoked" && queueRecord.metadata.revokedLaneRunId !== input.laneRunId)
+      ) {
         return createBlockedLaneRunOperatorActionResult(
           action,
           input,
@@ -1378,6 +1389,7 @@ async function createLinkedQueuedOperatorAttempt(
     const preservedEvidenceRefs = await readLaneRunEvidenceRefs(stateRoot, input.laneRunId);
     const enqueueSequence = queueRecord.enqueueSequence + 1;
     const sanitizedReason = publicSafeDiagnosticText(input.reason) ?? `operator requested ${action}`;
+    const metadataReason = toLaneRunQueueMetadataValue(sanitizedReason);
     const linkedMetadata = copyQueueMetadataWithout(queueRecord.metadata, [
       "blockerReason",
       "preservedEvidenceRefCount",
@@ -1386,7 +1398,7 @@ async function createLinkedQueuedOperatorAttempt(
     const operatorMetadata = {
       ...linkedMetadata,
       operatorAction: action,
-      operatorReason: sanitizedReason,
+      operatorReason: metadataReason,
       previousQueueRecordId: queueRecord.id,
       previousQueueStatus: queueRecord.status,
       [`${action}OfLaneRunId`]: input.laneRunId,
@@ -1524,6 +1536,12 @@ function createDiagnosticsLockFromQueueRecord(
       };
 }
 
+function toQueueRecordDiagnosticsLockStatus(record: LaneRunQueueRecord): LaneRunLockStatus {
+  return record.status === "completed" || record.status === "revoked" || record.status === "superseded"
+    ? record.status
+    : "active";
+}
+
 async function readLaneRunEvidenceRefs(stateRoot: string, laneRunId: string): Promise<readonly string[]> {
   const state = await readOptionalLaneRunState(stateRoot, laneRunId);
 
@@ -1560,6 +1578,10 @@ function createPreservedEvidenceQueueMetadata(
     : {
         preservedEvidenceRefCount: String(preservedEvidenceRefs.length),
       };
+}
+
+function toLaneRunQueueMetadataValue(value: string): string {
+  return value.length <= 256 ? value : `${value.slice(0, 253)}...`;
 }
 
 function copyQueueMetadataWithout(

--- a/src/lane/index.ts
+++ b/src/lane/index.ts
@@ -1139,6 +1139,15 @@ export async function stopLaneRun(
     }
 
     if (existingLock?.active === true) {
+      if (queueRecord.id !== existingLock.queueRecordId) {
+        return createBlockedLaneRunOperatorActionResult(
+          "stop",
+          input,
+          existingLock,
+          "lane run queue record does not match the active lane run lock",
+        );
+      }
+
       assertLaneRunCompletionTimestamp(existingLock.claimedAt, input.actedAt);
 
       const preservedEvidenceRefs = await readLaneRunEvidenceRefs(stateRoot, existingLock.laneRunId);
@@ -1222,7 +1231,7 @@ export async function stopLaneRun(
       status: "revoked",
       updatedAt: input.actedAt,
       metadata: {
-        ...queueRecord.metadata,
+        ...copyQueueMetadataWithout(queueRecord.metadata, ["blockerReason"]),
         operatorAction: "stop",
         operatorReason: sanitizedReason,
         revokedByOperatorAt: input.actedAt,
@@ -1369,7 +1378,11 @@ async function createLinkedQueuedOperatorAttempt(
     const preservedEvidenceRefs = await readLaneRunEvidenceRefs(stateRoot, input.laneRunId);
     const enqueueSequence = queueRecord.enqueueSequence + 1;
     const sanitizedReason = publicSafeDiagnosticText(input.reason) ?? `operator requested ${action}`;
-    const { blockerReason: _blockedReason, ...linkedMetadata } = queueRecord.metadata;
+    const linkedMetadata = copyQueueMetadataWithout(queueRecord.metadata, [
+      "blockerReason",
+      "preservedEvidenceRefCount",
+      "preservedEvidenceRefs",
+    ]);
     const operatorMetadata = {
       ...linkedMetadata,
       operatorAction: action,
@@ -1547,6 +1560,19 @@ function createPreservedEvidenceQueueMetadata(
     : {
         preservedEvidenceRefCount: String(preservedEvidenceRefs.length),
       };
+}
+
+function copyQueueMetadataWithout(
+  metadata: Record<string, string>,
+  keys: readonly string[],
+): Record<string, string> {
+  const copiedMetadata = { ...metadata };
+
+  for (const key of keys) {
+    delete copiedMetadata[key];
+  }
+
+  return copiedMetadata;
 }
 
 async function readOptionalLaneRunState(

--- a/test/lane-run-operator-actions.test.ts
+++ b/test/lane-run-operator-actions.test.ts
@@ -16,6 +16,7 @@ import {
   readLaneRunLock,
   readLaneRunQueueRecord,
   requeueLaneRun,
+  resolveLaneRunLockPath,
   resolveLaneRunQueueRecordPath,
   retryLaneRun,
   stopLaneRun,
@@ -73,6 +74,7 @@ test("stop revokes an active lane run with a public operator reason", async () =
       repositoryClassification: "owner-controlled-dogfood",
       queuedAt,
       metadata: {
+        blockerReason: "stale blocker carried by queued record",
         issueNumber: "112",
       },
     });
@@ -104,6 +106,41 @@ test("stop revokes an active lane run with a public operator reason", async () =
     assert.equal(queue.status, "revoked");
     assert.equal(queue.metadata.revokedByOperatorAt, actedAt);
     assert.equal(queue.metadata.operatorReason, "operator found missing evidence <redacted>");
+    assert.equal(Object.hasOwn(queue.metadata, "blockerReason"), false);
+    assert.equal((await getLaneRunStatus(stateRoot)).queue[0]?.laneState, "revoked");
+  });
+});
+
+test("stop stores a bounded public reason in queue metadata", async () => {
+  await withStateRoot(async (stateRoot) => {
+    await enqueueLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-112",
+      workItemId: "issue-112",
+      source: "github-issue",
+      laneId: "owner-dogfood",
+      repositoryClassification: "owner-controlled-dogfood",
+      queuedAt,
+    });
+    await claimQueuedLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-112",
+      laneRunId: "lane-run-112-a",
+      claimedBy: "local-supervisor",
+      claimedAt,
+    });
+
+    const longReason = `operator reason ${"x".repeat(300)}`;
+    const result = await stopLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-112",
+      laneRunId: "lane-run-112-a",
+      reason: longReason,
+      actedAt,
+    });
+
+    assert.equal(result.ok, true);
+
+    const queue = await readLaneRunQueueRecord(stateRoot, "github-issue-112");
+    assert.equal(queue.metadata.operatorReason.length, 256);
+    assert.equal(queue.metadata.operatorReason.endsWith("..."), true);
   });
 });
 
@@ -253,10 +290,11 @@ test("retry links a new queued attempt to prior evidence without deleting lane s
     );
 
     const originalState = await readFile(path.join(stateRoot, "lane-runs", "lane-run-112-a.json"), "utf8");
+    const longReason = `retry after focused fix ${"x".repeat(300)}`;
     const result = await retryLaneRun(stateRoot, {
       stableWorkItemId: "github-issue-112",
       laneRunId: "lane-run-112-a",
-      reason: "retry after focused fix",
+      reason: longReason,
       actedAt,
     });
 
@@ -278,6 +316,8 @@ test("retry links a new queued attempt to prior evidence without deleting lane s
     assert.equal(queue.enqueueSequence, 2);
     assert.equal(queue.metadata.retryOfLaneRunId, "lane-run-112-a");
     assert.equal(queue.metadata.previousQueueRecordId, "queue-github-issue-112-1");
+    assert.equal(queue.metadata.operatorReason.length, 256);
+    assert.equal(queue.metadata.operatorReason.endsWith("..."), true);
     assert.equal(queue.metadata.preservedEvidenceRefCount, "1");
     assert.equal(Object.hasOwn(queue.metadata, "preservedEvidenceRefs"), false);
     assert.equal(await readFile(path.join(stateRoot, "lane-runs", "lane-run-112-a.json"), "utf8"), originalState);
@@ -468,6 +508,63 @@ test("requeue without a lock requires verified revoked lane state ownership", as
     assert.equal(result.ok, false);
     assert.equal(result.publicDiagnostics.reason, "operator action target requires verified revoked lane run state");
     assert.deepEqual(await readLaneRunQueueRecord(stateRoot, "github-issue-112"), revokedQueue);
+  });
+});
+
+test("requeue without a lock accepts verified superseded queue records", async () => {
+  await withStateRoot(async (stateRoot) => {
+    await enqueueLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-112",
+      workItemId: "issue-112",
+      source: "github-issue",
+      laneId: "owner-dogfood",
+      repositoryClassification: "owner-controlled-dogfood",
+      queuedAt,
+    });
+    await claimQueuedLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-112",
+      laneRunId: "lane-run-112-a",
+      claimedBy: "local-supervisor",
+      claimedAt,
+    });
+    await completeLaneRunLock(stateRoot, {
+      stableWorkItemId: "github-issue-112",
+      laneRunId: "lane-run-112-a",
+      completedAt: actedAt,
+      terminalStatus: "superseded",
+    });
+    await writeLaneRunState(
+      stateRoot,
+      createLaneRunState({
+        id: "lane-run-112-a",
+        workItemId: "issue-112",
+        status: "failed",
+        revision: 1,
+        createdAt: claimedAt,
+        updatedAt: actedAt,
+        journal: createLaneJournal({
+          id: "journal-lane-run-112-a",
+          laneRunId: "lane-run-112-a",
+          workItemId: "issue-112",
+        }),
+      }),
+    );
+    await rm(resolveLaneRunLockPath(stateRoot, "github-issue-112"), { force: true });
+
+    const result = await requeueLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-112",
+      laneRunId: "lane-run-112-a",
+      reason: "operator requeue superseded record",
+      actedAt,
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.publicDiagnostics.lockStatus, "superseded");
+
+    const queue = await readLaneRunQueueRecord(stateRoot, "github-issue-112");
+    assert.equal(queue.status, "queued");
+    assert.equal(queue.metadata.previousQueueStatus, "superseded");
+    assert.equal(queue.metadata.requeueOfLaneRunId, "lane-run-112-a");
   });
 });
 

--- a/test/lane-run-operator-actions.test.ts
+++ b/test/lane-run-operator-actions.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import { execFile } from "node:child_process";
+import { createHash } from "node:crypto";
 import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -27,6 +28,10 @@ const execFileAsync = promisify(execFile);
 const queuedAt = new Date(Date.now() - 120_000).toISOString();
 const claimedAt = new Date(Date.now() - 60_000).toISOString();
 const actedAt = new Date(Date.now() - 1_000).toISOString();
+
+function laneRunIdDigest(laneRunId: string): string {
+  return createHash("sha256").update(laneRunId).digest("hex");
+}
 
 async function withStateRoot(callback: (stateRoot: string) => Promise<void>): Promise<void> {
   const stateRoot = await mkdtemp(path.join(os.tmpdir(), "ensen-loop-state-"));
@@ -826,6 +831,82 @@ test("requeue without a lock accepts verified superseded queue records", async (
     assert.equal(queue.status, "queued");
     assert.equal(queue.metadata.previousQueueStatus, "superseded");
     assert.equal(queue.metadata.requeueOfLaneRunId, "lane-run-112-a");
+  });
+});
+
+test("requeue without a lock verifies terminal lineage by digest when metadata id is bounded", async () => {
+  await withStateRoot(async (stateRoot) => {
+    await enqueueLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-112",
+      workItemId: "issue-112",
+      source: "github-issue",
+      laneId: "owner-dogfood",
+      repositoryClassification: "owner-controlled-dogfood",
+      queuedAt,
+    });
+    await claimQueuedLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-112",
+      laneRunId: "lane-run-112-a",
+      claimedBy: "local-supervisor",
+      claimedAt,
+    });
+    await completeLaneRunLock(stateRoot, {
+      stableWorkItemId: "github-issue-112",
+      laneRunId: "lane-run-112-a",
+      completedAt: actedAt,
+      terminalStatus: "superseded",
+    });
+    await writeLaneRunState(
+      stateRoot,
+      createLaneRunState({
+        id: "lane-run-112-a",
+        workItemId: "issue-112",
+        status: "failed",
+        revision: 1,
+        createdAt: claimedAt,
+        updatedAt: actedAt,
+        journal: createLaneJournal({
+          id: "journal-lane-run-112-a",
+          laneRunId: "lane-run-112-a",
+          workItemId: "issue-112",
+        }),
+      }),
+    );
+    await rm(resolveLaneRunLockPath(stateRoot, "github-issue-112"), { force: true });
+
+    const supersededQueue = await readLaneRunQueueRecord(stateRoot, "github-issue-112");
+    await writeFile(
+      resolveLaneRunQueueRecordPath(stateRoot, "github-issue-112"),
+      `${JSON.stringify(
+        {
+          ...supersededQueue,
+          metadata: {
+            ...supersededQueue.metadata,
+            supersededLaneRunId: "bounded-lane-run-id-projection",
+            supersededLaneRunIdSha256: laneRunIdDigest("lane-run-112-a"),
+          },
+        },
+        null,
+        2,
+      )}\n`,
+      "utf8",
+    );
+
+    const result = await requeueLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-112",
+      laneRunId: "lane-run-112-a",
+      reason: "operator requeue superseded record",
+      actedAt,
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.lineage.previousLaneRunId, "lane-run-112-a");
+
+    const queue = await readLaneRunQueueRecord(stateRoot, "github-issue-112");
+    assert.equal(queue.status, "queued");
+    assert.equal(queue.metadata.previousQueueStatus, "superseded");
+    assert.equal(queue.metadata.requeueOfLaneRunId, "lane-run-112-a");
+    assert.equal(queue.metadata.requeueOfLaneRunIdSha256, laneRunIdDigest("lane-run-112-a"));
   });
 });
 

--- a/test/lane-run-operator-actions.test.ts
+++ b/test/lane-run-operator-actions.test.ts
@@ -144,6 +144,45 @@ test("stop stores a bounded public reason in queue metadata", async () => {
   });
 });
 
+test("stop revokes a long-running active lane run", async () => {
+  await withStateRoot(async (stateRoot) => {
+    const staleQueuedAt = new Date(Date.now() - 10 * 24 * 60 * 60 * 1000).toISOString();
+    const staleClaimedAt = new Date(Date.now() - 9 * 24 * 60 * 60 * 1000).toISOString();
+
+    await enqueueLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-112",
+      workItemId: "issue-112",
+      source: "github-issue",
+      laneId: "owner-dogfood",
+      repositoryClassification: "owner-controlled-dogfood",
+      queuedAt: staleQueuedAt,
+    });
+    await claimQueuedLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-112",
+      laneRunId: "lane-run-112-a",
+      claimedBy: "local-supervisor",
+      claimedAt: staleClaimedAt,
+    });
+
+    const result = await stopLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-112",
+      laneRunId: "lane-run-112-a",
+      reason: "operator revokes stale active lane run",
+      actedAt,
+    });
+
+    assert.equal(result.ok, true);
+
+    const lock = await readLaneRunLock(stateRoot, "github-issue-112");
+    const queue = await readLaneRunQueueRecord(stateRoot, "github-issue-112");
+
+    assert.equal(lock.status, "revoked");
+    assert.equal(lock.releasedAt, actedAt);
+    assert.equal(queue.status, "revoked");
+    assert.equal(queue.metadata.revokedLaneRunId, "lane-run-112-a");
+  });
+});
+
 test("stop reads active lineage evidence before mutating durable state", async () => {
   await withStateRoot(async (stateRoot) => {
     const queued = await enqueueLaneRun(stateRoot, {

--- a/test/lane-run-operator-actions.test.ts
+++ b/test/lane-run-operator-actions.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { execFile } from "node:child_process";
-import { mkdir, mkdtemp, readFile, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -105,6 +105,67 @@ test("stop revokes an active lane run with a public operator reason", async () =
   });
 });
 
+test("stop reads active lineage evidence before mutating durable state", async () => {
+  await withStateRoot(async (stateRoot) => {
+    const queued = await enqueueLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-112",
+      workItemId: "issue-112",
+      source: "github-issue",
+      laneId: "owner-dogfood",
+      repositoryClassification: "owner-controlled-dogfood",
+      queuedAt,
+    });
+    const claim = await claimQueuedLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-112",
+      laneRunId: "lane-run-112-a",
+      claimedBy: "local-supervisor",
+      claimedAt,
+    });
+    await writeFile(path.join(stateRoot, "lane-runs", "lane-run-112-a.json"), "{}\n", "utf8");
+
+    await assert.rejects(
+      () =>
+        stopLaneRun(stateRoot, {
+          stableWorkItemId: "github-issue-112",
+          laneRunId: "lane-run-112-a",
+          reason: "operator stop",
+          actedAt,
+        }),
+      /Lane run state/,
+    );
+
+    assert.deepEqual(await readLaneRunQueueRecord(stateRoot, "github-issue-112"), queued);
+    assert.deepEqual(await readLaneRunLock(stateRoot, "github-issue-112"), claim.lock);
+  });
+});
+
+test("stop fails closed for a blocked queue item without verified lane state", async () => {
+  await withStateRoot(async (stateRoot) => {
+    const queued = await enqueueLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-112",
+      workItemId: "issue-112",
+      source: "github-issue",
+      laneId: "owner-dogfood",
+      repositoryClassification: "owner-controlled-dogfood",
+      queuedAt,
+      metadata: {
+        blockerReason: "waiting for operator review",
+      },
+    });
+
+    const result = await stopLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-112",
+      laneRunId: "lane-run-112-a",
+      reason: "operator stop",
+      actedAt,
+    });
+
+    assert.equal(result.ok, false);
+    assert.equal(result.publicDiagnostics.reason, "operator action target requires verified blocked lane run state");
+    assert.deepEqual(await readLaneRunQueueRecord(stateRoot, "github-issue-112"), queued);
+  });
+});
+
 test("retry links a new queued attempt to prior evidence without deleting lane state", async () => {
   await withStateRoot(async (stateRoot) => {
     await enqueueLaneRun(stateRoot, {
@@ -166,7 +227,8 @@ test("retry links a new queued attempt to prior evidence without deleting lane s
     assert.equal(queue.enqueueSequence, 2);
     assert.equal(queue.metadata.retryOfLaneRunId, "lane-run-112-a");
     assert.equal(queue.metadata.previousQueueRecordId, "queue-github-issue-112-1");
-    assert.equal(queue.metadata.preservedEvidenceRefs, "artifacts/evidence/lane-run-112-a.json");
+    assert.equal(queue.metadata.preservedEvidenceRefCount, "1");
+    assert.equal(Object.hasOwn(queue.metadata, "preservedEvidenceRefs"), false);
     assert.equal(await readFile(path.join(stateRoot, "lane-runs", "lane-run-112-a.json"), "utf8"), originalState);
   });
 });
@@ -244,6 +306,57 @@ test("requeue returns a revoked work item to the queue with lineage", async () =
   });
 });
 
+test("requeue without a lock requires verified revoked lane state ownership", async () => {
+  await withStateRoot(async (stateRoot) => {
+    await enqueueLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-112",
+      workItemId: "issue-112",
+      source: "github-issue",
+      laneId: "owner-dogfood",
+      repositoryClassification: "owner-controlled-dogfood",
+      queuedAt,
+      metadata: {
+        blockerReason: "waiting for operator review",
+      },
+    });
+    await writeLaneRunState(
+      stateRoot,
+      createLaneRunState({
+        id: "lane-run-112-a",
+        workItemId: "issue-112",
+        status: "blocked",
+        revision: 1,
+        createdAt: claimedAt,
+        updatedAt: actedAt,
+        journal: createLaneJournal({
+          id: "journal-lane-run-112-a",
+          laneRunId: "lane-run-112-a",
+          workItemId: "issue-112",
+        }),
+      }),
+    );
+    const stopped = await stopLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-112",
+      laneRunId: "lane-run-112-a",
+      reason: "operator stop blocked item",
+      actedAt,
+    });
+    assert.equal(stopped.ok, true);
+    const revokedQueue = await readLaneRunQueueRecord(stateRoot, "github-issue-112");
+
+    const result = await requeueLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-112",
+      laneRunId: "lane-run-112-b",
+      reason: "operator requeue wrong target",
+      actedAt,
+    });
+
+    assert.equal(result.ok, false);
+    assert.equal(result.publicDiagnostics.reason, "operator action target requires verified revoked lane run state");
+    assert.deepEqual(await readLaneRunQueueRecord(stateRoot, "github-issue-112"), revokedQueue);
+  });
+});
+
 test("CLI stop emits public-safe action diagnostics", async () => {
   await withStateRoot(async (stateRoot) => {
     await enqueueLaneRun(stateRoot, {
@@ -285,5 +398,7 @@ test("CLI stop emits public-safe action diagnostics", async () => {
     assert.equal(output.publicDiagnostics?.reason, "operator <redacted> stop");
     assert.equal(JSON.stringify(output).includes(stateRoot), false);
     assert.equal(JSON.stringify(output).includes("ghp_sampleSecretValue"), false);
+    assert.equal(JSON.stringify(output).includes("queueRecord"), false);
+    assert.equal(JSON.stringify(output).includes("metadata"), false);
   });
 });

--- a/test/lane-run-operator-actions.test.ts
+++ b/test/lane-run-operator-actions.test.ts
@@ -247,6 +247,52 @@ test("stop fails closed for a blocked queue item without verified lane state", a
   });
 });
 
+test("stop rejects blocked lineage from a lane run owned by another work item", async () => {
+  await withStateRoot(async (stateRoot) => {
+    const queued = await enqueueLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-112",
+      workItemId: "issue-112",
+      source: "github-issue",
+      laneId: "owner-dogfood",
+      repositoryClassification: "owner-controlled-dogfood",
+      queuedAt,
+      metadata: {
+        blockerReason: "waiting for operator review",
+      },
+    });
+    await writeLaneRunState(
+      stateRoot,
+      createLaneRunState({
+        id: "lane-run-112-a",
+        workItemId: "issue-999",
+        status: "blocked",
+        revision: 1,
+        createdAt: claimedAt,
+        updatedAt: actedAt,
+        journal: createLaneJournal({
+          id: "journal-lane-run-112-a",
+          laneRunId: "lane-run-112-a",
+          workItemId: "issue-999",
+        }),
+        evidence: {
+          bundleRefs: ["artifacts/evidence/unrelated.json"],
+        },
+      }),
+    );
+
+    const result = await stopLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-112",
+      laneRunId: "lane-run-112-a",
+      reason: "operator stop",
+      actedAt,
+    });
+
+    assert.equal(result.ok, false);
+    assert.equal(result.publicDiagnostics.reason, "operator action target requires verified blocked lane run state");
+    assert.deepEqual(await readLaneRunQueueRecord(stateRoot, "github-issue-112"), queued);
+  });
+});
+
 test("retry links a new queued attempt to prior evidence without deleting lane state", async () => {
   await withStateRoot(async (stateRoot) => {
     await enqueueLaneRun(stateRoot, {
@@ -269,6 +315,10 @@ test("retry links a new queued attempt to prior evidence without deleting lane s
       completedAt: actedAt,
       terminalStatus: "superseded",
     });
+    assert.equal(
+      (await readLaneRunQueueRecord(stateRoot, "github-issue-112")).metadata.supersededLaneRunId,
+      "lane-run-112-a",
+    );
     await writeLaneRunState(
       stateRoot,
       createLaneRunState({
@@ -567,8 +617,62 @@ test("requeue without a lock requires verified revoked lane state ownership", as
     });
 
     assert.equal(result.ok, false);
-    assert.equal(result.publicDiagnostics.reason, "operator action target requires verified revoked lane run state");
+    assert.equal(result.publicDiagnostics.reason, "operator action target requires verified terminal lane run state");
     assert.deepEqual(await readLaneRunQueueRecord(stateRoot, "github-issue-112"), revokedQueue);
+  });
+});
+
+test("requeue without a lock rejects superseded records without explicit lane run ownership", async () => {
+  await withStateRoot(async (stateRoot) => {
+    const queued = await enqueueLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-112",
+      workItemId: "issue-112",
+      source: "github-issue",
+      laneId: "owner-dogfood",
+      repositoryClassification: "owner-controlled-dogfood",
+      queuedAt,
+    });
+    const supersededQueue = {
+      ...queued,
+      status: "superseded" as const,
+      updatedAt: actedAt,
+      publicDiagnostics: {
+        ...queued.publicDiagnostics,
+        status: "superseded" as const,
+      },
+    };
+    await writeFile(
+      resolveLaneRunQueueRecordPath(stateRoot, "github-issue-112"),
+      `${JSON.stringify(supersededQueue, null, 2)}\n`,
+      "utf8",
+    );
+    await writeLaneRunState(
+      stateRoot,
+      createLaneRunState({
+        id: "lane-run-112-a",
+        workItemId: "issue-112",
+        status: "failed",
+        revision: 1,
+        createdAt: claimedAt,
+        updatedAt: actedAt,
+        journal: createLaneJournal({
+          id: "journal-lane-run-112-a",
+          laneRunId: "lane-run-112-a",
+          workItemId: "issue-112",
+        }),
+      }),
+    );
+
+    const result = await requeueLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-112",
+      laneRunId: "lane-run-112-a",
+      reason: "operator requeue superseded record",
+      actedAt,
+    });
+
+    assert.equal(result.ok, false);
+    assert.equal(result.publicDiagnostics.reason, "operator action target requires verified terminal lane run state");
+    assert.deepEqual(await readLaneRunQueueRecord(stateRoot, "github-issue-112"), supersededQueue);
   });
 });
 

--- a/test/lane-run-operator-actions.test.ts
+++ b/test/lane-run-operator-actions.test.ts
@@ -1,0 +1,289 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { mkdir, mkdtemp, readFile, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { promisify } from "node:util";
+
+import {
+  claimQueuedLaneRun,
+  completeLaneRunLock,
+  createLaneJournal,
+  createLaneRunState,
+  enqueueLaneRun,
+  readLaneRunLock,
+  readLaneRunQueueRecord,
+  requeueLaneRun,
+  retryLaneRun,
+  stopLaneRun,
+  writeLaneRunState,
+} from "../src/lane/index.js";
+
+const execFileAsync = promisify(execFile);
+const queuedAt = new Date(Date.now() - 120_000).toISOString();
+const claimedAt = new Date(Date.now() - 60_000).toISOString();
+const actedAt = new Date(Date.now() - 1_000).toISOString();
+
+async function withStateRoot(callback: (stateRoot: string) => Promise<void>): Promise<void> {
+  const stateRoot = await mkdtemp(path.join(os.tmpdir(), "ensen-loop-state-"));
+
+  try {
+    await mkdir(path.join(stateRoot, "lane-runs"), { recursive: true });
+    await callback(stateRoot);
+  } finally {
+    await rm(stateRoot, { recursive: true, force: true });
+  }
+}
+
+async function execCli(args: readonly string[]): Promise<{ readonly stdout: string; readonly stderr: string; readonly exitCode: number }> {
+  try {
+    const result = await execFileAsync(process.execPath, ["dist/src/cli/index.js", ...args]);
+
+    return { stdout: result.stdout, stderr: result.stderr, exitCode: 0 };
+  } catch (error) {
+    if (
+      error instanceof Error &&
+      typeof (error as { readonly code?: unknown }).code === "number" &&
+      typeof (error as { readonly stdout?: unknown }).stdout === "string" &&
+      typeof (error as { readonly stderr?: unknown }).stderr === "string"
+    ) {
+      const cliError = error as Error & { readonly code: number; readonly stdout: string; readonly stderr: string };
+
+      return {
+        stdout: cliError.stdout,
+        stderr: cliError.stderr,
+        exitCode: cliError.code,
+      };
+    }
+
+    throw error;
+  }
+}
+
+test("stop revokes an active lane run with a public operator reason", async () => {
+  await withStateRoot(async (stateRoot) => {
+    await enqueueLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-112",
+      workItemId: "issue-112",
+      source: "github-issue",
+      laneId: "owner-dogfood",
+      repositoryClassification: "owner-controlled-dogfood",
+      queuedAt,
+      metadata: {
+        issueNumber: "112",
+      },
+    });
+    await claimQueuedLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-112",
+      laneRunId: "lane-run-112-a",
+      claimedBy: "local-supervisor",
+      claimedAt,
+    });
+
+    const result = await stopLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-112",
+      laneRunId: "lane-run-112-a",
+      reason: "operator found missing evidence token=ghp_sampleSecretValue",
+      actedAt,
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.action, "stop");
+    assert.equal(result.publicDiagnostics.reason, "operator found missing evidence <redacted>");
+    assert.equal(result.lineage.relationship, "revoked");
+
+    const lock = await readLaneRunLock(stateRoot, "github-issue-112");
+    const queue = await readLaneRunQueueRecord(stateRoot, "github-issue-112");
+
+    assert.equal(lock.status, "revoked");
+    assert.equal(lock.active, false);
+    assert.equal(lock.releasedAt, actedAt);
+    assert.equal(queue.status, "revoked");
+    assert.equal(queue.metadata.revokedByOperatorAt, actedAt);
+    assert.equal(queue.metadata.operatorReason, "operator found missing evidence <redacted>");
+  });
+});
+
+test("retry links a new queued attempt to prior evidence without deleting lane state", async () => {
+  await withStateRoot(async (stateRoot) => {
+    await enqueueLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-112",
+      workItemId: "issue-112",
+      source: "github-issue",
+      laneId: "owner-dogfood",
+      repositoryClassification: "owner-controlled-dogfood",
+      queuedAt,
+    });
+    await claimQueuedLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-112",
+      laneRunId: "lane-run-112-a",
+      claimedBy: "local-supervisor",
+      claimedAt,
+    });
+    await completeLaneRunLock(stateRoot, {
+      stableWorkItemId: "github-issue-112",
+      laneRunId: "lane-run-112-a",
+      completedAt: actedAt,
+      terminalStatus: "superseded",
+    });
+    await writeLaneRunState(
+      stateRoot,
+      createLaneRunState({
+        id: "lane-run-112-a",
+        workItemId: "issue-112",
+        status: "failed",
+        revision: 1,
+        createdAt: claimedAt,
+        updatedAt: actedAt,
+        journal: createLaneJournal({
+          id: "journal-lane-run-112-a",
+          laneRunId: "lane-run-112-a",
+          workItemId: "issue-112",
+        }),
+        evidence: {
+          bundleRefs: ["artifacts/evidence/lane-run-112-a.json"],
+        },
+      }),
+    );
+
+    const originalState = await readFile(path.join(stateRoot, "lane-runs", "lane-run-112-a.json"), "utf8");
+    const result = await retryLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-112",
+      laneRunId: "lane-run-112-a",
+      reason: "retry after focused fix",
+      actedAt,
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.action, "retry");
+    assert.equal(result.queueRecord?.id, "queue-github-issue-112-2");
+    assert.equal(result.lineage.relationship, "retried");
+    assert.deepEqual(result.lineage.preservedEvidenceRefs, ["artifacts/evidence/lane-run-112-a.json"]);
+
+    const queue = await readLaneRunQueueRecord(stateRoot, "github-issue-112");
+    assert.equal(queue.status, "queued");
+    assert.equal(queue.enqueueSequence, 2);
+    assert.equal(queue.metadata.retryOfLaneRunId, "lane-run-112-a");
+    assert.equal(queue.metadata.previousQueueRecordId, "queue-github-issue-112-1");
+    assert.equal(queue.metadata.preservedEvidenceRefs, "artifacts/evidence/lane-run-112-a.json");
+    assert.equal(await readFile(path.join(stateRoot, "lane-runs", "lane-run-112-a.json"), "utf8"), originalState);
+  });
+});
+
+test("retry fails closed for an active lane run and keeps durable state unchanged", async () => {
+  await withStateRoot(async (stateRoot) => {
+    const queued = await enqueueLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-112",
+      workItemId: "issue-112",
+      source: "github-issue",
+      laneId: "owner-dogfood",
+      repositoryClassification: "owner-controlled-dogfood",
+      queuedAt,
+    });
+    const claim = await claimQueuedLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-112",
+      laneRunId: "lane-run-112-a",
+      claimedBy: "local-supervisor",
+      claimedAt,
+    });
+
+    const result = await retryLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-112",
+      laneRunId: "lane-run-112-a",
+      reason: "operator retry",
+      actedAt,
+    });
+
+    assert.equal(result.ok, false);
+    assert.equal(result.publicDiagnostics.reason, "cannot retry an active lane run; stop it first");
+    assert.deepEqual(await readLaneRunQueueRecord(stateRoot, "github-issue-112"), queued);
+    assert.deepEqual(await readLaneRunLock(stateRoot, "github-issue-112"), claim.lock);
+  });
+});
+
+test("requeue returns a revoked work item to the queue with lineage", async () => {
+  await withStateRoot(async (stateRoot) => {
+    await enqueueLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-112",
+      workItemId: "issue-112",
+      source: "github-issue",
+      laneId: "owner-dogfood",
+      repositoryClassification: "owner-controlled-dogfood",
+      queuedAt,
+    });
+    await claimQueuedLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-112",
+      laneRunId: "lane-run-112-a",
+      claimedBy: "local-supervisor",
+      claimedAt,
+    });
+    await stopLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-112",
+      laneRunId: "lane-run-112-a",
+      reason: "operator stop before requeue",
+      actedAt,
+    });
+
+    const result = await requeueLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-112",
+      laneRunId: "lane-run-112-a",
+      reason: "operator requeue",
+      actedAt,
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.action, "requeue");
+    assert.equal(result.lineage.relationship, "requeued");
+
+    const queue = await readLaneRunQueueRecord(stateRoot, "github-issue-112");
+    assert.equal(queue.status, "queued");
+    assert.equal(queue.enqueueSequence, 2);
+    assert.equal(queue.metadata.requeueOfLaneRunId, "lane-run-112-a");
+    assert.equal(queue.metadata.previousQueueStatus, "revoked");
+  });
+});
+
+test("CLI stop emits public-safe action diagnostics", async () => {
+  await withStateRoot(async (stateRoot) => {
+    await enqueueLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-112",
+      workItemId: "issue-112",
+      source: "github-issue",
+      laneId: "owner-dogfood",
+      repositoryClassification: "owner-controlled-dogfood",
+      queuedAt,
+    });
+    await claimQueuedLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-112",
+      laneRunId: "lane-run-112-a",
+      claimedBy: "local-supervisor",
+      claimedAt,
+    });
+
+    const result = await execCli([
+      "stop",
+      "--state-root",
+      stateRoot,
+      "--issue",
+      "github-issue-112",
+      "--lane-run",
+      "lane-run-112-a",
+      "--reason",
+      "operator token=ghp_sampleSecretValue stop",
+    ]);
+    const output = JSON.parse(result.stdout) as {
+      readonly ok?: unknown;
+      readonly action?: unknown;
+      readonly publicDiagnostics?: { readonly reason?: unknown };
+    };
+
+    assert.equal(result.stderr, "");
+    assert.equal(result.exitCode, 0);
+    assert.equal(output.ok, true);
+    assert.equal(output.action, "stop");
+    assert.equal(output.publicDiagnostics?.reason, "operator <redacted> stop");
+    assert.equal(JSON.stringify(output).includes(stateRoot), false);
+    assert.equal(JSON.stringify(output).includes("ghp_sampleSecretValue"), false);
+  });
+});

--- a/test/lane-run-operator-actions.test.ts
+++ b/test/lane-run-operator-actions.test.ts
@@ -477,6 +477,70 @@ test("retry drops stale preserved evidence metadata when the next target has no 
   });
 });
 
+test("retry fails closed when a retry attempt is already queued", async () => {
+  await withStateRoot(async (stateRoot) => {
+    await enqueueLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-112",
+      workItemId: "issue-112",
+      source: "github-issue",
+      laneId: "owner-dogfood",
+      repositoryClassification: "owner-controlled-dogfood",
+      queuedAt,
+    });
+    await claimQueuedLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-112",
+      laneRunId: "lane-run-112-a",
+      claimedBy: "local-supervisor",
+      claimedAt,
+    });
+    await completeLaneRunLock(stateRoot, {
+      stableWorkItemId: "github-issue-112",
+      laneRunId: "lane-run-112-a",
+      completedAt: actedAt,
+      terminalStatus: "superseded",
+    });
+    await writeLaneRunState(
+      stateRoot,
+      createLaneRunState({
+        id: "lane-run-112-a",
+        workItemId: "issue-112",
+        status: "failed",
+        revision: 1,
+        createdAt: claimedAt,
+        updatedAt: actedAt,
+        journal: createLaneJournal({
+          id: "journal-lane-run-112-a",
+          laneRunId: "lane-run-112-a",
+          workItemId: "issue-112",
+        }),
+      }),
+    );
+
+    const firstRetry = await retryLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-112",
+      laneRunId: "lane-run-112-a",
+      reason: "operator retry",
+      actedAt,
+    });
+
+    assert.equal(firstRetry.ok, true);
+
+    const queuedRetry = await readLaneRunQueueRecord(stateRoot, "github-issue-112");
+    const terminalLock = await readLaneRunLock(stateRoot, "github-issue-112");
+    const secondRetry = await retryLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-112",
+      laneRunId: "lane-run-112-a",
+      reason: "operator retry again",
+      actedAt,
+    });
+
+    assert.equal(secondRetry.ok, false);
+    assert.equal(secondRetry.publicDiagnostics.reason, "operator action requires a terminal lane run record");
+    assert.deepEqual(await readLaneRunQueueRecord(stateRoot, "github-issue-112"), queuedRetry);
+    assert.deepEqual(await readLaneRunLock(stateRoot, "github-issue-112"), terminalLock);
+  });
+});
+
 test("retry fails closed for an active lane run and keeps durable state unchanged", async () => {
   await withStateRoot(async (stateRoot) => {
     const queued = await enqueueLaneRun(stateRoot, {

--- a/test/lane-run-operator-actions.test.ts
+++ b/test/lane-run-operator-actions.test.ts
@@ -456,6 +456,67 @@ test("requeue returns a revoked work item to the queue with lineage", async () =
   });
 });
 
+test("requeue writes bounded operator metadata and drops stale blocker lineage", async () => {
+  await withStateRoot(async (stateRoot) => {
+    await enqueueLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-112",
+      workItemId: "issue-112",
+      source: "github-issue",
+      laneId: "owner-dogfood",
+      repositoryClassification: "owner-controlled-dogfood",
+      queuedAt,
+    });
+    await claimQueuedLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-112",
+      laneRunId: "lane-run-112-a",
+      claimedBy: "local-supervisor",
+      claimedAt,
+    });
+    await stopLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-112",
+      laneRunId: "lane-run-112-a",
+      reason: "operator stop before requeue",
+      actedAt,
+    });
+
+    const revokedQueue = await readLaneRunQueueRecord(stateRoot, "github-issue-112");
+    await writeFile(
+      resolveLaneRunQueueRecordPath(stateRoot, "github-issue-112"),
+      `${JSON.stringify(
+        {
+          ...revokedQueue,
+          metadata: {
+            ...revokedQueue.metadata,
+            blockerReason: "stale blocked projection",
+            preservedEvidenceRefCount: "7",
+            preservedEvidenceRefs: "artifacts/evidence/stale.json",
+          },
+        },
+        null,
+        2,
+      )}\n`,
+      "utf8",
+    );
+
+    const result = await requeueLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-112",
+      laneRunId: "lane-run-112-a",
+      reason: `operator requeue ${"x".repeat(300)}`,
+      actedAt,
+    });
+
+    assert.equal(result.ok, true);
+
+    const queue = await readLaneRunQueueRecord(stateRoot, "github-issue-112");
+    assert.equal(queue.status, "queued");
+    assert.equal(queue.metadata.operatorReason.length, 256);
+    assert.equal(queue.metadata.operatorReason.endsWith("..."), true);
+    assert.equal(Object.hasOwn(queue.metadata, "blockerReason"), false);
+    assert.equal(Object.hasOwn(queue.metadata, "preservedEvidenceRefCount"), false);
+    assert.equal(Object.hasOwn(queue.metadata, "preservedEvidenceRefs"), false);
+  });
+});
+
 test("requeue without a lock requires verified revoked lane state ownership", async () => {
   await withStateRoot(async (stateRoot) => {
     await enqueueLaneRun(stateRoot, {

--- a/test/lane-run-operator-actions.test.ts
+++ b/test/lane-run-operator-actions.test.ts
@@ -778,3 +778,76 @@ test("CLI stop emits public-safe action diagnostics", async () => {
     assert.equal(JSON.stringify(output).includes("metadata"), false);
   });
 });
+
+test("CLI retry does not print queued metadata values", async () => {
+  await withStateRoot(async (stateRoot) => {
+    await enqueueLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-112",
+      workItemId: "issue-112",
+      source: "github-issue",
+      laneId: "owner-dogfood",
+      repositoryClassification: "owner-controlled-dogfood",
+      queuedAt,
+      metadata: {
+        privateOperatorNote: "token=ghp_sampleSecretValue",
+      },
+    });
+    await claimQueuedLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-112",
+      laneRunId: "lane-run-112-a",
+      claimedBy: "local-supervisor",
+      claimedAt,
+    });
+    await completeLaneRunLock(stateRoot, {
+      stableWorkItemId: "github-issue-112",
+      laneRunId: "lane-run-112-a",
+      completedAt: actedAt,
+      terminalStatus: "superseded",
+    });
+    await writeLaneRunState(
+      stateRoot,
+      createLaneRunState({
+        id: "lane-run-112-a",
+        workItemId: "issue-112",
+        status: "failed",
+        revision: 1,
+        createdAt: claimedAt,
+        updatedAt: actedAt,
+        journal: createLaneJournal({
+          id: "journal-lane-run-112-a",
+          laneRunId: "lane-run-112-a",
+          workItemId: "issue-112",
+        }),
+      }),
+    );
+
+    const result = await execCli([
+      "retry",
+      "--state-root",
+      stateRoot,
+      "--issue",
+      "github-issue-112",
+      "--lane-run",
+      "lane-run-112-a",
+      "--reason",
+      "operator token=ghp_sampleSecretValue retry",
+    ]);
+    const output = JSON.parse(result.stdout) as {
+      readonly ok?: unknown;
+      readonly action?: unknown;
+      readonly publicDiagnostics?: { readonly reason?: unknown };
+    };
+    const serializedOutput = JSON.stringify(output);
+
+    assert.equal(result.stderr, "");
+    assert.equal(result.exitCode, 0);
+    assert.equal(output.ok, true);
+    assert.equal(output.action, "retry");
+    assert.equal(output.publicDiagnostics?.reason, "operator <redacted> retry");
+    assert.equal(serializedOutput.includes(stateRoot), false);
+    assert.equal(serializedOutput.includes("ghp_sampleSecretValue"), false);
+    assert.equal(serializedOutput.includes("queueRecord"), false);
+    assert.equal(serializedOutput.includes("metadata"), false);
+    assert.equal(serializedOutput.includes("privateOperatorNote"), false);
+  });
+});

--- a/test/lane-run-operator-actions.test.ts
+++ b/test/lane-run-operator-actions.test.ts
@@ -622,6 +622,63 @@ test("requeue without a lock requires verified revoked lane state ownership", as
   });
 });
 
+test("requeue without a lock rejects same-work-item lane state not linked by the terminal queue record", async () => {
+  await withStateRoot(async (stateRoot) => {
+    await enqueueLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-112",
+      workItemId: "issue-112",
+      source: "github-issue",
+      laneId: "owner-dogfood",
+      repositoryClassification: "owner-controlled-dogfood",
+      queuedAt,
+    });
+    await claimQueuedLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-112",
+      laneRunId: "lane-run-112-a",
+      claimedBy: "local-supervisor",
+      claimedAt,
+    });
+    await stopLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-112",
+      laneRunId: "lane-run-112-a",
+      reason: "operator stop before lockless requeue",
+      actedAt,
+    });
+    await writeLaneRunState(
+      stateRoot,
+      createLaneRunState({
+        id: "lane-run-112-b",
+        workItemId: "issue-112",
+        status: "failed",
+        revision: 1,
+        createdAt: claimedAt,
+        updatedAt: actedAt,
+        journal: createLaneJournal({
+          id: "journal-lane-run-112-b",
+          laneRunId: "lane-run-112-b",
+          workItemId: "issue-112",
+        }),
+        evidence: {
+          bundleRefs: ["artifacts/evidence/unlinked-lane-run.json"],
+        },
+      }),
+    );
+    await rm(resolveLaneRunLockPath(stateRoot, "github-issue-112"), { force: true });
+    const revokedQueue = await readLaneRunQueueRecord(stateRoot, "github-issue-112");
+
+    const result = await requeueLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-112",
+      laneRunId: "lane-run-112-b",
+      reason: "operator requeue unlinked lane state",
+      actedAt,
+    });
+
+    assert.equal(result.ok, false);
+    assert.equal(result.publicDiagnostics.reason, "operator action target requires verified terminal lane run state");
+    assert.deepEqual(await readLaneRunQueueRecord(stateRoot, "github-issue-112"), revokedQueue);
+  });
+});
+
 test("requeue without a lock rejects superseded records without explicit lane run ownership", async () => {
   await withStateRoot(async (stateRoot) => {
     const queued = await enqueueLaneRun(stateRoot, {

--- a/test/lane-run-operator-actions.test.ts
+++ b/test/lane-run-operator-actions.test.ts
@@ -12,9 +12,11 @@ import {
   createLaneJournal,
   createLaneRunState,
   enqueueLaneRun,
+  getLaneRunStatus,
   readLaneRunLock,
   readLaneRunQueueRecord,
   requeueLaneRun,
+  resolveLaneRunQueueRecordPath,
   retryLaneRun,
   stopLaneRun,
   writeLaneRunState,
@@ -139,6 +141,48 @@ test("stop reads active lineage evidence before mutating durable state", async (
   });
 });
 
+test("stop fails closed when the active lock no longer points at the queue record", async () => {
+  await withStateRoot(async (stateRoot) => {
+    const queued = await enqueueLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-112",
+      workItemId: "issue-112",
+      source: "github-issue",
+      laneId: "owner-dogfood",
+      repositoryClassification: "owner-controlled-dogfood",
+      queuedAt,
+    });
+    const claim = await claimQueuedLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-112",
+      laneRunId: "lane-run-112-a",
+      claimedBy: "local-supervisor",
+      claimedAt,
+    });
+    const driftedQueue = {
+      ...queued,
+      id: "queue-github-issue-112-2",
+      enqueueSequence: 2,
+      updatedAt: actedAt,
+    };
+    await writeFile(
+      resolveLaneRunQueueRecordPath(stateRoot, "github-issue-112"),
+      `${JSON.stringify(driftedQueue, null, 2)}\n`,
+      "utf8",
+    );
+
+    const result = await stopLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-112",
+      laneRunId: "lane-run-112-a",
+      reason: "operator stop",
+      actedAt,
+    });
+
+    assert.equal(result.ok, false);
+    assert.equal(result.publicDiagnostics.reason, "lane run queue record does not match the active lane run lock");
+    assert.deepEqual(await readLaneRunQueueRecord(stateRoot, "github-issue-112"), driftedQueue);
+    assert.deepEqual(await readLaneRunLock(stateRoot, "github-issue-112"), claim.lock);
+  });
+});
+
 test("stop fails closed for a blocked queue item without verified lane state", async () => {
   await withStateRoot(async (stateRoot) => {
     const queued = await enqueueLaneRun(stateRoot, {
@@ -216,9 +260,16 @@ test("retry links a new queued attempt to prior evidence without deleting lane s
       actedAt,
     });
 
-    assert.equal(result.ok, true);
+    if (!result.ok) {
+      assert.fail("retry should create a linked queued attempt");
+    }
+
+    if (result.queueRecord === undefined) {
+      assert.fail("retry should return the new queue record");
+    }
+
     assert.equal(result.action, "retry");
-    assert.equal(result.queueRecord?.id, "queue-github-issue-112-2");
+    assert.equal(result.queueRecord.id, "queue-github-issue-112-2");
     assert.equal(result.lineage.relationship, "retried");
     assert.deepEqual(result.lineage.preservedEvidenceRefs, ["artifacts/evidence/lane-run-112-a.json"]);
 
@@ -230,6 +281,65 @@ test("retry links a new queued attempt to prior evidence without deleting lane s
     assert.equal(queue.metadata.preservedEvidenceRefCount, "1");
     assert.equal(Object.hasOwn(queue.metadata, "preservedEvidenceRefs"), false);
     assert.equal(await readFile(path.join(stateRoot, "lane-runs", "lane-run-112-a.json"), "utf8"), originalState);
+  });
+});
+
+test("retry drops stale preserved evidence metadata when the next target has no evidence", async () => {
+  await withStateRoot(async (stateRoot) => {
+    await enqueueLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-112",
+      workItemId: "issue-112",
+      source: "github-issue",
+      laneId: "owner-dogfood",
+      repositoryClassification: "owner-controlled-dogfood",
+      queuedAt,
+      metadata: {
+        issueNumber: "112",
+        preservedEvidenceRefCount: "9",
+      },
+    });
+    await claimQueuedLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-112",
+      laneRunId: "lane-run-112-a",
+      claimedBy: "local-supervisor",
+      claimedAt,
+    });
+    await completeLaneRunLock(stateRoot, {
+      stableWorkItemId: "github-issue-112",
+      laneRunId: "lane-run-112-a",
+      completedAt: actedAt,
+      terminalStatus: "superseded",
+    });
+    await writeLaneRunState(
+      stateRoot,
+      createLaneRunState({
+        id: "lane-run-112-a",
+        workItemId: "issue-112",
+        status: "failed",
+        revision: 1,
+        createdAt: claimedAt,
+        updatedAt: actedAt,
+        journal: createLaneJournal({
+          id: "journal-lane-run-112-a",
+          laneRunId: "lane-run-112-a",
+          workItemId: "issue-112",
+        }),
+      }),
+    );
+
+    const result = await retryLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-112",
+      laneRunId: "lane-run-112-a",
+      reason: "retry after focused fix",
+      actedAt,
+    });
+
+    assert.equal(result.ok, true);
+
+    const queue = await readLaneRunQueueRecord(stateRoot, "github-issue-112");
+    assert.equal(queue.metadata.issueNumber, "112");
+    assert.equal(queue.metadata.retryOfLaneRunId, "lane-run-112-a");
+    assert.equal(Object.hasOwn(queue.metadata, "preservedEvidenceRefCount"), false);
   });
 });
 
@@ -343,6 +453,10 @@ test("requeue without a lock requires verified revoked lane state ownership", as
     });
     assert.equal(stopped.ok, true);
     const revokedQueue = await readLaneRunQueueRecord(stateRoot, "github-issue-112");
+    const status = await getLaneRunStatus(stateRoot);
+
+    assert.equal(Object.hasOwn(revokedQueue.metadata, "blockerReason"), false);
+    assert.equal(status.queue[0]?.laneState, "revoked");
 
     const result = await requeueLaneRun(stateRoot, {
       stableWorkItemId: "github-issue-112",

--- a/test/lane-run-queue.test.ts
+++ b/test/lane-run-queue.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
 import { chmod, mkdir, mkdtemp, rm, utimes, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -18,6 +19,10 @@ import {
 const queuedAt = "2026-05-21T05:00:00.000Z";
 const claimedAt = "2026-05-21T05:01:00.000Z";
 const completedAt = "2026-05-21T05:02:00.000Z";
+
+function laneRunIdDigest(laneRunId: string): string {
+  return createHash("sha256").update(laneRunId).digest("hex");
+}
 
 test("queues an issue work item and claims it exactly once while the lock is active", async () => {
   const stateRoot = await mkdtemp(path.join(os.tmpdir(), "ensen-loop-state-"));
@@ -368,6 +373,7 @@ test("bounds terminal queue metadata for long lane run ids", async () => {
     assert.equal(durableQueueRecord.status, "completed");
     assert.equal(durableQueueRecord.metadata.completedLaneRunId.length, 256);
     assert.equal(durableQueueRecord.metadata.completedLaneRunId.endsWith("..."), true);
+    assert.equal(durableQueueRecord.metadata.completedLaneRunIdSha256, laneRunIdDigest(longLaneRunId));
   } finally {
     await rm(stateRoot, { recursive: true, force: true });
   }

--- a/test/lane-run-queue.test.ts
+++ b/test/lane-run-queue.test.ts
@@ -332,6 +332,47 @@ test("rejects attempts to rewrite a terminal lock", async () => {
   }
 });
 
+test("bounds terminal queue metadata for long lane run ids", async () => {
+  const stateRoot = await mkdtemp(path.join(os.tmpdir(), "ensen-loop-state-"));
+
+  try {
+    const longLaneRunId = `lane-run-110-${"a".repeat(260)}`;
+
+    await enqueueLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-110",
+      workItemId: "issue-110",
+      source: "github-issue",
+      laneId: "owner-dogfood",
+      repositoryClassification: "owner-controlled-dogfood",
+      queuedAt,
+    });
+
+    const claim = await claimQueuedLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-110",
+      laneRunId: longLaneRunId,
+      claimedBy: "local-supervisor",
+      claimedAt,
+    });
+
+    await completeLaneRunLock(stateRoot, {
+      stableWorkItemId: "github-issue-110",
+      laneRunId: claim.lock.laneRunId,
+      completedAt,
+      terminalStatus: "completed",
+    });
+
+    const durableLock = await readLaneRunLock(stateRoot, "github-issue-110");
+    const durableQueueRecord = await readLaneRunQueueRecord(stateRoot, "github-issue-110");
+
+    assert.equal(durableLock.laneRunId, longLaneRunId);
+    assert.equal(durableQueueRecord.status, "completed");
+    assert.equal(durableQueueRecord.metadata.completedLaneRunId.length, 256);
+    assert.equal(durableQueueRecord.metadata.completedLaneRunId.endsWith("..."), true);
+  } finally {
+    await rm(stateRoot, { recursive: true, force: true });
+  }
+});
+
 test("rejects completion timestamps outside the active claim window", async () => {
   const stateRoot = await mkdtemp(path.join(os.tmpdir(), "ensen-loop-state-"));
 


### PR DESCRIPTION
## Summary
- Add queue/lock-backed stop, retry, and requeue operator actions with public-safe diagnostics.
- Preserve prior lane evidence refs in retry/requeue lineage metadata without deleting lane state.
- Wire CLI stop, retry, and requeue commands and add focused regression coverage.

## Verification
- npm ci
- npm run typecheck
- npm run build
- npm run build && npm test

Part of #109. Closes #112.