### PR TITLE
LOOP-053 add stale-state reconciliation

### DIFF
--- a/src/lane/index.ts
+++ b/src/lane/index.ts
@@ -1165,7 +1165,10 @@ export async function reconcileLaneRunState(
     queueRecord = await readOptionalLaneRunQueueRecord(stateRoot, input.stableWorkItemId);
     existingLock = await readOptionalLaneRunLock(stateRoot, input.stableWorkItemId);
     terminalQueueLaneRunId =
-      queueRecord === undefined ? undefined : readTerminalQueueRecordLaneRunId(queueRecord);
+      queueRecord === undefined ? undefined : await readTerminalQueueRecordLaneRunId(stateRoot, queueRecord);
+    const existingLockMatchesQueueRecord =
+      existingLock !== undefined &&
+      (queueRecord === undefined || isLaneRunLockContextCompatibleWithQueueRecord(existingLock, queueRecord));
     const inputLaneRunMatchesQueueRecord =
       input.laneRunId !== undefined &&
       queueRecord !== undefined &&
@@ -1174,7 +1177,7 @@ export async function reconcileLaneRunState(
       input.laneRunId !== undefined &&
       existingLock !== undefined &&
       existingLock.laneRunId === input.laneRunId &&
-      (queueRecord === undefined || isLaneRunLockContextCompatibleWithQueueRecord(existingLock, queueRecord));
+      existingLockMatchesQueueRecord;
     inputLaneRunOwnershipUnverified =
       input.laneRunId !== undefined &&
       existingLock?.active !== true &&
@@ -1188,7 +1191,7 @@ export async function reconcileLaneRunState(
           : inputLaneRunMatchesQueueRecord
           ? input.laneRunId
           : input.laneRunId === undefined
-            ? (existingLock?.laneRunId ?? terminalQueueLaneRunId)
+            ? (terminalQueueLaneRunId ?? (existingLockMatchesQueueRecord ? existingLock?.laneRunId : undefined))
             : undefined;
     state = laneRunId === undefined ? undefined : await readOptionalLaneRunState(stateRoot, laneRunId);
   } catch (error) {
@@ -1242,6 +1245,23 @@ export async function reconcileLaneRunState(
   }
 
   let laneRunStateOwnershipRejected = false;
+
+  if (
+    existingLock?.active === true &&
+    queueRecord !== undefined &&
+    !isLaneRunLockContextCompatibleWithQueueRecord(existingLock, queueRecord)
+  ) {
+    mismatches.push(
+      createLaneRunReconciliationMismatch(
+        "lane-run-ownership-unverified",
+        "blocked",
+        "active lane run lock context does not match the queue record",
+        "repair queue or lock identity before exposing lane evidence or requeueing",
+      ),
+    );
+    laneRunStateOwnershipRejected = true;
+    state = undefined;
+  }
 
   if (inputLaneRunOwnershipUnverified) {
     mismatches.push(
@@ -1988,7 +2008,10 @@ function isTerminalQueueRecordLinkedToLaneRun(record: LaneRunQueueRecord, laneRu
   return false;
 }
 
-function readTerminalQueueRecordLaneRunId(record: LaneRunQueueRecord): string | undefined {
+async function readTerminalQueueRecordLaneRunId(
+  stateRoot: string,
+  record: LaneRunQueueRecord,
+): Promise<string | undefined> {
   const prefix = toTerminalQueueRecordLaneRunIdMetadataPrefix(record);
 
   if (prefix === undefined) {
@@ -1996,10 +2019,56 @@ function readTerminalQueueRecordLaneRunId(record: LaneRunQueueRecord): string | 
   }
 
   const laneRunId = record.metadata[`${prefix}LaneRunId`];
+  const digest = record.metadata[`${prefix}LaneRunIdSha256`];
 
-  return laneRunId !== undefined && isLaneRunId(laneRunId) && isLaneRunIdMetadataMatch(record.metadata, prefix, laneRunId)
-    ? laneRunId
-    : undefined;
+  if (laneRunId !== undefined && !isTruncatedLaneRunIdMetadataValue(laneRunId)) {
+    return isLaneRunId(laneRunId) && isLaneRunIdMetadataMatch(record.metadata, prefix, laneRunId) ? laneRunId : undefined;
+  }
+
+  return digest === undefined ? undefined : await readLaneRunIdByDigest(stateRoot, digest);
+}
+
+async function readLaneRunIdByDigest(stateRoot: string, digest: string): Promise<string | undefined> {
+  if (!isLaneRunIdDigest(digest)) {
+    return undefined;
+  }
+
+  const realRoot = await resolveCanonicalStateRoot(stateRoot);
+  const laneRunsRoot = path.join(path.resolve(stateRoot), "lane-runs");
+
+  try {
+    await assertExistingPathSafe(realRoot, laneRunsRoot, "directory");
+  } catch (error) {
+    if (isNodeError(error) && error.code === "ENOENT") {
+      return undefined;
+    }
+
+    throw error;
+  }
+
+  const entries = await readdir(laneRunsRoot, { withFileTypes: true });
+
+  for (const entry of entries) {
+    if (!entry.isFile() || !entry.name.endsWith(".json")) {
+      continue;
+    }
+
+    const laneRunId = entry.name.slice(0, -".json".length);
+
+    if (isLaneRunId(laneRunId) && createLaneRunIdDigest(laneRunId) === digest) {
+      return laneRunId;
+    }
+  }
+
+  return undefined;
+}
+
+function isTruncatedLaneRunIdMetadataValue(value: string): boolean {
+  return value.length === 256 && value.endsWith("...");
+}
+
+function isLaneRunIdDigest(value: string): boolean {
+  return /^[a-f0-9]{64}$/.test(value);
 }
 
 function toTerminalQueueRecordLaneRunIdMetadataPrefix(record: LaneRunQueueRecord): string | undefined {

--- a/src/lane/index.ts
+++ b/src/lane/index.ts
@@ -1162,7 +1162,12 @@ export async function reconcileLaneRunState(
   stateRoot: string,
   input: ReconcileLaneRunStateInput,
 ): Promise<LaneRunReconciliationResult> {
-  assertSafeStableWorkItemId(input.stableWorkItemId);
+  if (!isSafeStableWorkItemId(input.stableWorkItemId)) {
+    return createMalformedReconciliationInputResult(
+      input,
+      "provide a valid stable work item id before retrying",
+    );
+  }
 
   if (!isIsoDateTime(input.observedAt)) {
     return createMalformedReconciliationInputResult(
@@ -3220,7 +3225,9 @@ function createMalformedLaneRunReconciliationResult(
     schemaVersion: "ensen.lane-run-reconciliation.v1",
     state: "blocked",
     category: "blocked",
-    stableWorkItemId: input.stableWorkItemId,
+    stableWorkItemId: isSafeStableWorkItemId(input.stableWorkItemId)
+      ? input.stableWorkItemId
+      : "invalid-stable-work-item-id",
     laneRunId: context.laneRunId ?? input.laneRunId,
     observedAt: input.observedAt,
     publicDiagnostics: {
@@ -3259,6 +3266,9 @@ function createMalformedReconciliationInputResult(
   input: ReconcileLaneRunStateInput,
   nextOperatorAction: string,
 ): LaneRunReconciliationResult {
+  const stableWorkItemId = isSafeStableWorkItemId(input.stableWorkItemId)
+    ? input.stableWorkItemId
+    : "invalid-stable-work-item-id";
   const mismatch = createLaneRunReconciliationMismatch(
     "malformed-reconciliation-input",
     "blocked",
@@ -3270,11 +3280,11 @@ function createMalformedReconciliationInputResult(
     schemaVersion: "ensen.lane-run-reconciliation.v1",
     state: "blocked",
     category: "blocked",
-    stableWorkItemId: input.stableWorkItemId,
+    stableWorkItemId,
     laneRunId: isLaneRunId(input.laneRunId) ? input.laneRunId : undefined,
     observedAt: isIsoDateTime(input.observedAt) ? input.observedAt : "1970-01-01T00:00:00.000Z",
     publicDiagnostics: {
-      stableWorkItemId: input.stableWorkItemId,
+      stableWorkItemId,
       reason: mismatch.publicMessage,
     },
     nextOperatorAction: mismatch.nextOperatorAction,
@@ -3492,6 +3502,10 @@ function assertSafeStableWorkItemId(stableWorkItemId: string): void {
 }
 
 function isSafeStableWorkItemId(stableWorkItemId: string): boolean {
+  if (typeof stableWorkItemId !== "string") {
+    return false;
+  }
+
   if (!stableWorkItemIdPattern.test(stableWorkItemId)) {
     return false;
   }

--- a/src/lane/index.ts
+++ b/src/lane/index.ts
@@ -1209,6 +1209,8 @@ export async function reconcileLaneRunState(
       input.laneRunId !== undefined &&
       queueRecord !== undefined &&
       isTerminalQueueRecordLinkedToLaneRun(queueRecord, input.laneRunId);
+    const activeLockMatchesQueueRecord =
+      existingLock?.active === true && existingLockMatchesQueueRecord;
     const inputLaneRunMatchesExistingLock =
       input.laneRunId !== undefined &&
       existingLock !== undefined &&
@@ -1220,8 +1222,8 @@ export async function reconcileLaneRunState(
       !inputLaneRunMatchesQueueRecord &&
       !inputLaneRunMatchesExistingLock;
     laneRunId =
-      existingLock?.active === true
-        ? existingLock.laneRunId
+      activeLockMatchesQueueRecord
+        ? existingLock!.laneRunId
         : inputLaneRunMatchesExistingLock
           ? input.laneRunId
           : inputLaneRunMatchesQueueRecord
@@ -1269,7 +1271,12 @@ export async function reconcileLaneRunState(
     );
   }
 
-  if (existingLock?.active === true && input.laneRunId !== undefined && existingLock.laneRunId !== input.laneRunId) {
+  if (
+    existingLock?.active === true &&
+    (queueRecord === undefined || isLaneRunLockContextCompatibleWithQueueRecord(existingLock, queueRecord)) &&
+    input.laneRunId !== undefined &&
+    existingLock.laneRunId !== input.laneRunId
+  ) {
     mismatches.push(
       createLaneRunReconciliationMismatch(
         "lane-run-target-mismatch",
@@ -2223,7 +2230,7 @@ async function readOptionalLaneRunState(
   try {
     return await readLaneRunState(stateRoot, laneRunId);
   } catch (error) {
-    if (isNodeError(error) && (error.code === "ENOENT" || error.code === "ENAMETOOLONG")) {
+    if (isNodeError(error) && error.code === "ENOENT") {
       return undefined;
     }
 
@@ -3308,7 +3315,7 @@ function isMalformedLaneRunStateError(error: unknown): boolean {
   );
 }
 
-const malformedLaneRunStateErrorCodes = new Set(["EISDIR", "ENOTDIR"]);
+const malformedLaneRunStateErrorCodes = new Set(["EISDIR", "ENAMETOOLONG", "ENOTDIR"]);
 
 async function readOptionalLaneRunQueueRecord(
   stateRoot: string,

--- a/src/lane/index.ts
+++ b/src/lane/index.ts
@@ -252,7 +252,8 @@ export type LaneRunReconciliationMismatchKind =
   | "stale-lock"
   | "conflicting-verification-facts"
   | "missing-queue-record"
-  | "lane-run-target-mismatch";
+  | "lane-run-target-mismatch"
+  | "malformed-lane-state";
 
 export interface LaneRunObservedSurface {
   readonly expected: boolean;
@@ -1149,10 +1150,28 @@ export async function reconcileLaneRunState(
     throw new Error("Lane run reconciliation input is malformed.");
   }
 
-  const queueRecord = await readOptionalLaneRunQueueRecord(stateRoot, input.stableWorkItemId);
-  const existingLock = await readOptionalLaneRunLock(stateRoot, input.stableWorkItemId);
-  const laneRunId = input.laneRunId ?? existingLock?.laneRunId;
-  const state = laneRunId === undefined ? undefined : await readOptionalLaneRunState(stateRoot, laneRunId);
+  let queueRecord: LaneRunQueueRecord | undefined;
+  let existingLock: LaneRunLock | undefined;
+  let laneRunId: string | undefined;
+  let state: LaneRunState | undefined;
+
+  try {
+    queueRecord = await readOptionalLaneRunQueueRecord(stateRoot, input.stableWorkItemId);
+    existingLock = await readOptionalLaneRunLock(stateRoot, input.stableWorkItemId);
+    laneRunId = existingLock?.active === true ? existingLock.laneRunId : input.laneRunId ?? existingLock?.laneRunId;
+    state = laneRunId === undefined ? undefined : await readOptionalLaneRunState(stateRoot, laneRunId);
+  } catch (error) {
+    if (isMalformedLaneRunStateError(error)) {
+      return createMalformedLaneRunReconciliationResult(input, {
+        laneRunId,
+        queueRecord,
+        existingLock,
+      });
+    }
+
+    throw error;
+  }
+
   const mismatches: LaneRunReconciliationMismatch[] = [];
 
   if (queueRecord === undefined) {
@@ -1166,7 +1185,7 @@ export async function reconcileLaneRunState(
     );
   }
 
-  if (existingLock !== undefined && input.laneRunId !== undefined && existingLock.laneRunId !== input.laneRunId) {
+  if (existingLock?.active === true && input.laneRunId !== undefined && existingLock.laneRunId !== input.laneRunId) {
     mismatches.push(
       createLaneRunReconciliationMismatch(
         "lane-run-target-mismatch",
@@ -2775,6 +2794,60 @@ function createMalformedLaneRunExplanation(
     verificationState: "unknown",
     blockerReason: "lane run state is malformed",
     nextOperatorAction: "repair or remove malformed lane state before continuing",
+  };
+}
+
+function createMalformedLaneRunReconciliationResult(
+  input: ReconcileLaneRunStateInput,
+  context: {
+    readonly laneRunId?: string;
+    readonly queueRecord?: LaneRunQueueRecord;
+    readonly existingLock?: LaneRunLock;
+  },
+): LaneRunReconciliationResult {
+  const mismatch = createLaneRunReconciliationMismatch(
+    "malformed-lane-state",
+    "blocked",
+    "lane run state is malformed",
+    "repair or remove malformed lane state before continuing",
+  );
+
+  return {
+    schemaVersion: "ensen.lane-run-reconciliation.v1",
+    state: "blocked",
+    category: "blocked",
+    stableWorkItemId: input.stableWorkItemId,
+    laneRunId: context.laneRunId ?? input.laneRunId,
+    observedAt: input.observedAt,
+    publicDiagnostics: {
+      stableWorkItemId: input.stableWorkItemId,
+      laneId: context.queueRecord?.laneId ?? context.existingLock?.laneId,
+      source: context.queueRecord?.source ?? context.existingLock?.source,
+      repositoryClassification:
+        context.queueRecord?.repositoryClassification ?? context.existingLock?.repositoryClassification,
+      reason: mismatch.publicMessage,
+    },
+    nextOperatorAction: mismatch.nextOperatorAction,
+    mismatches: [mismatch],
+    evidence: {
+      bundleRefs: [],
+    },
+    queue:
+      context.queueRecord === undefined
+        ? undefined
+        : {
+            status: context.queueRecord.status,
+            enqueueSequence: context.queueRecord.enqueueSequence,
+          },
+    lock:
+      context.existingLock === undefined
+        ? undefined
+        : {
+            status: context.existingLock.status,
+            active: context.existingLock.active,
+            laneRunId: context.existingLock.laneRunId,
+          },
+    startsAgentExecution: false,
   };
 }
 

--- a/src/lane/index.ts
+++ b/src/lane/index.ts
@@ -243,6 +243,80 @@ export interface LaneRunOperatorActionLineage {
 }
 
 export type LaneRunOperatorAction = "stop" | "retry" | "requeue";
+export type LaneRunReconciliationCategory = "safe-to-requeue" | "needs-cleanup" | "manual-review" | "blocked";
+export type LaneRunReconciliationMismatchKind =
+  | "missing-branch"
+  | "missing-worktree"
+  | "missing-journal"
+  | "missing-pr-draft"
+  | "stale-lock"
+  | "conflicting-verification-facts"
+  | "missing-queue-record"
+  | "lane-run-target-mismatch";
+
+export interface LaneRunObservedSurface {
+  readonly expected: boolean;
+  readonly exists: boolean;
+  readonly ref?: string;
+}
+
+export interface LaneRunObservedVerificationFact {
+  readonly source: string;
+  readonly status: LaneRunStatus | LaneRunOperatorVerificationState;
+  readonly evidenceRef?: string;
+}
+
+export interface ReconcileLaneRunStateInput {
+  readonly stableWorkItemId: string;
+  readonly laneRunId?: string;
+  readonly observedAt: string;
+  readonly surfaces: {
+    readonly branch?: LaneRunObservedSurface;
+    readonly worktree?: LaneRunObservedSurface;
+    readonly journal?: LaneRunObservedSurface;
+    readonly prDraft?: LaneRunObservedSurface;
+    readonly verificationFacts?: readonly LaneRunObservedVerificationFact[];
+  };
+}
+
+export interface LaneRunReconciliationMismatch {
+  readonly kind: LaneRunReconciliationMismatchKind;
+  readonly category: LaneRunReconciliationCategory;
+  readonly publicMessage: string;
+  readonly nextOperatorAction: string;
+  readonly ref?: string;
+}
+
+export interface LaneRunReconciliationResult {
+  readonly schemaVersion: "ensen.lane-run-reconciliation.v1";
+  readonly state: "ok" | "blocked";
+  readonly category: LaneRunReconciliationCategory;
+  readonly stableWorkItemId: string;
+  readonly laneRunId?: string;
+  readonly observedAt: string;
+  readonly publicDiagnostics: {
+    readonly stableWorkItemId: string;
+    readonly laneId?: string;
+    readonly source?: string;
+    readonly repositoryClassification?: LaneRepositoryClassification;
+    readonly reason: string;
+  };
+  readonly nextOperatorAction: string;
+  readonly mismatches: readonly LaneRunReconciliationMismatch[];
+  readonly evidence: {
+    readonly bundleRefs: readonly string[];
+  };
+  readonly queue?: {
+    readonly status: LaneRunQueueStatus;
+    readonly enqueueSequence: number;
+  };
+  readonly lock?: {
+    readonly status: LaneRunLockStatus;
+    readonly active: boolean;
+    readonly laneRunId: string;
+  };
+  readonly startsAgentExecution: false;
+}
 
 const blockedLaneRunMetadataKeys = ["blockerReason"] as const;
 const linkedAttemptVolatileMetadataKeys = [
@@ -1062,6 +1136,164 @@ export async function explainLaneRun(
     blockerReason: selected.blockerReason,
     nextOperatorAction: selected.nextOperatorAction,
     activeLock: selected.activeLock,
+  };
+}
+
+export async function reconcileLaneRunState(
+  stateRoot: string,
+  input: ReconcileLaneRunStateInput,
+): Promise<LaneRunReconciliationResult> {
+  assertSafeStableWorkItemId(input.stableWorkItemId);
+
+  if (!isIsoDateTime(input.observedAt) || (input.laneRunId !== undefined && !isLaneRunId(input.laneRunId))) {
+    throw new Error("Lane run reconciliation input is malformed.");
+  }
+
+  const queueRecord = await readOptionalLaneRunQueueRecord(stateRoot, input.stableWorkItemId);
+  const existingLock = await readOptionalLaneRunLock(stateRoot, input.stableWorkItemId);
+  const laneRunId = input.laneRunId ?? existingLock?.laneRunId;
+  const state = laneRunId === undefined ? undefined : await readOptionalLaneRunState(stateRoot, laneRunId);
+  const mismatches: LaneRunReconciliationMismatch[] = [];
+
+  if (queueRecord === undefined) {
+    mismatches.push(
+      createLaneRunReconciliationMismatch(
+        "missing-queue-record",
+        "blocked",
+        "lane run queue record is missing",
+        "select or enqueue the lane run before reconciling stale state",
+      ),
+    );
+  }
+
+  if (existingLock !== undefined && input.laneRunId !== undefined && existingLock.laneRunId !== input.laneRunId) {
+    mismatches.push(
+      createLaneRunReconciliationMismatch(
+        "lane-run-target-mismatch",
+        "blocked",
+        "reconciliation target does not match the active lane run lock",
+        "inspect the selected issue and retry reconciliation with the authoritative lane run id",
+      ),
+    );
+  }
+
+  if (existingLock?.active === true && state === undefined) {
+    mismatches.push(
+      createLaneRunReconciliationMismatch(
+        "stale-lock",
+        "safe-to-requeue",
+        "active lane run lock has no lane state",
+        "stop or remove the stale lock, then requeue explicitly if the issue is still selected",
+      ),
+    );
+  }
+
+  if (isMissingExpectedSurface(input.surfaces.branch)) {
+    mismatches.push(
+      createLaneRunReconciliationMismatch(
+        "missing-branch",
+        existingLock?.active === true ? "blocked" : "needs-cleanup",
+        existingLock?.active === true
+          ? "active lane run is missing its branch"
+          : "terminal lane run is missing its branch",
+        existingLock?.active === true
+          ? "stop the active lane run, inspect evidence, then requeue explicitly if safe"
+          : "clean up stale lane references before rediscovery or requeue",
+        input.surfaces.branch?.ref,
+      ),
+    );
+  }
+
+  if (isMissingExpectedSurface(input.surfaces.worktree)) {
+    mismatches.push(
+      createLaneRunReconciliationMismatch(
+        "missing-worktree",
+        existingLock?.active === true ? "blocked" : "needs-cleanup",
+        existingLock?.active === true
+          ? "active lane run is missing its worktree"
+          : "terminal lane run is missing its worktree",
+        existingLock?.active === true
+          ? "stop the active lane run, inspect evidence, then recreate or requeue explicitly"
+          : "remove stale worktree references or recreate the worktree before continuing",
+        input.surfaces.worktree?.ref,
+      ),
+    );
+  }
+
+  if (isLaneRunJournalMissing(input.surfaces.journal, state)) {
+    mismatches.push(
+      createLaneRunReconciliationMismatch(
+        "missing-journal",
+        "manual-review",
+        "lane run journal entry is missing",
+        "manually review preserved evidence before retrying, requeueing, or cleaning up the lane",
+        input.surfaces.journal?.ref,
+      ),
+    );
+  }
+
+  if (isMissingExpectedSurface(input.surfaces.prDraft)) {
+    mismatches.push(
+      createLaneRunReconciliationMismatch(
+        "missing-pr-draft",
+        "safe-to-requeue",
+        "lane run is missing its PR draft reference",
+        "requeue explicitly after confirming no draft PR exists for this lane",
+        input.surfaces.prDraft?.ref,
+      ),
+    );
+  }
+
+  if (hasConflictingVerificationFacts(input.surfaces.verificationFacts ?? [], state)) {
+    mismatches.push(
+      createLaneRunReconciliationMismatch(
+        "conflicting-verification-facts",
+        "manual-review",
+        "verification facts conflict with authoritative lane state",
+        "manually review verification evidence before changing queue, lock, or PR state",
+      ),
+    );
+  }
+
+  const leadingMismatch = selectLeadingLaneRunReconciliationMismatch(mismatches);
+  const reason = leadingMismatch?.publicMessage ?? "lane run state is consistent";
+  const nextOperatorAction = leadingMismatch?.nextOperatorAction ?? "no action required";
+
+  return {
+    schemaVersion: "ensen.lane-run-reconciliation.v1",
+    state: leadingMismatch === undefined ? "ok" : "blocked",
+    category: leadingMismatch?.category ?? "safe-to-requeue",
+    stableWorkItemId: input.stableWorkItemId,
+    laneRunId,
+    observedAt: input.observedAt,
+    publicDiagnostics: {
+      stableWorkItemId: input.stableWorkItemId,
+      laneId: queueRecord?.laneId ?? existingLock?.laneId,
+      source: queueRecord?.source ?? existingLock?.source,
+      repositoryClassification: queueRecord?.repositoryClassification ?? existingLock?.repositoryClassification,
+      reason,
+    },
+    nextOperatorAction,
+    mismatches,
+    evidence: {
+      bundleRefs: state?.evidence.bundleRefs ?? [],
+    },
+    queue:
+      queueRecord === undefined
+        ? undefined
+        : {
+            status: queueRecord.status,
+            enqueueSequence: queueRecord.enqueueSequence,
+          },
+    lock:
+      existingLock === undefined
+        ? undefined
+        : {
+            status: existingLock.status,
+            active: existingLock.active,
+            laneRunId: existingLock.laneRunId,
+          },
+    startsAgentExecution: false,
   };
 }
 
@@ -2420,6 +2652,106 @@ function createRequestedIssueNotFoundExplanation(stableWorkItemId: string): Lane
     blockerReason: "requested issue is not queued",
     nextOperatorAction: "select an existing lane run or enqueue the requested issue before claiming readiness",
   };
+}
+
+function isMissingExpectedSurface(surface: LaneRunObservedSurface | undefined): boolean {
+  return surface?.expected === true && surface.exists === false;
+}
+
+function isLaneRunJournalMissing(
+  journalSurface: LaneRunObservedSurface | undefined,
+  state: LaneRunState | undefined,
+): boolean {
+  if (isMissingExpectedSurface(journalSurface)) {
+    return true;
+  }
+
+  return state !== undefined && state.journal.entries.length === 0;
+}
+
+function hasConflictingVerificationFacts(
+  facts: readonly LaneRunObservedVerificationFact[],
+  state: LaneRunState | undefined,
+): boolean {
+  if (facts.length === 0) {
+    return false;
+  }
+
+  const normalizedStatuses = new Set(facts.map((fact) => normalizeVerificationFactStatus(fact.status)));
+
+  if (normalizedStatuses.size > 1) {
+    return true;
+  }
+
+  if (state === undefined) {
+    return false;
+  }
+
+  const [observedStatus] = normalizedStatuses;
+
+  return observedStatus !== undefined && observedStatus !== normalizeVerificationFactStatus(state.status);
+}
+
+function normalizeVerificationFactStatus(
+  status: LaneRunStatus | LaneRunOperatorVerificationState,
+): "not-started" | "running" | "blocked" | "succeeded" | "failed" | "unknown" {
+  if (status === "queued" || status === "not-started") {
+    return "not-started";
+  }
+
+  if (status === "running" || status === "verifying" || status === "reviewing") {
+    return "running";
+  }
+
+  if (status === "completed" || status === "succeeded") {
+    return "succeeded";
+  }
+
+  if (status === "failed") {
+    return "failed";
+  }
+
+  if (status === "blocked") {
+    return "blocked";
+  }
+
+  return "unknown";
+}
+
+function createLaneRunReconciliationMismatch(
+  kind: LaneRunReconciliationMismatchKind,
+  category: LaneRunReconciliationCategory,
+  publicMessage: string,
+  nextOperatorAction: string,
+  ref?: string,
+): LaneRunReconciliationMismatch {
+  const safeRef = publicSafeDiagnosticText(ref);
+
+  return safeRef === undefined
+    ? {
+        kind,
+        category,
+        publicMessage,
+        nextOperatorAction,
+      }
+    : {
+        kind,
+        category,
+        publicMessage,
+        nextOperatorAction,
+        ref: safeRef,
+      };
+}
+
+function selectLeadingLaneRunReconciliationMismatch(
+  mismatches: readonly LaneRunReconciliationMismatch[],
+): LaneRunReconciliationMismatch | undefined {
+  return (
+    mismatches.find((mismatch) => mismatch.category === "blocked") ??
+    mismatches.find((mismatch) => mismatch.category === "manual-review") ??
+    mismatches.find((mismatch) => mismatch.category === "needs-cleanup") ??
+    mismatches[0]
+  );
 }
 
 function createMalformedLaneRunStatus(): LaneRunOperatorStatus {

--- a/src/lane/index.ts
+++ b/src/lane/index.ts
@@ -1166,12 +1166,22 @@ export async function reconcileLaneRunState(
       input.laneRunId !== undefined &&
       queueRecord !== undefined &&
       isTerminalQueueRecordLinkedToLaneRun(queueRecord, input.laneRunId);
+    const inputLaneRunMatchesExistingLock =
+      input.laneRunId !== undefined &&
+      existingLock !== undefined &&
+      existingLock.laneRunId === input.laneRunId &&
+      (queueRecord === undefined || isLaneRunLockContextCompatibleWithQueueRecord(existingLock, queueRecord));
     inputLaneRunOwnershipUnverified =
-      input.laneRunId !== undefined && existingLock?.active !== true && !inputLaneRunMatchesQueueRecord;
+      input.laneRunId !== undefined &&
+      existingLock?.active !== true &&
+      !inputLaneRunMatchesQueueRecord &&
+      !inputLaneRunMatchesExistingLock;
     laneRunId =
       existingLock?.active === true
         ? existingLock.laneRunId
-        : inputLaneRunMatchesQueueRecord
+        : inputLaneRunMatchesExistingLock
+          ? input.laneRunId
+          : inputLaneRunMatchesQueueRecord
           ? input.laneRunId
           : input.laneRunId === undefined
             ? existingLock?.laneRunId
@@ -1227,7 +1237,7 @@ export async function reconcileLaneRunState(
     );
   }
 
-  let laneRunStateOwnershipUnverified = false;
+  let laneRunStateOwnershipRejected = false;
 
   if (inputLaneRunOwnershipUnverified) {
     mismatches.push(
@@ -1249,7 +1259,7 @@ export async function reconcileLaneRunState(
         "restore the queue record or remove the unverified lock before exposing lane evidence",
       ),
     );
-    laneRunStateOwnershipUnverified = true;
+    laneRunStateOwnershipRejected = true;
     state = undefined;
   } else if (state !== undefined && queueRecord !== undefined && state.workItemId !== queueRecord.workItemId) {
     mismatches.push(
@@ -1260,10 +1270,26 @@ export async function reconcileLaneRunState(
         "retry reconciliation with the authoritative lane run id for the selected issue",
       ),
     );
+    laneRunStateOwnershipRejected = true;
+    state = undefined;
+  } else if (
+    state !== undefined &&
+    queueRecord !== undefined &&
+    !isLaneRunStateLinkedToSelectedWorkItem(state, queueRecord, existingLock)
+  ) {
+    mismatches.push(
+      createLaneRunReconciliationMismatch(
+        "lane-run-ownership-unverified",
+        "blocked",
+        "lane run state ownership is unverifiable",
+        "restore the queue record or retry reconciliation with a lane run id linked to the selected issue identity",
+      ),
+    );
+    laneRunStateOwnershipRejected = true;
     state = undefined;
   }
 
-  if (existingLock?.active === true && state === undefined && !laneRunStateOwnershipUnverified) {
+  if (existingLock?.active === true && state === undefined && !laneRunStateOwnershipRejected) {
     mismatches.push(
       createLaneRunReconciliationMismatch(
         "stale-lock",
@@ -1939,6 +1965,31 @@ function isTerminalQueueRecordLinkedToLaneRun(record: LaneRunQueueRecord, laneRu
   }
 
   return false;
+}
+
+function isLaneRunStateLinkedToSelectedWorkItem(
+  state: LaneRunState,
+  record: LaneRunQueueRecord,
+  lock: LaneRunLock | undefined,
+): boolean {
+  if (lock?.laneRunId === state.id && isLaneRunLockContextCompatibleWithQueueRecord(lock, record)) {
+    return true;
+  }
+
+  return isTerminalQueueRecordLinkedToLaneRun(record, state.id);
+}
+
+function isLaneRunLockContextCompatibleWithQueueRecord(lock: LaneRunLock, record: LaneRunQueueRecord): boolean {
+  if (
+    lock.stableWorkItemId !== record.stableWorkItemId ||
+    lock.source !== record.source ||
+    lock.laneId !== record.laneId ||
+    lock.repositoryClassification !== record.repositoryClassification
+  ) {
+    return false;
+  }
+
+  return lock.active === true ? lock.queueRecordId === record.id : true;
 }
 
 function createLaneRunIdQueueMetadata(prefix: string, laneRunId: string): Record<string, string> {

--- a/src/lane/index.ts
+++ b/src/lane/index.ts
@@ -254,6 +254,7 @@ export type LaneRunReconciliationMismatchKind =
   | "missing-queue-record"
   | "lane-run-target-mismatch"
   | "malformed-lane-state"
+  | "lane-run-ownership-unverified"
   | "lane-run-work-item-mismatch"
   | "lock-queue-record-mismatch";
 
@@ -1156,14 +1157,21 @@ export async function reconcileLaneRunState(
   let existingLock: LaneRunLock | undefined;
   let laneRunId: string | undefined;
   let state: LaneRunState | undefined;
+  let inputLaneRunOwnershipUnverified = false;
 
   try {
     queueRecord = await readOptionalLaneRunQueueRecord(stateRoot, input.stableWorkItemId);
     existingLock = await readOptionalLaneRunLock(stateRoot, input.stableWorkItemId);
+    const inputLaneRunMatchesQueueRecord =
+      input.laneRunId !== undefined &&
+      queueRecord !== undefined &&
+      isTerminalQueueRecordLinkedToLaneRun(queueRecord, input.laneRunId);
+    inputLaneRunOwnershipUnverified =
+      input.laneRunId !== undefined && existingLock?.active !== true && !inputLaneRunMatchesQueueRecord;
     laneRunId =
       existingLock?.active === true
         ? existingLock.laneRunId
-        : input.laneRunId !== undefined && queueRecord !== undefined
+        : inputLaneRunMatchesQueueRecord
           ? input.laneRunId
           : input.laneRunId === undefined
             ? existingLock?.laneRunId
@@ -1184,12 +1192,15 @@ export async function reconcileLaneRunState(
   const mismatches: LaneRunReconciliationMismatch[] = [];
 
   if (queueRecord === undefined) {
+    const hasActiveLock = existingLock?.active === true;
     mismatches.push(
       createLaneRunReconciliationMismatch(
         "missing-queue-record",
         "blocked",
-        "lane run queue record is missing",
-        "select or enqueue the lane run before reconciling stale state",
+        hasActiveLock ? "active lane run lock has no queue record" : "lane run queue record is missing",
+        hasActiveLock
+          ? "stop or remove the active lock, then enqueue or requeue explicitly if the issue is still selected"
+          : "select or enqueue the lane run before reconciling stale state",
       ),
     );
   }
@@ -1216,7 +1227,31 @@ export async function reconcileLaneRunState(
     );
   }
 
-  if (state !== undefined && queueRecord !== undefined && state.workItemId !== queueRecord.workItemId) {
+  let laneRunStateOwnershipUnverified = false;
+
+  if (inputLaneRunOwnershipUnverified) {
+    mismatches.push(
+      createLaneRunReconciliationMismatch(
+        "lane-run-ownership-unverified",
+        "blocked",
+        "lane run state ownership is unverifiable",
+        "restore the queue record or retry reconciliation with the lane run id linked to the selected issue",
+      ),
+    );
+  }
+
+  if (state !== undefined && queueRecord === undefined) {
+    mismatches.push(
+      createLaneRunReconciliationMismatch(
+        "lane-run-ownership-unverified",
+        "blocked",
+        "lane run state ownership is unverifiable",
+        "restore the queue record or remove the unverified lock before exposing lane evidence",
+      ),
+    );
+    laneRunStateOwnershipUnverified = true;
+    state = undefined;
+  } else if (state !== undefined && queueRecord !== undefined && state.workItemId !== queueRecord.workItemId) {
     mismatches.push(
       createLaneRunReconciliationMismatch(
         "lane-run-work-item-mismatch",
@@ -1228,7 +1263,7 @@ export async function reconcileLaneRunState(
     state = undefined;
   }
 
-  if (existingLock?.active === true && state === undefined) {
+  if (existingLock?.active === true && state === undefined && !laneRunStateOwnershipUnverified) {
     mismatches.push(
       createLaneRunReconciliationMismatch(
         "stale-lock",
@@ -1891,6 +1926,10 @@ function createPreservedEvidenceQueueMetadata(
 }
 
 function isTerminalQueueRecordLinkedToLaneRun(record: LaneRunQueueRecord, laneRunId: string): boolean {
+  if (record.status === "completed") {
+    return isLaneRunIdMetadataMatch(record.metadata, "completed", laneRunId);
+  }
+
   if (record.status === "revoked") {
     return isLaneRunIdMetadataMatch(record.metadata, "revoked", laneRunId);
   }

--- a/src/lane/index.ts
+++ b/src/lane/index.ts
@@ -254,6 +254,7 @@ export type LaneRunReconciliationMismatchKind =
   | "missing-queue-record"
   | "missing-lane-state"
   | "malformed-reconciliation-input"
+  | "terminal-metadata-mismatch"
   | "lane-run-target-mismatch"
   | "malformed-lane-state"
   | "lane-run-ownership-unverified"
@@ -286,6 +287,9 @@ export interface ReconcileLaneRunStateInput {
 }
 
 type LaneRunReconciliationSurfaces = ReconcileLaneRunStateInput["surfaces"];
+type TerminalQueueRecordLaneRunIdResolution =
+  | { readonly laneRunId?: string; readonly metadataMismatch?: false }
+  | { readonly laneRunId?: undefined; readonly metadataMismatch: true };
 
 export interface LaneRunReconciliationMismatch {
   readonly kind: LaneRunReconciliationMismatchKind;
@@ -1160,8 +1164,15 @@ export async function reconcileLaneRunState(
 ): Promise<LaneRunReconciliationResult> {
   assertSafeStableWorkItemId(input.stableWorkItemId);
 
-  if (!isIsoDateTime(input.observedAt) || (input.laneRunId !== undefined && !isLaneRunId(input.laneRunId))) {
-    throw new Error("Lane run reconciliation input is malformed.");
+  if (!isIsoDateTime(input.observedAt)) {
+    return createMalformedReconciliationInputResult(
+      input,
+      "provide a valid ISO observedAt timestamp before retrying",
+    );
+  }
+
+  if (input.laneRunId !== undefined && !isLaneRunId(input.laneRunId)) {
+    return createMalformedReconciliationInputResult(input, "provide a valid lane run id before retrying");
   }
 
   const surfacesResult = parseLaneRunReconciliationSurfaces(
@@ -1180,12 +1191,17 @@ export async function reconcileLaneRunState(
   let state: LaneRunState | undefined;
   let inputLaneRunOwnershipUnverified = false;
   let terminalQueueLaneRunId: string | undefined;
+  let terminalQueueLaneRunMetadataMismatch = false;
 
   try {
     queueRecord = await readOptionalLaneRunQueueRecord(stateRoot, input.stableWorkItemId);
     existingLock = await readOptionalLaneRunLock(stateRoot, input.stableWorkItemId);
-    terminalQueueLaneRunId =
-      queueRecord === undefined ? undefined : await readTerminalQueueRecordLaneRunId(stateRoot, queueRecord);
+    const terminalQueueLaneRunResolution =
+      queueRecord === undefined
+        ? undefined
+        : await readTerminalQueueRecordLaneRunId(stateRoot, queueRecord);
+    terminalQueueLaneRunId = terminalQueueLaneRunResolution?.laneRunId;
+    terminalQueueLaneRunMetadataMismatch = terminalQueueLaneRunResolution?.metadataMismatch === true;
     const existingLockMatchesQueueRecord =
       existingLock !== undefined &&
       (queueRecord === undefined || isLaneRunLockContextCompatibleWithQueueRecord(existingLock, queueRecord));
@@ -1290,6 +1306,17 @@ export async function reconcileLaneRunState(
         "blocked",
         "lane run state ownership is unverifiable",
         "restore the queue record or retry reconciliation with the lane run id linked to the selected issue",
+      ),
+    );
+  }
+
+  if (terminalQueueLaneRunMetadataMismatch) {
+    mismatches.push(
+      createLaneRunReconciliationMismatch(
+        "terminal-metadata-mismatch",
+        "manual-review",
+        "terminal lane run metadata is inconsistent",
+        "manually review terminal queue metadata before exposing evidence, cleanup, or requeue",
       ),
     );
   }
@@ -2031,31 +2058,39 @@ function isTerminalQueueRecordLinkedToLaneRun(record: LaneRunQueueRecord, laneRu
 async function readTerminalQueueRecordLaneRunId(
   stateRoot: string,
   record: LaneRunQueueRecord,
-): Promise<string | undefined> {
+): Promise<TerminalQueueRecordLaneRunIdResolution> {
   const prefix = toTerminalQueueRecordLaneRunIdMetadataPrefix(record);
 
   if (prefix === undefined) {
-    return undefined;
+    return {};
   }
 
   const laneRunId = record.metadata[`${prefix}LaneRunId`];
   const digest = record.metadata[`${prefix}LaneRunIdSha256`];
 
   if (laneRunId !== undefined && isLaneRunId(laneRunId)) {
-    const digestMatchesMetadata = digest === undefined || digest === createLaneRunIdDigest(laneRunId);
+    if (isTruncatedLaneRunIdMetadataValue(laneRunId, digest)) {
+      const recoveredLaneRunId = await readLaneRunIdByDigest(stateRoot, digest);
 
-    if (digestMatchesMetadata && isLaneRunIdMetadataMatch(record.metadata, prefix, laneRunId)) {
-      return laneRunId;
+      return recoveredLaneRunId === undefined ? { metadataMismatch: true } : { laneRunId: recoveredLaneRunId };
     }
 
-    if (!isTruncatedLaneRunIdMetadataValue(laneRunId, digest)) {
-      return undefined;
+    if (digest !== undefined && (!isLaneRunIdDigest(digest) || digest !== createLaneRunIdDigest(laneRunId))) {
+      return { metadataMismatch: true };
     }
-  } else if (laneRunId !== undefined) {
-    return undefined;
+
+    return isLaneRunIdMetadataMatch(record.metadata, prefix, laneRunId)
+      ? { laneRunId }
+      : { metadataMismatch: true };
   }
 
-  return digest === undefined ? undefined : await readLaneRunIdByDigest(stateRoot, digest);
+  if (digest === undefined) {
+    return laneRunId === undefined ? {} : { metadataMismatch: true };
+  }
+
+  const recoveredLaneRunId = await readLaneRunIdByDigest(stateRoot, digest);
+
+  return recoveredLaneRunId === undefined ? { metadataMismatch: true } : { laneRunId: recoveredLaneRunId };
 }
 
 async function readLaneRunIdByDigest(stateRoot: string, digest: string): Promise<string | undefined> {
@@ -2076,7 +2111,13 @@ async function readLaneRunIdByDigest(stateRoot: string, digest: string): Promise
     throw error;
   }
 
-  const entries = await readdir(laneRunsRoot, { withFileTypes: true });
+  const entries = await readdir(laneRunsRoot, { withFileTypes: true }).catch((error: unknown) => {
+    if (isNodeError(error) && error.code === "ENOENT") {
+      return [];
+    }
+
+    throw error;
+  });
 
   for (const entry of entries) {
     if (!entry.isFile() || !entry.name.endsWith(".json")) {
@@ -2147,11 +2188,11 @@ function isLaneRunIdMetadataMatch(
   laneRunId: string,
 ): boolean {
   const projectedLaneRunId = metadata[`${prefix}LaneRunId`];
+  const projectedLaneRunIdDigest = metadata[`${prefix}LaneRunIdSha256`];
 
-  return (
-    projectedLaneRunId === laneRunId ||
-    (projectedLaneRunId !== undefined && metadata[`${prefix}LaneRunIdSha256`] === createLaneRunIdDigest(laneRunId))
-  );
+  return projectedLaneRunIdDigest === undefined
+    ? projectedLaneRunId === laneRunId
+    : projectedLaneRunIdDigest === createLaneRunIdDigest(laneRunId);
 }
 
 function createLaneRunIdDigest(laneRunId: string): string {
@@ -3223,8 +3264,8 @@ function createMalformedReconciliationInputResult(
     state: "blocked",
     category: "blocked",
     stableWorkItemId: input.stableWorkItemId,
-    laneRunId: input.laneRunId,
-    observedAt: input.observedAt,
+    laneRunId: isLaneRunId(input.laneRunId) ? input.laneRunId : undefined,
+    observedAt: isIsoDateTime(input.observedAt) ? input.observedAt : "1970-01-01T00:00:00.000Z",
     publicDiagnostics: {
       stableWorkItemId: input.stableWorkItemId,
       reason: mismatch.publicMessage,

--- a/src/lane/index.ts
+++ b/src/lane/index.ts
@@ -253,6 +253,7 @@ export type LaneRunReconciliationMismatchKind =
   | "conflicting-verification-facts"
   | "missing-queue-record"
   | "missing-lane-state"
+  | "malformed-reconciliation-input"
   | "lane-run-target-mismatch"
   | "malformed-lane-state"
   | "lane-run-ownership-unverified"
@@ -283,6 +284,8 @@ export interface ReconcileLaneRunStateInput {
     readonly verificationFacts?: readonly LaneRunObservedVerificationFact[];
   };
 }
+
+type LaneRunReconciliationSurfaces = ReconcileLaneRunStateInput["surfaces"];
 
 export interface LaneRunReconciliationMismatch {
   readonly kind: LaneRunReconciliationMismatchKind;
@@ -503,6 +506,13 @@ const laneRunStatuses = new Set<unknown>([
   "blocked",
   "completed",
   "failed",
+]);
+const laneRunOperatorVerificationStates = new Set<unknown>([
+  "not-started",
+  "running",
+  "blocked",
+  "succeeded",
+  "unknown",
 ]);
 const laneRunQueueStatuses = new Set<unknown>(["queued", "completed", "revoked", "superseded"]);
 const laneRunLockStatuses = new Set<unknown>(["active", "completed", "revoked", "superseded"]);
@@ -1154,6 +1164,16 @@ export async function reconcileLaneRunState(
     throw new Error("Lane run reconciliation input is malformed.");
   }
 
+  const surfacesResult = parseLaneRunReconciliationSurfaces(
+    (input as { readonly surfaces?: unknown }).surfaces,
+  );
+
+  if (!surfacesResult.ok) {
+    return createMalformedReconciliationInputResult(input, surfacesResult.nextOperatorAction);
+  }
+
+  const surfaces = surfacesResult.surfaces;
+
   let queueRecord: LaneRunQueueRecord | undefined;
   let existingLock: LaneRunLock | undefined;
   let laneRunId: string | undefined;
@@ -1341,7 +1361,7 @@ export async function reconcileLaneRunState(
     );
   }
 
-  if (isMissingExpectedSurface(input.surfaces.branch)) {
+  if (isMissingExpectedSurface(surfaces.branch)) {
     mismatches.push(
       createLaneRunReconciliationMismatch(
         "missing-branch",
@@ -1352,12 +1372,12 @@ export async function reconcileLaneRunState(
         existingLock?.active === true
           ? "stop the active lane run, inspect evidence, then requeue explicitly if safe"
           : "clean up stale lane references before rediscovery or requeue",
-        input.surfaces.branch?.ref,
+        surfaces.branch?.ref,
       ),
     );
   }
 
-  if (isMissingExpectedSurface(input.surfaces.worktree)) {
+  if (isMissingExpectedSurface(surfaces.worktree)) {
     mismatches.push(
       createLaneRunReconciliationMismatch(
         "missing-worktree",
@@ -1368,24 +1388,24 @@ export async function reconcileLaneRunState(
         existingLock?.active === true
           ? "stop the active lane run, inspect evidence, then recreate or requeue explicitly"
           : "remove stale worktree references or recreate the worktree before continuing",
-        input.surfaces.worktree?.ref,
+        surfaces.worktree?.ref,
       ),
     );
   }
 
-  if (isLaneRunJournalMissing(input.surfaces.journal, state)) {
+  if (isLaneRunJournalMissing(surfaces.journal, state)) {
     mismatches.push(
       createLaneRunReconciliationMismatch(
         "missing-journal",
         "manual-review",
         "lane run journal entry is missing",
         "manually review preserved evidence before retrying, requeueing, or cleaning up the lane",
-        input.surfaces.journal?.ref,
+        surfaces.journal?.ref,
       ),
     );
   }
 
-  if (isMissingExpectedSurface(input.surfaces.prDraft)) {
+  if (isMissingExpectedSurface(surfaces.prDraft)) {
     const activeLock = existingLock?.active === true;
     mismatches.push(
       createLaneRunReconciliationMismatch(
@@ -1395,12 +1415,12 @@ export async function reconcileLaneRunState(
         activeLock
           ? "stop the active lane run, inspect evidence, then requeue explicitly if safe"
           : "requeue explicitly after confirming no draft PR exists for this lane",
-        input.surfaces.prDraft?.ref,
+        surfaces.prDraft?.ref,
       ),
     );
   }
 
-  if (hasConflictingVerificationFacts(input.surfaces.verificationFacts ?? [], state)) {
+  if (hasConflictingVerificationFacts(surfaces.verificationFacts ?? [], state)) {
     mismatches.push(
       createLaneRunReconciliationMismatch(
         "conflicting-verification-facts",
@@ -2021,8 +2041,18 @@ async function readTerminalQueueRecordLaneRunId(
   const laneRunId = record.metadata[`${prefix}LaneRunId`];
   const digest = record.metadata[`${prefix}LaneRunIdSha256`];
 
-  if (laneRunId !== undefined && !isTruncatedLaneRunIdMetadataValue(laneRunId)) {
-    return isLaneRunId(laneRunId) && isLaneRunIdMetadataMatch(record.metadata, prefix, laneRunId) ? laneRunId : undefined;
+  if (laneRunId !== undefined && isLaneRunId(laneRunId)) {
+    const digestMatchesMetadata = digest === undefined || digest === createLaneRunIdDigest(laneRunId);
+
+    if (digestMatchesMetadata && isLaneRunIdMetadataMatch(record.metadata, prefix, laneRunId)) {
+      return laneRunId;
+    }
+
+    if (!isTruncatedLaneRunIdMetadataValue(laneRunId, digest)) {
+      return undefined;
+    }
+  } else if (laneRunId !== undefined) {
+    return undefined;
   }
 
   return digest === undefined ? undefined : await readLaneRunIdByDigest(stateRoot, digest);
@@ -2063,8 +2093,8 @@ async function readLaneRunIdByDigest(stateRoot: string, digest: string): Promise
   return undefined;
 }
 
-function isTruncatedLaneRunIdMetadataValue(value: string): boolean {
-  return value.length === 256 && value.endsWith("...");
+function isTruncatedLaneRunIdMetadataValue(value: string, digest: string | undefined): boolean {
+  return digest !== undefined && value.length === 256 && value.endsWith("...") && digest !== createLaneRunIdDigest(value);
 }
 
 function isLaneRunIdDigest(value: string): boolean {
@@ -2152,7 +2182,7 @@ async function readOptionalLaneRunState(
   try {
     return await readLaneRunState(stateRoot, laneRunId);
   } catch (error) {
-    if (isNodeError(error) && error.code === "ENOENT") {
+    if (isNodeError(error) && (error.code === "ENOENT" || error.code === "ENAMETOOLONG")) {
       return undefined;
     }
 
@@ -2910,6 +2940,91 @@ function createRequestedIssueNotFoundExplanation(stableWorkItemId: string): Lane
   };
 }
 
+function parseLaneRunReconciliationSurfaces(
+  value: unknown,
+):
+  | { readonly ok: true; readonly surfaces: LaneRunReconciliationSurfaces }
+  | { readonly ok: false; readonly nextOperatorAction: string } {
+  if (!isRecord(value)) {
+    return createMalformedReconciliationSurfacesParseResult("provide a valid reconciliation surfaces payload before retrying");
+  }
+
+  const branch = value.branch;
+  const worktree = value.worktree;
+  const journal = value.journal;
+  const prDraft = value.prDraft;
+  const verificationFacts = value.verificationFacts;
+
+  if (
+    (branch !== undefined && !isLaneRunObservedSurface(branch)) ||
+    (worktree !== undefined && !isLaneRunObservedSurface(worktree)) ||
+    (journal !== undefined && !isLaneRunObservedSurface(journal)) ||
+    (prDraft !== undefined && !isLaneRunObservedSurface(prDraft))
+  ) {
+    return createMalformedReconciliationSurfacesParseResult(
+      "provide reconciliation surface entries with boolean expected and exists fields before retrying",
+    );
+  }
+
+  if (
+    verificationFacts !== undefined &&
+    (!Array.isArray(verificationFacts) || !verificationFacts.every(isLaneRunObservedVerificationFact))
+  ) {
+    return createMalformedReconciliationSurfacesParseResult(
+      "provide verification facts with source and status fields before retrying",
+    );
+  }
+
+  return {
+    ok: true,
+    surfaces: {
+      ...(branch === undefined ? {} : { branch }),
+      ...(worktree === undefined ? {} : { worktree }),
+      ...(journal === undefined ? {} : { journal }),
+      ...(prDraft === undefined ? {} : { prDraft }),
+      ...(verificationFacts === undefined ? {} : { verificationFacts }),
+    },
+  };
+}
+
+function createMalformedReconciliationSurfacesParseResult(
+  nextOperatorAction: string,
+): { readonly ok: false; readonly nextOperatorAction: string } {
+  return { ok: false, nextOperatorAction };
+}
+
+function isLaneRunObservedSurface(value: unknown): value is LaneRunObservedSurface {
+  if (!isRecord(value)) {
+    return false;
+  }
+
+  const expectedKeys = Object.hasOwn(value, "ref") ? ["expected", "exists", "ref"] : ["expected", "exists"];
+
+  return (
+    hasExactKeys(value, expectedKeys) &&
+    typeof value.expected === "boolean" &&
+    typeof value.exists === "boolean" &&
+    (!Object.hasOwn(value, "ref") || typeof value.ref === "string")
+  );
+}
+
+function isLaneRunObservedVerificationFact(value: unknown): value is LaneRunObservedVerificationFact {
+  if (!isRecord(value)) {
+    return false;
+  }
+
+  const expectedKeys = Object.hasOwn(value, "evidenceRef")
+    ? ["source", "status", "evidenceRef"]
+    : ["source", "status"];
+
+  return (
+    hasExactKeys(value, expectedKeys) &&
+    isNonEmptyString(value.source) &&
+    (laneRunStatuses.has(value.status) || laneRunOperatorVerificationStates.has(value.status)) &&
+    (!Object.hasOwn(value, "evidenceRef") || typeof value.evidenceRef === "string")
+  );
+}
+
 function isMissingExpectedSurface(surface: LaneRunObservedSurface | undefined): boolean {
   return surface?.expected === true && surface.exists === false;
 }
@@ -3088,6 +3203,37 @@ function createMalformedLaneRunReconciliationResult(
             active: context.existingLock.active,
             laneRunId: context.existingLock.laneRunId,
           },
+    startsAgentExecution: false,
+  };
+}
+
+function createMalformedReconciliationInputResult(
+  input: ReconcileLaneRunStateInput,
+  nextOperatorAction: string,
+): LaneRunReconciliationResult {
+  const mismatch = createLaneRunReconciliationMismatch(
+    "malformed-reconciliation-input",
+    "blocked",
+    "lane run reconciliation input is malformed",
+    nextOperatorAction,
+  );
+
+  return {
+    schemaVersion: "ensen.lane-run-reconciliation.v1",
+    state: "blocked",
+    category: "blocked",
+    stableWorkItemId: input.stableWorkItemId,
+    laneRunId: input.laneRunId,
+    observedAt: input.observedAt,
+    publicDiagnostics: {
+      stableWorkItemId: input.stableWorkItemId,
+      reason: mismatch.publicMessage,
+    },
+    nextOperatorAction: mismatch.nextOperatorAction,
+    mismatches: [mismatch],
+    evidence: {
+      bundleRefs: [],
+    },
     startsAgentExecution: false,
   };
 }

--- a/src/lane/index.ts
+++ b/src/lane/index.ts
@@ -253,7 +253,9 @@ export type LaneRunReconciliationMismatchKind =
   | "conflicting-verification-facts"
   | "missing-queue-record"
   | "lane-run-target-mismatch"
-  | "malformed-lane-state";
+  | "malformed-lane-state"
+  | "lane-run-work-item-mismatch"
+  | "lock-queue-record-mismatch";
 
 export interface LaneRunObservedSurface {
   readonly expected: boolean;
@@ -1158,7 +1160,14 @@ export async function reconcileLaneRunState(
   try {
     queueRecord = await readOptionalLaneRunQueueRecord(stateRoot, input.stableWorkItemId);
     existingLock = await readOptionalLaneRunLock(stateRoot, input.stableWorkItemId);
-    laneRunId = existingLock?.active === true ? existingLock.laneRunId : input.laneRunId ?? existingLock?.laneRunId;
+    laneRunId =
+      existingLock?.active === true
+        ? existingLock.laneRunId
+        : input.laneRunId !== undefined && queueRecord !== undefined
+          ? input.laneRunId
+          : input.laneRunId === undefined
+            ? existingLock?.laneRunId
+            : undefined;
     state = laneRunId === undefined ? undefined : await readOptionalLaneRunState(stateRoot, laneRunId);
   } catch (error) {
     if (isMalformedLaneRunStateError(error)) {
@@ -1185,6 +1194,17 @@ export async function reconcileLaneRunState(
     );
   }
 
+  if (existingLock?.active === true && queueRecord !== undefined && existingLock.queueRecordId !== queueRecord.id) {
+    mismatches.push(
+      createLaneRunReconciliationMismatch(
+        "lock-queue-record-mismatch",
+        "blocked",
+        "active lane run lock does not match the queue record",
+        "stop reconciliation and repair queue or lock state before retrying",
+      ),
+    );
+  }
+
   if (existingLock?.active === true && input.laneRunId !== undefined && existingLock.laneRunId !== input.laneRunId) {
     mismatches.push(
       createLaneRunReconciliationMismatch(
@@ -1194,6 +1214,18 @@ export async function reconcileLaneRunState(
         "inspect the selected issue and retry reconciliation with the authoritative lane run id",
       ),
     );
+  }
+
+  if (state !== undefined && queueRecord !== undefined && state.workItemId !== queueRecord.workItemId) {
+    mismatches.push(
+      createLaneRunReconciliationMismatch(
+        "lane-run-work-item-mismatch",
+        "blocked",
+        "lane run state does not belong to the requested work item",
+        "retry reconciliation with the authoritative lane run id for the selected issue",
+      ),
+    );
+    state = undefined;
   }
 
   if (existingLock?.active === true && state === undefined) {
@@ -1252,12 +1284,15 @@ export async function reconcileLaneRunState(
   }
 
   if (isMissingExpectedSurface(input.surfaces.prDraft)) {
+    const activeLock = existingLock?.active === true;
     mismatches.push(
       createLaneRunReconciliationMismatch(
         "missing-pr-draft",
-        "safe-to-requeue",
-        "lane run is missing its PR draft reference",
-        "requeue explicitly after confirming no draft PR exists for this lane",
+        activeLock ? "blocked" : "safe-to-requeue",
+        activeLock ? "active lane run is missing its PR draft reference" : "lane run is missing its PR draft reference",
+        activeLock
+          ? "stop the active lane run, inspect evidence, then requeue explicitly if safe"
+          : "requeue explicitly after confirming no draft PR exists for this lane",
         input.surfaces.prDraft?.ref,
       ),
     );

--- a/src/lane/index.ts
+++ b/src/lane/index.ts
@@ -252,6 +252,7 @@ export type LaneRunReconciliationMismatchKind =
   | "stale-lock"
   | "conflicting-verification-facts"
   | "missing-queue-record"
+  | "missing-lane-state"
   | "lane-run-target-mismatch"
   | "malformed-lane-state"
   | "lane-run-ownership-unverified"
@@ -1158,10 +1159,13 @@ export async function reconcileLaneRunState(
   let laneRunId: string | undefined;
   let state: LaneRunState | undefined;
   let inputLaneRunOwnershipUnverified = false;
+  let terminalQueueLaneRunId: string | undefined;
 
   try {
     queueRecord = await readOptionalLaneRunQueueRecord(stateRoot, input.stableWorkItemId);
     existingLock = await readOptionalLaneRunLock(stateRoot, input.stableWorkItemId);
+    terminalQueueLaneRunId =
+      queueRecord === undefined ? undefined : readTerminalQueueRecordLaneRunId(queueRecord);
     const inputLaneRunMatchesQueueRecord =
       input.laneRunId !== undefined &&
       queueRecord !== undefined &&
@@ -1184,7 +1188,7 @@ export async function reconcileLaneRunState(
           : inputLaneRunMatchesQueueRecord
           ? input.laneRunId
           : input.laneRunId === undefined
-            ? existingLock?.laneRunId
+            ? (existingLock?.laneRunId ?? terminalQueueLaneRunId)
             : undefined;
     state = laneRunId === undefined ? undefined : await readOptionalLaneRunState(stateRoot, laneRunId);
   } catch (error) {
@@ -1296,6 +1300,23 @@ export async function reconcileLaneRunState(
         "safe-to-requeue",
         "active lane run lock has no lane state",
         "stop or remove the stale lock, then requeue explicitly if the issue is still selected",
+      ),
+    );
+  }
+
+  if (
+    existingLock?.active !== true &&
+    state === undefined &&
+    laneRunId !== undefined &&
+    queueRecord !== undefined &&
+    isTerminalQueueRecordLinkedToLaneRun(queueRecord, laneRunId)
+  ) {
+    mismatches.push(
+      createLaneRunReconciliationMismatch(
+        "missing-lane-state",
+        "manual-review",
+        "terminal lane run state is missing",
+        "restore terminal lane state or manually review preserved evidence before cleanup or requeue",
       ),
     );
   }
@@ -1965,6 +1986,28 @@ function isTerminalQueueRecordLinkedToLaneRun(record: LaneRunQueueRecord, laneRu
   }
 
   return false;
+}
+
+function readTerminalQueueRecordLaneRunId(record: LaneRunQueueRecord): string | undefined {
+  const prefix = toTerminalQueueRecordLaneRunIdMetadataPrefix(record);
+
+  if (prefix === undefined) {
+    return undefined;
+  }
+
+  const laneRunId = record.metadata[`${prefix}LaneRunId`];
+
+  return laneRunId !== undefined && isLaneRunId(laneRunId) && isLaneRunIdMetadataMatch(record.metadata, prefix, laneRunId)
+    ? laneRunId
+    : undefined;
+}
+
+function toTerminalQueueRecordLaneRunIdMetadataPrefix(record: LaneRunQueueRecord): string | undefined {
+  if (record.status === "completed" || record.status === "revoked" || record.status === "superseded") {
+    return record.status;
+  }
+
+  return undefined;
 }
 
 function isLaneRunStateLinkedToSelectedWorkItem(
@@ -2821,7 +2864,11 @@ function hasConflictingVerificationFacts(
     return false;
   }
 
-  const normalizedStatuses = new Set(facts.map((fact) => normalizeVerificationFactStatus(fact.status)));
+  const normalizedStatuses = new Set(
+    facts
+      .map((fact) => normalizeVerificationFactStatus(fact.status))
+      .filter((status): status is Exclude<ReturnType<typeof normalizeVerificationFactStatus>, "unknown"> => status !== "unknown"),
+  );
 
   if (normalizedStatuses.size > 1) {
     return true;

--- a/test/lane-run-reconciliation.test.ts
+++ b/test/lane-run-reconciliation.test.ts
@@ -287,6 +287,39 @@ test("reconciliation blocks stale-lock advice when active lock identity drifts w
   });
 });
 
+test("reconciliation checks active lock context before target mismatch or malformed state", async () => {
+  await withStateRoot(async (stateRoot) => {
+    const { claim } = await queueAndClaim(stateRoot);
+    await writeFile(path.join(stateRoot, "lane-runs", "lane-run-113-a.json"), "{", "utf8");
+    await writeFile(
+      resolveLaneRunLockPath(stateRoot, "github-issue-113"),
+      JSON.stringify({ ...claim.lock, source: "manual-import" }),
+      "utf8",
+    );
+
+    const result = await reconcileLaneRunState(stateRoot, {
+      stableWorkItemId: "github-issue-113",
+      laneRunId: "lane-run-113-stale",
+      observedAt,
+      surfaces: {
+        branch: { expected: true, exists: true, ref: "codex/issue-113" },
+        worktree: { expected: true, exists: true, ref: "<lane-worktree>" },
+        journal: { expected: true, exists: true },
+        prDraft: { expected: false, exists: false },
+        verificationFacts: [{ status: "running", source: "operator-status" }],
+      },
+    });
+
+    assert.equal(result.state, "blocked");
+    assert.equal(result.category, "blocked");
+    assert.equal(result.publicDiagnostics.reason, "active lane run lock context does not match the queue record");
+    assert.equal(result.mismatches[0]?.kind, "lane-run-ownership-unverified");
+    assert.equal(result.mismatches.some((mismatch) => mismatch.kind === "lane-run-target-mismatch"), false);
+    assert.equal(result.mismatches.some((mismatch) => mismatch.kind === "malformed-lane-state"), false);
+    assert.deepEqual(result.evidence.bundleRefs, []);
+  });
+});
+
 test("reconciliation prefers active-lock cleanup guidance when queue state is missing", async () => {
   await withStateRoot(async (stateRoot) => {
     await queueAndClaim(stateRoot);
@@ -700,10 +733,39 @@ test("reconciliation preserves exact 256-character terminal lane run ids ending 
     });
 
     assert.equal(result.state, "blocked");
-    assert.equal(result.category, "manual-review");
+    assert.equal(result.category, "blocked");
     assert.equal(result.laneRunId, exactLaneRunId);
-    assert.equal(result.publicDiagnostics.reason, "terminal lane run state is missing");
-    assert.equal(result.mismatches[0]?.kind, "missing-lane-state");
+    assert.equal(result.publicDiagnostics.reason, "lane run state is malformed");
+    assert.equal(result.mismatches[0]?.kind, "malformed-lane-state");
+  });
+});
+
+test("reconciliation reports overlong active lane state paths as malformed state", async () => {
+  await withStateRoot(async (stateRoot) => {
+    const exactLaneRunId = `${"lane-run-113-".padEnd(253, "a")}...`;
+
+    assert.equal(exactLaneRunId.length, 256);
+
+    await queueAndClaim(stateRoot, exactLaneRunId);
+
+    const result = await reconcileLaneRunState(stateRoot, {
+      stableWorkItemId: "github-issue-113",
+      laneRunId: exactLaneRunId,
+      observedAt,
+      surfaces: {
+        branch: { expected: true, exists: true, ref: "codex/issue-113" },
+        worktree: { expected: true, exists: true, ref: "<lane-worktree>" },
+        journal: { expected: true, exists: true },
+        prDraft: { expected: false, exists: false },
+        verificationFacts: [{ status: "running", source: "operator-status" }],
+      },
+    });
+
+    assert.equal(result.state, "blocked");
+    assert.equal(result.category, "blocked");
+    assert.equal(result.laneRunId, exactLaneRunId);
+    assert.equal(result.publicDiagnostics.reason, "lane run state is malformed");
+    assert.equal(result.mismatches[0]?.kind, "malformed-lane-state");
   });
 });
 

--- a/test/lane-run-reconciliation.test.ts
+++ b/test/lane-run-reconciliation.test.ts
@@ -476,6 +476,53 @@ test("reconciliation recovers truncated terminal metadata from the lane run id d
   });
 });
 
+test("reconciliation recovers terminal lane run id from digest when plain metadata id is invalid", async () => {
+  await withStateRoot(async (stateRoot) => {
+    await queueAndClaim(stateRoot);
+    await completeLaneRunLock(stateRoot, {
+      stableWorkItemId: "github-issue-113",
+      laneRunId: "lane-run-113-a",
+      completedAt: observedAt,
+      terminalStatus: "completed",
+    });
+    await writeLaneState(stateRoot, {
+      status: "completed",
+      evidenceRefs: ["artifacts/evidence/completed-lane.json"],
+    });
+    await rm(resolveLaneRunLockPath(stateRoot, "github-issue-113"), { force: true });
+
+    const queue = await readLaneRunQueueRecord(stateRoot, "github-issue-113");
+    await writeFile(
+      resolveLaneRunQueueRecordPath(stateRoot, "github-issue-113"),
+      JSON.stringify({
+        ...queue,
+        metadata: {
+          ...queue.metadata,
+          completedLaneRunId: "invalid/lane-run-id",
+          completedLaneRunIdSha256: laneRunIdDigest("lane-run-113-a"),
+        },
+      }),
+      "utf8",
+    );
+
+    const result = await reconcileLaneRunState(stateRoot, {
+      stableWorkItemId: "github-issue-113",
+      observedAt,
+      surfaces: {
+        branch: { expected: true, exists: true, ref: "codex/issue-113" },
+        worktree: { expected: true, exists: true, ref: "<lane-worktree>" },
+        journal: { expected: true, exists: true },
+        prDraft: { expected: false, exists: false },
+        verificationFacts: [{ status: "succeeded", source: "operator-status" }],
+      },
+    });
+
+    assert.equal(result.state, "ok");
+    assert.equal(result.laneRunId, "lane-run-113-a");
+    assert.deepEqual(result.evidence.bundleRefs, ["artifacts/evidence/completed-lane.json"]);
+  });
+});
+
 test("reconciliation prefers terminal queue metadata over an incompatible terminal lock", async () => {
   await withStateRoot(async (stateRoot) => {
     await queueAndClaim(stateRoot);
@@ -512,6 +559,84 @@ test("reconciliation prefers terminal queue metadata over an incompatible termin
     assert.equal(result.state, "ok");
     assert.equal(result.laneRunId, "lane-run-113-a");
     assert.deepEqual(result.evidence.bundleRefs, ["artifacts/evidence/completed-lane.json"]);
+  });
+});
+
+test("reconciliation reports terminal metadata mismatch when digest recovery cannot scan lane state", async () => {
+  await withStateRoot(async (stateRoot) => {
+    const longLaneRunId = `lane-run-113-${"a".repeat(260)}`;
+
+    await queueAndClaim(stateRoot, longLaneRunId);
+    await completeLaneRunLock(stateRoot, {
+      stableWorkItemId: "github-issue-113",
+      laneRunId: longLaneRunId,
+      completedAt: observedAt,
+      terminalStatus: "completed",
+    });
+    await rm(resolveLaneRunLockPath(stateRoot, "github-issue-113"), { force: true });
+    await rm(path.join(stateRoot, "lane-runs"), { recursive: true, force: true });
+
+    const result = await reconcileLaneRunState(stateRoot, {
+      stableWorkItemId: "github-issue-113",
+      observedAt,
+      surfaces: {
+        branch: { expected: true, exists: true, ref: "codex/issue-113" },
+        worktree: { expected: true, exists: true, ref: "<lane-worktree>" },
+        journal: { expected: true, exists: true },
+        prDraft: { expected: false, exists: false },
+        verificationFacts: [{ status: "succeeded", source: "operator-status" }],
+      },
+    });
+
+    assert.equal(result.state, "blocked");
+    assert.equal(result.category, "manual-review");
+    assert.equal(result.publicDiagnostics.reason, "terminal lane run metadata is inconsistent");
+    assert.equal(result.mismatches[0]?.kind, "terminal-metadata-mismatch");
+  });
+});
+
+test("reconciliation reports terminal metadata mismatch when plain id and digest disagree", async () => {
+  await withStateRoot(async (stateRoot) => {
+    await queueAndClaim(stateRoot);
+    await completeLaneRunLock(stateRoot, {
+      stableWorkItemId: "github-issue-113",
+      laneRunId: "lane-run-113-a",
+      completedAt: observedAt,
+      terminalStatus: "completed",
+    });
+    await rm(resolveLaneRunLockPath(stateRoot, "github-issue-113"), { force: true });
+
+    const queue = await readLaneRunQueueRecord(stateRoot, "github-issue-113");
+    await writeFile(
+      resolveLaneRunQueueRecordPath(stateRoot, "github-issue-113"),
+      JSON.stringify({
+        ...queue,
+        metadata: {
+          ...queue.metadata,
+          completedLaneRunId: "lane-run-113-a",
+          completedLaneRunIdSha256: laneRunIdDigest("lane-run-113-b"),
+        },
+      }),
+      "utf8",
+    );
+
+    const result = await reconcileLaneRunState(stateRoot, {
+      stableWorkItemId: "github-issue-113",
+      observedAt,
+      surfaces: {
+        branch: { expected: true, exists: true, ref: "codex/issue-113" },
+        worktree: { expected: true, exists: true, ref: "<lane-worktree>" },
+        journal: { expected: true, exists: true },
+        prDraft: { expected: false, exists: false },
+        verificationFacts: [{ status: "succeeded", source: "operator-status" }],
+      },
+    });
+
+    assert.equal(result.state, "blocked");
+    assert.equal(result.category, "manual-review");
+    assert.equal(result.laneRunId, undefined);
+    assert.equal(result.publicDiagnostics.reason, "terminal lane run metadata is inconsistent");
+    assert.equal(result.mismatches[0]?.kind, "terminal-metadata-mismatch");
   });
 });
 
@@ -810,6 +935,38 @@ test("reconciliation returns blocked diagnostics for malformed surfaces input", 
       malformedFactsResult.nextOperatorAction,
       "provide verification facts with source and status fields before retrying",
     );
+  });
+});
+
+test("reconciliation returns blocked diagnostics for malformed timestamp and lane id input", async () => {
+  await withStateRoot(async (stateRoot) => {
+    const invalidObservedAtResult = await reconcileLaneRunState(stateRoot, {
+      stableWorkItemId: "github-issue-113",
+      laneRunId: "lane-run-113-a",
+      observedAt: "not-a-timestamp",
+    } as unknown as Parameters<typeof reconcileLaneRunState>[1]);
+
+    assert.equal(invalidObservedAtResult.state, "blocked");
+    assert.equal(invalidObservedAtResult.category, "blocked");
+    assert.equal(invalidObservedAtResult.publicDiagnostics.reason, "lane run reconciliation input is malformed");
+    assert.equal(invalidObservedAtResult.mismatches[0]?.kind, "malformed-reconciliation-input");
+    assert.equal(
+      invalidObservedAtResult.nextOperatorAction,
+      "provide a valid ISO observedAt timestamp before retrying",
+    );
+
+    const invalidLaneRunIdResult = await reconcileLaneRunState(stateRoot, {
+      stableWorkItemId: "github-issue-113",
+      laneRunId: "unsafe/lane-run",
+      observedAt,
+    } as unknown as Parameters<typeof reconcileLaneRunState>[1]);
+
+    assert.equal(invalidLaneRunIdResult.state, "blocked");
+    assert.equal(invalidLaneRunIdResult.category, "blocked");
+    assert.equal(invalidLaneRunIdResult.laneRunId, undefined);
+    assert.equal(invalidLaneRunIdResult.publicDiagnostics.reason, "lane run reconciliation input is malformed");
+    assert.equal(invalidLaneRunIdResult.mismatches[0]?.kind, "malformed-reconciliation-input");
+    assert.equal(invalidLaneRunIdResult.nextOperatorAction, "provide a valid lane run id before retrying");
   });
 });
 

--- a/test/lane-run-reconciliation.test.ts
+++ b/test/lane-run-reconciliation.test.ts
@@ -1,0 +1,309 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, readFile, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import {
+  claimQueuedLaneRun,
+  completeLaneRunLock,
+  createLaneJournal,
+  createLaneRunState,
+  enqueueLaneRun,
+  readLaneRunLock,
+  readLaneRunQueueRecord,
+  reconcileLaneRunState,
+  writeLaneRunState,
+} from "../src/lane/index.js";
+
+const queuedAt = "2026-05-23T05:00:00.000Z";
+const claimedAt = "2026-05-23T05:01:00.000Z";
+const observedAt = "2026-05-23T05:02:00.000Z";
+
+async function withStateRoot(callback: (stateRoot: string) => Promise<void>): Promise<void> {
+  const stateRoot = await mkdtemp(path.join(os.tmpdir(), "ensen-loop-state-"));
+
+  try {
+    await mkdir(path.join(stateRoot, "lane-runs"), { recursive: true });
+    await callback(stateRoot);
+  } finally {
+    await rm(stateRoot, { recursive: true, force: true });
+  }
+}
+
+async function queueAndClaim(stateRoot: string, laneRunId = "lane-run-113-a") {
+  const queued = await enqueueLaneRun(stateRoot, {
+    stableWorkItemId: "github-issue-113",
+    workItemId: "issue-113",
+    source: "github-issue",
+    laneId: "owner-dogfood",
+    repositoryClassification: "owner-controlled-dogfood",
+    queuedAt,
+    metadata: {
+      issueNumber: "113",
+    },
+  });
+  const claim = await claimQueuedLaneRun(stateRoot, {
+    stableWorkItemId: "github-issue-113",
+    laneRunId,
+    claimedBy: "local-supervisor",
+    claimedAt,
+  });
+
+  return { queued, claim };
+}
+
+async function writeLaneState(
+  stateRoot: string,
+  input: {
+    readonly laneRunId?: string;
+    readonly status?: "running" | "completed" | "failed" | "blocked";
+    readonly journalEntries?: Parameters<typeof createLaneJournal>[0]["entries"];
+    readonly evidenceRefs?: readonly string[];
+  } = {},
+): Promise<void> {
+  const laneRunId = input.laneRunId ?? "lane-run-113-a";
+
+  await writeLaneRunState(
+    stateRoot,
+    createLaneRunState({
+      id: laneRunId,
+      workItemId: "issue-113",
+      status: input.status ?? "running",
+      revision: 1,
+      createdAt: claimedAt,
+      updatedAt: claimedAt,
+      journal: createLaneJournal({
+        id: `journal-${laneRunId}`,
+        laneRunId,
+        workItemId: "issue-113",
+        entries:
+          input.journalEntries ??
+          [
+            {
+              id: `${laneRunId}-branch`,
+              recordedAt: claimedAt,
+              kind: "change",
+              message: "branch intent: codex/issue-113 from main",
+            },
+          ],
+      }),
+      evidence: {
+        bundleRefs: input.evidenceRefs ?? ["artifacts/evidence/lane-run-113-a.json"],
+      },
+    }),
+  );
+}
+
+test("reconciliation fails closed when an active lane run is missing its branch", async () => {
+  await withStateRoot(async (stateRoot) => {
+    const { queued, claim } = await queueAndClaim(stateRoot);
+    await writeLaneState(stateRoot);
+
+    const originalState = await readFile(path.join(stateRoot, "lane-runs", "lane-run-113-a.json"), "utf8");
+    const result = await reconcileLaneRunState(stateRoot, {
+      stableWorkItemId: "github-issue-113",
+      laneRunId: "lane-run-113-a",
+      observedAt,
+      surfaces: {
+        branch: { expected: true, exists: false, ref: "codex/issue-113" },
+        worktree: { expected: true, exists: true, ref: "<lane-worktree>" },
+        journal: { expected: true, exists: true },
+        prDraft: { expected: false, exists: false },
+        verificationFacts: [{ status: "running", source: "operator-status" }],
+      },
+    });
+
+    assert.equal(result.state, "blocked");
+    assert.equal(result.category, "blocked");
+    assert.equal(result.publicDiagnostics.reason, "active lane run is missing its branch");
+    assert.equal(result.nextOperatorAction, "stop the active lane run, inspect evidence, then requeue explicitly if safe");
+    assert.deepEqual(result.evidence.bundleRefs, ["artifacts/evidence/lane-run-113-a.json"]);
+    assert.equal(JSON.stringify(result).includes(stateRoot), false);
+    assert.deepEqual(await readLaneRunQueueRecord(stateRoot, "github-issue-113"), queued);
+    assert.deepEqual(await readLaneRunLock(stateRoot, "github-issue-113"), claim.lock);
+    assert.equal(await readFile(path.join(stateRoot, "lane-runs", "lane-run-113-a.json"), "utf8"), originalState);
+  });
+});
+
+test("reconciliation classifies an active lock without lane state as safe to requeue after explicit cleanup", async () => {
+  await withStateRoot(async (stateRoot) => {
+    const { queued, claim } = await queueAndClaim(stateRoot);
+
+    const result = await reconcileLaneRunState(stateRoot, {
+      stableWorkItemId: "github-issue-113",
+      laneRunId: "lane-run-113-a",
+      observedAt,
+      surfaces: {
+        branch: { expected: true, exists: true, ref: "codex/issue-113" },
+        worktree: { expected: true, exists: true, ref: "<lane-worktree>" },
+        journal: { expected: true, exists: true },
+        prDraft: { expected: false, exists: false },
+        verificationFacts: [{ status: "running", source: "operator-status" }],
+      },
+    });
+
+    assert.equal(result.state, "blocked");
+    assert.equal(result.category, "safe-to-requeue");
+    assert.equal(result.publicDiagnostics.reason, "active lane run lock has no lane state");
+    assert.equal(result.mismatches[0]?.kind, "stale-lock");
+    assert.deepEqual(result.evidence.bundleRefs, []);
+    assert.deepEqual(await readLaneRunQueueRecord(stateRoot, "github-issue-113"), queued);
+    assert.deepEqual(await readLaneRunLock(stateRoot, "github-issue-113"), claim.lock);
+  });
+});
+
+test("reconciliation classifies a missing terminal worktree as cleanup-required without deleting evidence", async () => {
+  await withStateRoot(async (stateRoot) => {
+    await queueAndClaim(stateRoot);
+    await completeLaneRunLock(stateRoot, {
+      stableWorkItemId: "github-issue-113",
+      laneRunId: "lane-run-113-a",
+      completedAt: observedAt,
+      terminalStatus: "completed",
+    });
+    await writeLaneState(stateRoot, {
+      status: "completed",
+      evidenceRefs: ["artifacts/evidence/completed-lane.json"],
+    });
+    const originalState = await readFile(path.join(stateRoot, "lane-runs", "lane-run-113-a.json"), "utf8");
+
+    const result = await reconcileLaneRunState(stateRoot, {
+      stableWorkItemId: "github-issue-113",
+      laneRunId: "lane-run-113-a",
+      observedAt,
+      surfaces: {
+        branch: { expected: true, exists: true, ref: "codex/issue-113" },
+        worktree: { expected: true, exists: false, ref: "<lane-worktree>" },
+        journal: { expected: true, exists: true },
+        prDraft: { expected: false, exists: false },
+        verificationFacts: [{ status: "succeeded", source: "operator-status" }],
+      },
+    });
+
+    assert.equal(result.state, "blocked");
+    assert.equal(result.category, "needs-cleanup");
+    assert.equal(result.publicDiagnostics.reason, "terminal lane run is missing its worktree");
+    assert.deepEqual(result.evidence.bundleRefs, ["artifacts/evidence/completed-lane.json"]);
+    assert.equal(await readFile(path.join(stateRoot, "lane-runs", "lane-run-113-a.json"), "utf8"), originalState);
+  });
+});
+
+test("reconciliation sends missing journal evidence to manual review", async () => {
+  await withStateRoot(async (stateRoot) => {
+    await queueAndClaim(stateRoot);
+    await writeLaneState(stateRoot, {
+      journalEntries: [],
+    });
+
+    const result = await reconcileLaneRunState(stateRoot, {
+      stableWorkItemId: "github-issue-113",
+      laneRunId: "lane-run-113-a",
+      observedAt,
+      surfaces: {
+        branch: { expected: true, exists: true, ref: "codex/issue-113" },
+        worktree: { expected: true, exists: true, ref: "<lane-worktree>" },
+        journal: { expected: true, exists: false },
+        prDraft: { expected: false, exists: false },
+        verificationFacts: [{ status: "running", source: "operator-status" }],
+      },
+    });
+
+    assert.equal(result.state, "blocked");
+    assert.equal(result.category, "manual-review");
+    assert.equal(result.publicDiagnostics.reason, "lane run journal entry is missing");
+    assert.equal(result.nextOperatorAction, "manually review preserved evidence before retrying, requeueing, or cleaning up the lane");
+  });
+});
+
+test("reconciliation distinguishes a missing PR draft reference as requeue-eligible", async () => {
+  await withStateRoot(async (stateRoot) => {
+    await queueAndClaim(stateRoot);
+    await writeLaneState(stateRoot, {
+      status: "failed",
+    });
+    await completeLaneRunLock(stateRoot, {
+      stableWorkItemId: "github-issue-113",
+      laneRunId: "lane-run-113-a",
+      completedAt: observedAt,
+      terminalStatus: "superseded",
+    });
+
+    const result = await reconcileLaneRunState(stateRoot, {
+      stableWorkItemId: "github-issue-113",
+      laneRunId: "lane-run-113-a",
+      observedAt,
+      surfaces: {
+        branch: { expected: true, exists: true, ref: "codex/issue-113" },
+        worktree: { expected: true, exists: true, ref: "<lane-worktree>" },
+        journal: { expected: true, exists: true },
+        prDraft: { expected: true, exists: false, ref: "draft-pr" },
+        verificationFacts: [{ status: "failed", source: "operator-status" }],
+      },
+    });
+
+    assert.equal(result.state, "blocked");
+    assert.equal(result.category, "safe-to-requeue");
+    assert.equal(result.publicDiagnostics.reason, "lane run is missing its PR draft reference");
+    assert.equal(result.mismatches[0]?.kind, "missing-pr-draft");
+  });
+});
+
+test("reconciliation fails closed for conflicting verification facts", async () => {
+  await withStateRoot(async (stateRoot) => {
+    await queueAndClaim(stateRoot);
+    await writeLaneState(stateRoot, {
+      status: "completed",
+    });
+
+    const result = await reconcileLaneRunState(stateRoot, {
+      stableWorkItemId: "github-issue-113",
+      laneRunId: "lane-run-113-a",
+      observedAt,
+      surfaces: {
+        branch: { expected: true, exists: true, ref: "codex/issue-113" },
+        worktree: { expected: true, exists: true, ref: "<lane-worktree>" },
+        journal: { expected: true, exists: true },
+        prDraft: { expected: false, exists: false },
+        verificationFacts: [
+          { status: "succeeded", source: "operator-status" },
+          { status: "running", source: "verification-summary" },
+        ],
+      },
+    });
+
+    assert.equal(result.state, "blocked");
+    assert.equal(result.category, "manual-review");
+    assert.equal(result.publicDiagnostics.reason, "verification facts conflict with authoritative lane state");
+    assert.equal(result.mismatches[0]?.kind, "conflicting-verification-facts");
+  });
+});
+
+test("reconciliation public diagnostics redact workstation paths and secret-looking refs", async () => {
+  await withStateRoot(async (stateRoot) => {
+    await queueAndClaim(stateRoot);
+    await writeLaneState(stateRoot);
+
+    const result = await reconcileLaneRunState(stateRoot, {
+      stableWorkItemId: "github-issue-113",
+      laneRunId: "lane-run-113-a",
+      observedAt,
+      surfaces: {
+        branch: {
+          expected: true,
+          exists: false,
+          ref: "/Users/example/private/repo token=ghp_sampleSecretValue",
+        },
+        worktree: { expected: true, exists: true, ref: "<lane-worktree>" },
+        journal: { expected: true, exists: true },
+        prDraft: { expected: false, exists: false },
+        verificationFacts: [{ status: "running", source: "operator-status" }],
+      },
+    });
+    const serialized = JSON.stringify(result);
+
+    assert.equal(serialized.includes("/Users/example/private/repo"), false);
+    assert.equal(serialized.includes("ghp_sampleSecretValue"), false);
+    assert.equal(result.mismatches[0]?.ref, "<redacted>");
+  });
+});

--- a/test/lane-run-reconciliation.test.ts
+++ b/test/lane-run-reconciliation.test.ts
@@ -1002,6 +1002,29 @@ test("reconciliation returns blocked diagnostics for malformed surfaces input", 
 
 test("reconciliation returns blocked diagnostics for malformed timestamp and lane id input", async () => {
   await withStateRoot(async (stateRoot) => {
+    const invalidStableWorkItemIdResult = await reconcileLaneRunState(stateRoot, {
+      stableWorkItemId: "github/issue-113",
+      laneRunId: "lane-run-113-a",
+      observedAt,
+    } as unknown as Parameters<typeof reconcileLaneRunState>[1]);
+
+    assert.equal(invalidStableWorkItemIdResult.state, "blocked");
+    assert.equal(invalidStableWorkItemIdResult.category, "blocked");
+    assert.equal(invalidStableWorkItemIdResult.stableWorkItemId, "invalid-stable-work-item-id");
+    assert.equal(
+      invalidStableWorkItemIdResult.publicDiagnostics.stableWorkItemId,
+      "invalid-stable-work-item-id",
+    );
+    assert.equal(
+      invalidStableWorkItemIdResult.publicDiagnostics.reason,
+      "lane run reconciliation input is malformed",
+    );
+    assert.equal(invalidStableWorkItemIdResult.mismatches[0]?.kind, "malformed-reconciliation-input");
+    assert.equal(
+      invalidStableWorkItemIdResult.nextOperatorAction,
+      "provide a valid stable work item id before retrying",
+    );
+
     const invalidObservedAtResult = await reconcileLaneRunState(stateRoot, {
       stableWorkItemId: "github-issue-113",
       laneRunId: "lane-run-113-a",

--- a/test/lane-run-reconciliation.test.ts
+++ b/test/lane-run-reconciliation.test.ts
@@ -283,6 +283,7 @@ test("reconciliation public diagnostics redact workstation paths and secret-look
   await withStateRoot(async (stateRoot) => {
     await queueAndClaim(stateRoot);
     await writeLaneState(stateRoot);
+    const workstationPath = ["", "Users", "example", "private", "repo"].join("/");
 
     const result = await reconcileLaneRunState(stateRoot, {
       stableWorkItemId: "github-issue-113",
@@ -292,7 +293,7 @@ test("reconciliation public diagnostics redact workstation paths and secret-look
         branch: {
           expected: true,
           exists: false,
-          ref: "/Users/example/private/repo token=ghp_sampleSecretValue",
+          ref: `${workstationPath} token=ghp_sampleSecretValue`,
         },
         worktree: { expected: true, exists: true, ref: "<lane-worktree>" },
         journal: { expected: true, exists: true },
@@ -302,7 +303,7 @@ test("reconciliation public diagnostics redact workstation paths and secret-look
     });
     const serialized = JSON.stringify(result);
 
-    assert.equal(serialized.includes("/Users/example/private/repo"), false);
+    assert.equal(serialized.includes(workstationPath), false);
     assert.equal(serialized.includes("ghp_sampleSecretValue"), false);
     assert.equal(result.mismatches[0]?.ref, "<redacted>");
   });

--- a/test/lane-run-reconciliation.test.ts
+++ b/test/lane-run-reconciliation.test.ts
@@ -14,6 +14,7 @@ import {
   readLaneRunQueueRecord,
   reconcileLaneRunState,
   resolveLaneRunLockPath,
+  resolveLaneRunQueueRecordPath,
   writeLaneRunState,
 } from "../src/lane/index.js";
 
@@ -215,6 +216,35 @@ test("reconciliation blocks active lock and queue record divergence", async () =
   });
 });
 
+test("reconciliation prefers active-lock cleanup guidance when queue state is missing", async () => {
+  await withStateRoot(async (stateRoot) => {
+    await queueAndClaim(stateRoot);
+    await rm(resolveLaneRunQueueRecordPath(stateRoot, "github-issue-113"), { force: true });
+
+    const result = await reconcileLaneRunState(stateRoot, {
+      stableWorkItemId: "github-issue-113",
+      laneRunId: "lane-run-113-a",
+      observedAt,
+      surfaces: {
+        branch: { expected: true, exists: true, ref: "codex/issue-113" },
+        worktree: { expected: true, exists: true, ref: "<lane-worktree>" },
+        journal: { expected: true, exists: true },
+        prDraft: { expected: false, exists: false },
+        verificationFacts: [{ status: "running", source: "operator-status" }],
+      },
+    });
+
+    assert.equal(result.state, "blocked");
+    assert.equal(result.category, "blocked");
+    assert.equal(result.publicDiagnostics.reason, "active lane run lock has no queue record");
+    assert.equal(
+      result.nextOperatorAction,
+      "stop or remove the active lock, then enqueue or requeue explicitly if the issue is still selected",
+    );
+    assert.equal(result.mismatches[0]?.kind, "missing-queue-record");
+  });
+});
+
 test("reconciliation classifies a missing terminal worktree as cleanup-required without deleting evidence", async () => {
   await withStateRoot(async (stateRoot) => {
     await queueAndClaim(stateRoot);
@@ -251,7 +281,7 @@ test("reconciliation classifies a missing terminal worktree as cleanup-required 
   });
 });
 
-test("reconciliation ignores target mismatch for terminal historical locks", async () => {
+test("reconciliation blocks unlinked terminal targets without reporting active-lock target mismatch", async () => {
   await withStateRoot(async (stateRoot) => {
     await queueAndClaim(stateRoot);
     await completeLaneRunLock(stateRoot, {
@@ -278,13 +308,16 @@ test("reconciliation ignores target mismatch for terminal historical locks", asy
       },
     });
 
-    assert.equal(result.state, "ok");
-    assert.equal(result.laneRunId, "lane-run-113-b");
+    assert.equal(result.state, "blocked");
+    assert.equal(result.category, "blocked");
+    assert.equal(result.laneRunId, undefined);
     assert.equal(result.mismatches.some((mismatch) => mismatch.kind === "lane-run-target-mismatch"), false);
+    assert.equal(result.mismatches.some((mismatch) => mismatch.kind === "lane-run-ownership-unverified"), true);
+    assert.deepEqual(result.evidence.bundleRefs, []);
   });
 });
 
-test("reconciliation blocks cross-work-item lane state without exposing evidence", async () => {
+test("reconciliation blocks unlinked same-work-item lane state without exposing evidence", async () => {
   await withStateRoot(async (stateRoot) => {
     await enqueueLaneRun(stateRoot, {
       stableWorkItemId: "github-issue-113",
@@ -299,7 +332,7 @@ test("reconciliation blocks cross-work-item lane state without exposing evidence
     });
     await writeLaneState(stateRoot, {
       laneRunId: "lane-run-999-a",
-      workItemId: "issue-999",
+      workItemId: "issue-113",
       evidenceRefs: ["artifacts/evidence/other-issue-private.json"],
     });
 
@@ -318,8 +351,38 @@ test("reconciliation blocks cross-work-item lane state without exposing evidence
 
     assert.equal(result.state, "blocked");
     assert.equal(result.category, "blocked");
-    assert.equal(result.publicDiagnostics.reason, "lane run state does not belong to the requested work item");
-    assert.equal(result.mismatches[0]?.kind, "lane-run-work-item-mismatch");
+    assert.equal(result.publicDiagnostics.reason, "lane run state ownership is unverifiable");
+    assert.equal(result.mismatches[0]?.kind, "lane-run-ownership-unverified");
+    assert.deepEqual(result.evidence.bundleRefs, []);
+  });
+});
+
+test("reconciliation does not expose evidence when queue ownership is missing", async () => {
+  await withStateRoot(async (stateRoot) => {
+    await queueAndClaim(stateRoot);
+    await writeLaneState(stateRoot, {
+      evidenceRefs: ["artifacts/evidence/unverified-private.json"],
+    });
+    await rm(resolveLaneRunQueueRecordPath(stateRoot, "github-issue-113"), { force: true });
+
+    const result = await reconcileLaneRunState(stateRoot, {
+      stableWorkItemId: "github-issue-113",
+      laneRunId: "lane-run-113-a",
+      observedAt,
+      surfaces: {
+        branch: { expected: true, exists: true, ref: "codex/issue-113" },
+        worktree: { expected: true, exists: true, ref: "<lane-worktree>" },
+        journal: { expected: true, exists: true },
+        prDraft: { expected: false, exists: false },
+        verificationFacts: [{ status: "running", source: "operator-status" }],
+      },
+    });
+
+    assert.equal(result.state, "blocked");
+    assert.equal(result.category, "blocked");
+    assert.equal(result.publicDiagnostics.reason, "active lane run lock has no queue record");
+    assert.equal(result.mismatches.some((mismatch) => mismatch.kind === "lane-run-ownership-unverified"), true);
+    assert.equal(result.mismatches.some((mismatch) => mismatch.kind === "stale-lock"), false);
     assert.deepEqual(result.evidence.bundleRefs, []);
   });
 });

--- a/test/lane-run-reconciliation.test.ts
+++ b/test/lane-run-reconciliation.test.ts
@@ -547,6 +547,41 @@ test("reconciliation reports missing terminal lane state derived from queue meta
   });
 });
 
+test("reconciliation preserves exact 256-character terminal lane run ids ending with ellipsis", async () => {
+  await withStateRoot(async (stateRoot) => {
+    const exactLaneRunId = `${"lane-run-113-".padEnd(253, "a")}...`;
+
+    assert.equal(exactLaneRunId.length, 256);
+
+    await queueAndClaim(stateRoot, exactLaneRunId);
+    await completeLaneRunLock(stateRoot, {
+      stableWorkItemId: "github-issue-113",
+      laneRunId: exactLaneRunId,
+      completedAt: observedAt,
+      terminalStatus: "completed",
+    });
+    await rm(resolveLaneRunLockPath(stateRoot, "github-issue-113"), { force: true });
+
+    const result = await reconcileLaneRunState(stateRoot, {
+      stableWorkItemId: "github-issue-113",
+      observedAt,
+      surfaces: {
+        branch: { expected: true, exists: true, ref: "codex/issue-113" },
+        worktree: { expected: true, exists: true, ref: "<lane-worktree>" },
+        journal: { expected: true, exists: true },
+        prDraft: { expected: false, exists: false },
+        verificationFacts: [{ status: "succeeded", source: "operator-status" }],
+      },
+    });
+
+    assert.equal(result.state, "blocked");
+    assert.equal(result.category, "manual-review");
+    assert.equal(result.laneRunId, exactLaneRunId);
+    assert.equal(result.publicDiagnostics.reason, "terminal lane run state is missing");
+    assert.equal(result.mismatches[0]?.kind, "missing-lane-state");
+  });
+});
+
 test("reconciliation blocks unlinked terminal targets without reporting active-lock target mismatch", async () => {
   await withStateRoot(async (stateRoot) => {
     await queueAndClaim(stateRoot);
@@ -734,6 +769,47 @@ test("reconciliation returns blocked diagnostics for malformed lane state", asyn
     assert.equal(result.nextOperatorAction, "repair or remove malformed lane state before continuing");
     assert.equal(result.mismatches[0]?.kind, "malformed-lane-state");
     assert.deepEqual(result.evidence.bundleRefs, []);
+  });
+});
+
+test("reconciliation returns blocked diagnostics for malformed surfaces input", async () => {
+  await withStateRoot(async (stateRoot) => {
+    const missingSurfacesResult = await reconcileLaneRunState(stateRoot, {
+      stableWorkItemId: "github-issue-113",
+      laneRunId: "lane-run-113-a",
+      observedAt,
+    } as unknown as Parameters<typeof reconcileLaneRunState>[1]);
+
+    assert.equal(missingSurfacesResult.state, "blocked");
+    assert.equal(missingSurfacesResult.category, "blocked");
+    assert.equal(missingSurfacesResult.publicDiagnostics.reason, "lane run reconciliation input is malformed");
+    assert.equal(missingSurfacesResult.mismatches[0]?.kind, "malformed-reconciliation-input");
+    assert.equal(
+      missingSurfacesResult.nextOperatorAction,
+      "provide a valid reconciliation surfaces payload before retrying",
+    );
+
+    const malformedFactsResult = await reconcileLaneRunState(stateRoot, {
+      stableWorkItemId: "github-issue-113",
+      laneRunId: "lane-run-113-a",
+      observedAt,
+      surfaces: {
+        branch: { expected: true, exists: true, ref: "codex/issue-113" },
+        worktree: { expected: true, exists: true, ref: "<lane-worktree>" },
+        journal: { expected: true, exists: true },
+        prDraft: { expected: false, exists: false },
+        verificationFacts: [null],
+      },
+    } as unknown as Parameters<typeof reconcileLaneRunState>[1]);
+
+    assert.equal(malformedFactsResult.state, "blocked");
+    assert.equal(malformedFactsResult.category, "blocked");
+    assert.equal(malformedFactsResult.publicDiagnostics.reason, "lane run reconciliation input is malformed");
+    assert.equal(malformedFactsResult.mismatches[0]?.kind, "malformed-reconciliation-input");
+    assert.equal(
+      malformedFactsResult.nextOperatorAction,
+      "provide verification facts with source and status fields before retrying",
+    );
   });
 });
 

--- a/test/lane-run-reconciliation.test.ts
+++ b/test/lane-run-reconciliation.test.ts
@@ -360,6 +360,71 @@ test("reconciliation classifies a missing terminal worktree as cleanup-required 
   });
 });
 
+test("reconciliation derives terminal lane run id from queue metadata when input omits it", async () => {
+  await withStateRoot(async (stateRoot) => {
+    await queueAndClaim(stateRoot);
+    await completeLaneRunLock(stateRoot, {
+      stableWorkItemId: "github-issue-113",
+      laneRunId: "lane-run-113-a",
+      completedAt: observedAt,
+      terminalStatus: "completed",
+    });
+    await writeLaneState(stateRoot, {
+      status: "completed",
+      evidenceRefs: ["artifacts/evidence/completed-lane.json"],
+    });
+    await rm(resolveLaneRunLockPath(stateRoot, "github-issue-113"), { force: true });
+
+    const result = await reconcileLaneRunState(stateRoot, {
+      stableWorkItemId: "github-issue-113",
+      observedAt,
+      surfaces: {
+        branch: { expected: true, exists: true, ref: "codex/issue-113" },
+        worktree: { expected: true, exists: true, ref: "<lane-worktree>" },
+        journal: { expected: true, exists: true },
+        prDraft: { expected: false, exists: false },
+        verificationFacts: [{ status: "succeeded", source: "operator-status" }],
+      },
+    });
+
+    assert.equal(result.state, "ok");
+    assert.equal(result.laneRunId, "lane-run-113-a");
+    assert.deepEqual(result.evidence.bundleRefs, ["artifacts/evidence/completed-lane.json"]);
+  });
+});
+
+test("reconciliation reports missing terminal lane state derived from queue metadata", async () => {
+  await withStateRoot(async (stateRoot) => {
+    await queueAndClaim(stateRoot);
+    await completeLaneRunLock(stateRoot, {
+      stableWorkItemId: "github-issue-113",
+      laneRunId: "lane-run-113-a",
+      completedAt: observedAt,
+      terminalStatus: "completed",
+    });
+    await rm(resolveLaneRunLockPath(stateRoot, "github-issue-113"), { force: true });
+
+    const result = await reconcileLaneRunState(stateRoot, {
+      stableWorkItemId: "github-issue-113",
+      observedAt,
+      surfaces: {
+        branch: { expected: true, exists: true, ref: "codex/issue-113" },
+        worktree: { expected: true, exists: true, ref: "<lane-worktree>" },
+        journal: { expected: true, exists: true },
+        prDraft: { expected: false, exists: false },
+        verificationFacts: [{ status: "succeeded", source: "operator-status" }],
+      },
+    });
+
+    assert.equal(result.state, "blocked");
+    assert.equal(result.category, "manual-review");
+    assert.equal(result.laneRunId, "lane-run-113-a");
+    assert.equal(result.publicDiagnostics.reason, "terminal lane run state is missing");
+    assert.equal(result.mismatches[0]?.kind, "missing-lane-state");
+    assert.deepEqual(result.evidence.bundleRefs, []);
+  });
+});
+
 test("reconciliation blocks unlinked terminal targets without reporting active-lock target mismatch", async () => {
   await withStateRoot(async (stateRoot) => {
     await queueAndClaim(stateRoot);
@@ -636,6 +701,34 @@ test("reconciliation fails closed for conflicting verification facts", async () 
     assert.equal(result.category, "manual-review");
     assert.equal(result.publicDiagnostics.reason, "verification facts conflict with authoritative lane state");
     assert.equal(result.mismatches[0]?.kind, "conflicting-verification-facts");
+  });
+});
+
+test("reconciliation ignores unknown verification facts as non-authoritative", async () => {
+  await withStateRoot(async (stateRoot) => {
+    await queueAndClaim(stateRoot);
+    await writeLaneState(stateRoot, {
+      status: "completed",
+    });
+
+    const result = await reconcileLaneRunState(stateRoot, {
+      stableWorkItemId: "github-issue-113",
+      laneRunId: "lane-run-113-a",
+      observedAt,
+      surfaces: {
+        branch: { expected: true, exists: true, ref: "codex/issue-113" },
+        worktree: { expected: true, exists: true, ref: "<lane-worktree>" },
+        journal: { expected: true, exists: true },
+        prDraft: { expected: false, exists: false },
+        verificationFacts: [
+          { status: "unknown", source: "operator-status" },
+          { status: "succeeded", source: "verification-summary" },
+        ],
+      },
+    });
+
+    assert.equal(result.state, "ok");
+    assert.equal(result.mismatches.some((mismatch) => mismatch.kind === "conflicting-verification-facts"), false);
   });
 });
 

--- a/test/lane-run-reconciliation.test.ts
+++ b/test/lane-run-reconciliation.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdir, mkdtemp, readFile, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -153,6 +153,35 @@ test("reconciliation classifies an active lock without lane state as safe to req
   });
 });
 
+test("reconciliation reads authoritative active lock state before reporting target mismatch", async () => {
+  await withStateRoot(async (stateRoot) => {
+    await queueAndClaim(stateRoot);
+    await writeLaneState(stateRoot, {
+      evidenceRefs: ["artifacts/evidence/active-lane.json"],
+    });
+
+    const result = await reconcileLaneRunState(stateRoot, {
+      stableWorkItemId: "github-issue-113",
+      laneRunId: "lane-run-113-stale",
+      observedAt,
+      surfaces: {
+        branch: { expected: true, exists: true, ref: "codex/issue-113" },
+        worktree: { expected: true, exists: true, ref: "<lane-worktree>" },
+        journal: { expected: true, exists: true },
+        prDraft: { expected: false, exists: false },
+        verificationFacts: [{ status: "running", source: "operator-status" }],
+      },
+    });
+
+    assert.equal(result.state, "blocked");
+    assert.equal(result.category, "blocked");
+    assert.equal(result.laneRunId, "lane-run-113-a");
+    assert.deepEqual(result.evidence.bundleRefs, ["artifacts/evidence/active-lane.json"]);
+    assert.equal(result.mismatches.some((mismatch) => mismatch.kind === "lane-run-target-mismatch"), true);
+    assert.equal(result.mismatches.some((mismatch) => mismatch.kind === "stale-lock"), false);
+  });
+});
+
 test("reconciliation classifies a missing terminal worktree as cleanup-required without deleting evidence", async () => {
   await withStateRoot(async (stateRoot) => {
     await queueAndClaim(stateRoot);
@@ -189,6 +218,39 @@ test("reconciliation classifies a missing terminal worktree as cleanup-required 
   });
 });
 
+test("reconciliation ignores target mismatch for terminal historical locks", async () => {
+  await withStateRoot(async (stateRoot) => {
+    await queueAndClaim(stateRoot);
+    await completeLaneRunLock(stateRoot, {
+      stableWorkItemId: "github-issue-113",
+      laneRunId: "lane-run-113-a",
+      completedAt: observedAt,
+      terminalStatus: "completed",
+    });
+    await writeLaneState(stateRoot, {
+      laneRunId: "lane-run-113-b",
+      status: "completed",
+    });
+
+    const result = await reconcileLaneRunState(stateRoot, {
+      stableWorkItemId: "github-issue-113",
+      laneRunId: "lane-run-113-b",
+      observedAt,
+      surfaces: {
+        branch: { expected: true, exists: true, ref: "codex/issue-113" },
+        worktree: { expected: true, exists: true, ref: "<lane-worktree>" },
+        journal: { expected: true, exists: true },
+        prDraft: { expected: false, exists: false },
+        verificationFacts: [{ status: "succeeded", source: "operator-status" }],
+      },
+    });
+
+    assert.equal(result.state, "ok");
+    assert.equal(result.laneRunId, "lane-run-113-b");
+    assert.equal(result.mismatches.some((mismatch) => mismatch.kind === "lane-run-target-mismatch"), false);
+  });
+});
+
 test("reconciliation sends missing journal evidence to manual review", async () => {
   await withStateRoot(async (stateRoot) => {
     await queueAndClaim(stateRoot);
@@ -213,6 +275,33 @@ test("reconciliation sends missing journal evidence to manual review", async () 
     assert.equal(result.category, "manual-review");
     assert.equal(result.publicDiagnostics.reason, "lane run journal entry is missing");
     assert.equal(result.nextOperatorAction, "manually review preserved evidence before retrying, requeueing, or cleaning up the lane");
+  });
+});
+
+test("reconciliation returns blocked diagnostics for malformed lane state", async () => {
+  await withStateRoot(async (stateRoot) => {
+    await queueAndClaim(stateRoot);
+    await writeFile(path.join(stateRoot, "lane-runs", "lane-run-113-a.json"), "{", "utf8");
+
+    const result = await reconcileLaneRunState(stateRoot, {
+      stableWorkItemId: "github-issue-113",
+      laneRunId: "lane-run-113-a",
+      observedAt,
+      surfaces: {
+        branch: { expected: true, exists: true, ref: "codex/issue-113" },
+        worktree: { expected: true, exists: true, ref: "<lane-worktree>" },
+        journal: { expected: true, exists: true },
+        prDraft: { expected: false, exists: false },
+        verificationFacts: [{ status: "running", source: "operator-status" }],
+      },
+    });
+
+    assert.equal(result.state, "blocked");
+    assert.equal(result.category, "blocked");
+    assert.equal(result.publicDiagnostics.reason, "lane run state is malformed");
+    assert.equal(result.nextOperatorAction, "repair or remove malformed lane state before continuing");
+    assert.equal(result.mismatches[0]?.kind, "malformed-lane-state");
+    assert.deepEqual(result.evidence.bundleRefs, []);
   });
 });
 

--- a/test/lane-run-reconciliation.test.ts
+++ b/test/lane-run-reconciliation.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
 import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -22,6 +23,10 @@ import {
 const queuedAt = "2026-05-23T05:00:00.000Z";
 const claimedAt = "2026-05-23T05:01:00.000Z";
 const observedAt = "2026-05-23T05:02:00.000Z";
+
+function laneRunIdDigest(laneRunId: string): string {
+  return createHash("sha256").update(laneRunId).digest("hex");
+}
 
 async function withStateRoot(callback: (stateRoot: string) => Promise<void>): Promise<void> {
   const stateRoot = await mkdtemp(path.join(os.tmpdir(), "ensen-loop-state-"));
@@ -244,7 +249,38 @@ test("reconciliation blocks lock identity drift without exposing same-work-item 
 
     assert.equal(result.state, "blocked");
     assert.equal(result.category, "blocked");
-    assert.equal(result.publicDiagnostics.reason, "lane run state ownership is unverifiable");
+    assert.equal(result.publicDiagnostics.reason, "active lane run lock context does not match the queue record");
+    assert.equal(result.mismatches.some((mismatch) => mismatch.kind === "lane-run-ownership-unverified"), true);
+    assert.equal(result.mismatches.some((mismatch) => mismatch.kind === "stale-lock"), false);
+    assert.deepEqual(result.evidence.bundleRefs, []);
+  });
+});
+
+test("reconciliation blocks stale-lock advice when active lock identity drifts without lane state", async () => {
+  await withStateRoot(async (stateRoot) => {
+    const { claim } = await queueAndClaim(stateRoot);
+    await writeFile(
+      resolveLaneRunLockPath(stateRoot, "github-issue-113"),
+      JSON.stringify({ ...claim.lock, source: "manual-import" }),
+      "utf8",
+    );
+
+    const result = await reconcileLaneRunState(stateRoot, {
+      stableWorkItemId: "github-issue-113",
+      laneRunId: "lane-run-113-a",
+      observedAt,
+      surfaces: {
+        branch: { expected: true, exists: true, ref: "codex/issue-113" },
+        worktree: { expected: true, exists: true, ref: "<lane-worktree>" },
+        journal: { expected: true, exists: true },
+        prDraft: { expected: false, exists: false },
+        verificationFacts: [{ status: "running", source: "operator-status" }],
+      },
+    });
+
+    assert.equal(result.state, "blocked");
+    assert.equal(result.category, "blocked");
+    assert.equal(result.publicDiagnostics.reason, "active lane run lock context does not match the queue record");
     assert.equal(result.mismatches.some((mismatch) => mismatch.kind === "lane-run-ownership-unverified"), true);
     assert.equal(result.mismatches.some((mismatch) => mismatch.kind === "stale-lock"), false);
     assert.deepEqual(result.evidence.bundleRefs, []);
@@ -374,6 +410,92 @@ test("reconciliation derives terminal lane run id from queue metadata when input
       evidenceRefs: ["artifacts/evidence/completed-lane.json"],
     });
     await rm(resolveLaneRunLockPath(stateRoot, "github-issue-113"), { force: true });
+
+    const result = await reconcileLaneRunState(stateRoot, {
+      stableWorkItemId: "github-issue-113",
+      observedAt,
+      surfaces: {
+        branch: { expected: true, exists: true, ref: "codex/issue-113" },
+        worktree: { expected: true, exists: true, ref: "<lane-worktree>" },
+        journal: { expected: true, exists: true },
+        prDraft: { expected: false, exists: false },
+        verificationFacts: [{ status: "succeeded", source: "operator-status" }],
+      },
+    });
+
+    assert.equal(result.state, "ok");
+    assert.equal(result.laneRunId, "lane-run-113-a");
+    assert.deepEqual(result.evidence.bundleRefs, ["artifacts/evidence/completed-lane.json"]);
+  });
+});
+
+test("reconciliation recovers truncated terminal metadata from the lane run id digest", async () => {
+  await withStateRoot(async (stateRoot) => {
+    await queueAndClaim(stateRoot);
+    await completeLaneRunLock(stateRoot, {
+      stableWorkItemId: "github-issue-113",
+      laneRunId: "lane-run-113-a",
+      completedAt: observedAt,
+      terminalStatus: "completed",
+    });
+    await writeLaneState(stateRoot, {
+      status: "completed",
+      evidenceRefs: ["artifacts/evidence/completed-lane.json"],
+    });
+    await rm(resolveLaneRunLockPath(stateRoot, "github-issue-113"), { force: true });
+
+    const queue = await readLaneRunQueueRecord(stateRoot, "github-issue-113");
+    await writeFile(
+      resolveLaneRunQueueRecordPath(stateRoot, "github-issue-113"),
+      JSON.stringify({
+        ...queue,
+        metadata: {
+          ...queue.metadata,
+          completedLaneRunId: `${"lane-run-113-".padEnd(253, "a")}...`,
+          completedLaneRunIdSha256: laneRunIdDigest("lane-run-113-a"),
+        },
+      }),
+      "utf8",
+    );
+
+    const result = await reconcileLaneRunState(stateRoot, {
+      stableWorkItemId: "github-issue-113",
+      observedAt,
+      surfaces: {
+        branch: { expected: true, exists: true, ref: "codex/issue-113" },
+        worktree: { expected: true, exists: true, ref: "<lane-worktree>" },
+        journal: { expected: true, exists: true },
+        prDraft: { expected: false, exists: false },
+        verificationFacts: [{ status: "succeeded", source: "operator-status" }],
+      },
+    });
+
+    assert.equal(result.state, "ok");
+    assert.equal(result.laneRunId, "lane-run-113-a");
+    assert.deepEqual(result.evidence.bundleRefs, ["artifacts/evidence/completed-lane.json"]);
+  });
+});
+
+test("reconciliation prefers terminal queue metadata over an incompatible terminal lock", async () => {
+  await withStateRoot(async (stateRoot) => {
+    await queueAndClaim(stateRoot);
+    await completeLaneRunLock(stateRoot, {
+      stableWorkItemId: "github-issue-113",
+      laneRunId: "lane-run-113-a",
+      completedAt: observedAt,
+      terminalStatus: "completed",
+    });
+    await writeLaneState(stateRoot, {
+      status: "completed",
+      evidenceRefs: ["artifacts/evidence/completed-lane.json"],
+    });
+
+    const terminalLock = await readLaneRunLock(stateRoot, "github-issue-113");
+    await writeFile(
+      resolveLaneRunLockPath(stateRoot, "github-issue-113"),
+      JSON.stringify({ ...terminalLock, laneRunId: "lane-run-113-b", source: "manual-import" }),
+      "utf8",
+    );
 
     const result = await reconcileLaneRunState(stateRoot, {
       stableWorkItemId: "github-issue-113",

--- a/test/lane-run-reconciliation.test.ts
+++ b/test/lane-run-reconciliation.test.ts
@@ -15,6 +15,7 @@ import {
   reconcileLaneRunState,
   resolveLaneRunLockPath,
   resolveLaneRunQueueRecordPath,
+  retryLaneRun,
   writeLaneRunState,
 } from "../src/lane/index.js";
 
@@ -216,6 +217,40 @@ test("reconciliation blocks active lock and queue record divergence", async () =
   });
 });
 
+test("reconciliation blocks lock identity drift without exposing same-work-item evidence", async () => {
+  await withStateRoot(async (stateRoot) => {
+    const { claim } = await queueAndClaim(stateRoot);
+    await writeLaneState(stateRoot, {
+      evidenceRefs: ["artifacts/evidence/drifted-lock-private.json"],
+    });
+    await writeFile(
+      resolveLaneRunLockPath(stateRoot, "github-issue-113"),
+      JSON.stringify({ ...claim.lock, source: "manual-import" }),
+      "utf8",
+    );
+
+    const result = await reconcileLaneRunState(stateRoot, {
+      stableWorkItemId: "github-issue-113",
+      laneRunId: "lane-run-113-a",
+      observedAt,
+      surfaces: {
+        branch: { expected: true, exists: true, ref: "codex/issue-113" },
+        worktree: { expected: true, exists: true, ref: "<lane-worktree>" },
+        journal: { expected: true, exists: true },
+        prDraft: { expected: false, exists: false },
+        verificationFacts: [{ status: "running", source: "operator-status" }],
+      },
+    });
+
+    assert.equal(result.state, "blocked");
+    assert.equal(result.category, "blocked");
+    assert.equal(result.publicDiagnostics.reason, "lane run state ownership is unverifiable");
+    assert.equal(result.mismatches.some((mismatch) => mismatch.kind === "lane-run-ownership-unverified"), true);
+    assert.equal(result.mismatches.some((mismatch) => mismatch.kind === "stale-lock"), false);
+    assert.deepEqual(result.evidence.bundleRefs, []);
+  });
+});
+
 test("reconciliation prefers active-lock cleanup guidance when queue state is missing", async () => {
   await withStateRoot(async (stateRoot) => {
     await queueAndClaim(stateRoot);
@@ -242,6 +277,50 @@ test("reconciliation prefers active-lock cleanup guidance when queue state is mi
       "stop or remove the active lock, then enqueue or requeue explicitly if the issue is still selected",
     );
     assert.equal(result.mismatches[0]?.kind, "missing-queue-record");
+  });
+});
+
+test("reconciliation accepts explicit terminal lock lane run id after retry queues a new attempt", async () => {
+  await withStateRoot(async (stateRoot) => {
+    await queueAndClaim(stateRoot);
+    await writeLaneState(stateRoot, {
+      status: "failed",
+      evidenceRefs: ["artifacts/evidence/retry-source.json"],
+    });
+    await completeLaneRunLock(stateRoot, {
+      stableWorkItemId: "github-issue-113",
+      laneRunId: "lane-run-113-a",
+      completedAt: observedAt,
+      terminalStatus: "superseded",
+    });
+
+    const retry = await retryLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-113",
+      laneRunId: "lane-run-113-a",
+      reason: "retry after focused fix",
+      actedAt: "2026-05-23T05:03:00.000Z",
+    });
+
+    assert.equal(retry.ok, true);
+    assert.equal((await readLaneRunQueueRecord(stateRoot, "github-issue-113")).status, "queued");
+
+    const result = await reconcileLaneRunState(stateRoot, {
+      stableWorkItemId: "github-issue-113",
+      laneRunId: "lane-run-113-a",
+      observedAt: "2026-05-23T05:04:00.000Z",
+      surfaces: {
+        branch: { expected: true, exists: true, ref: "codex/issue-113" },
+        worktree: { expected: true, exists: true, ref: "<lane-worktree>" },
+        journal: { expected: true, exists: true },
+        prDraft: { expected: false, exists: false },
+        verificationFacts: [{ status: "failed", source: "operator-status" }],
+      },
+    });
+
+    assert.equal(result.state, "ok");
+    assert.equal(result.laneRunId, "lane-run-113-a");
+    assert.deepEqual(result.evidence.bundleRefs, ["artifacts/evidence/retry-source.json"]);
+    assert.equal(result.mismatches.some((mismatch) => mismatch.kind === "lane-run-ownership-unverified"), false);
   });
 });
 
@@ -382,6 +461,36 @@ test("reconciliation does not expose evidence when queue ownership is missing", 
     assert.equal(result.category, "blocked");
     assert.equal(result.publicDiagnostics.reason, "active lane run lock has no queue record");
     assert.equal(result.mismatches.some((mismatch) => mismatch.kind === "lane-run-ownership-unverified"), true);
+    assert.equal(result.mismatches.some((mismatch) => mismatch.kind === "stale-lock"), false);
+    assert.deepEqual(result.evidence.bundleRefs, []);
+  });
+});
+
+test("reconciliation skips stale-lock classification after rejecting mismatched work-item state", async () => {
+  await withStateRoot(async (stateRoot) => {
+    await queueAndClaim(stateRoot);
+    await writeLaneState(stateRoot, {
+      workItemId: "issue-999",
+      evidenceRefs: ["artifacts/evidence/mismatched-work-item.json"],
+    });
+
+    const result = await reconcileLaneRunState(stateRoot, {
+      stableWorkItemId: "github-issue-113",
+      laneRunId: "lane-run-113-a",
+      observedAt,
+      surfaces: {
+        branch: { expected: true, exists: true, ref: "codex/issue-113" },
+        worktree: { expected: true, exists: true, ref: "<lane-worktree>" },
+        journal: { expected: true, exists: true },
+        prDraft: { expected: false, exists: false },
+        verificationFacts: [{ status: "running", source: "operator-status" }],
+      },
+    });
+
+    assert.equal(result.state, "blocked");
+    assert.equal(result.category, "blocked");
+    assert.equal(result.publicDiagnostics.reason, "lane run state does not belong to the requested work item");
+    assert.equal(result.mismatches.some((mismatch) => mismatch.kind === "lane-run-work-item-mismatch"), true);
     assert.equal(result.mismatches.some((mismatch) => mismatch.kind === "stale-lock"), false);
     assert.deepEqual(result.evidence.bundleRefs, []);
   });

--- a/test/lane-run-reconciliation.test.ts
+++ b/test/lane-run-reconciliation.test.ts
@@ -13,6 +13,7 @@ import {
   readLaneRunLock,
   readLaneRunQueueRecord,
   reconcileLaneRunState,
+  resolveLaneRunLockPath,
   writeLaneRunState,
 } from "../src/lane/index.js";
 
@@ -58,17 +59,19 @@ async function writeLaneState(
   input: {
     readonly laneRunId?: string;
     readonly status?: "running" | "completed" | "failed" | "blocked";
+    readonly workItemId?: string;
     readonly journalEntries?: Parameters<typeof createLaneJournal>[0]["entries"];
     readonly evidenceRefs?: readonly string[];
   } = {},
 ): Promise<void> {
   const laneRunId = input.laneRunId ?? "lane-run-113-a";
+  const workItemId = input.workItemId ?? "issue-113";
 
   await writeLaneRunState(
     stateRoot,
     createLaneRunState({
       id: laneRunId,
-      workItemId: "issue-113",
+      workItemId,
       status: input.status ?? "running",
       revision: 1,
       createdAt: claimedAt,
@@ -76,7 +79,7 @@ async function writeLaneState(
       journal: createLaneJournal({
         id: `journal-${laneRunId}`,
         laneRunId,
-        workItemId: "issue-113",
+        workItemId,
         entries:
           input.journalEntries ??
           [
@@ -182,6 +185,36 @@ test("reconciliation reads authoritative active lock state before reporting targ
   });
 });
 
+test("reconciliation blocks active lock and queue record divergence", async () => {
+  await withStateRoot(async (stateRoot) => {
+    const { claim } = await queueAndClaim(stateRoot);
+    await writeLaneState(stateRoot);
+    await writeFile(
+      resolveLaneRunLockPath(stateRoot, "github-issue-113"),
+      JSON.stringify({ ...claim.lock, queueRecordId: "queue-github-issue-113-999" }),
+      "utf8",
+    );
+
+    const result = await reconcileLaneRunState(stateRoot, {
+      stableWorkItemId: "github-issue-113",
+      laneRunId: "lane-run-113-a",
+      observedAt,
+      surfaces: {
+        branch: { expected: true, exists: true, ref: "codex/issue-113" },
+        worktree: { expected: true, exists: true, ref: "<lane-worktree>" },
+        journal: { expected: true, exists: true },
+        prDraft: { expected: false, exists: false },
+        verificationFacts: [{ status: "running", source: "operator-status" }],
+      },
+    });
+
+    assert.equal(result.state, "blocked");
+    assert.equal(result.category, "blocked");
+    assert.equal(result.publicDiagnostics.reason, "active lane run lock does not match the queue record");
+    assert.equal(result.mismatches[0]?.kind, "lock-queue-record-mismatch");
+  });
+});
+
 test("reconciliation classifies a missing terminal worktree as cleanup-required without deleting evidence", async () => {
   await withStateRoot(async (stateRoot) => {
     await queueAndClaim(stateRoot);
@@ -251,6 +284,46 @@ test("reconciliation ignores target mismatch for terminal historical locks", asy
   });
 });
 
+test("reconciliation blocks cross-work-item lane state without exposing evidence", async () => {
+  await withStateRoot(async (stateRoot) => {
+    await enqueueLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-113",
+      workItemId: "issue-113",
+      source: "github-issue",
+      laneId: "owner-dogfood",
+      repositoryClassification: "owner-controlled-dogfood",
+      queuedAt,
+      metadata: {
+        issueNumber: "113",
+      },
+    });
+    await writeLaneState(stateRoot, {
+      laneRunId: "lane-run-999-a",
+      workItemId: "issue-999",
+      evidenceRefs: ["artifacts/evidence/other-issue-private.json"],
+    });
+
+    const result = await reconcileLaneRunState(stateRoot, {
+      stableWorkItemId: "github-issue-113",
+      laneRunId: "lane-run-999-a",
+      observedAt,
+      surfaces: {
+        branch: { expected: true, exists: true, ref: "codex/issue-999" },
+        worktree: { expected: true, exists: true, ref: "<lane-worktree>" },
+        journal: { expected: true, exists: true },
+        prDraft: { expected: false, exists: false },
+        verificationFacts: [{ status: "running", source: "operator-status" }],
+      },
+    });
+
+    assert.equal(result.state, "blocked");
+    assert.equal(result.category, "blocked");
+    assert.equal(result.publicDiagnostics.reason, "lane run state does not belong to the requested work item");
+    assert.equal(result.mismatches[0]?.kind, "lane-run-work-item-mismatch");
+    assert.deepEqual(result.evidence.bundleRefs, []);
+  });
+});
+
 test("reconciliation sends missing journal evidence to manual review", async () => {
   await withStateRoot(async (stateRoot) => {
     await queueAndClaim(stateRoot);
@@ -302,6 +375,32 @@ test("reconciliation returns blocked diagnostics for malformed lane state", asyn
     assert.equal(result.nextOperatorAction, "repair or remove malformed lane state before continuing");
     assert.equal(result.mismatches[0]?.kind, "malformed-lane-state");
     assert.deepEqual(result.evidence.bundleRefs, []);
+  });
+});
+
+test("reconciliation blocks missing PR draft advice for active lane runs", async () => {
+  await withStateRoot(async (stateRoot) => {
+    await queueAndClaim(stateRoot);
+    await writeLaneState(stateRoot);
+
+    const result = await reconcileLaneRunState(stateRoot, {
+      stableWorkItemId: "github-issue-113",
+      laneRunId: "lane-run-113-a",
+      observedAt,
+      surfaces: {
+        branch: { expected: true, exists: true, ref: "codex/issue-113" },
+        worktree: { expected: true, exists: true, ref: "<lane-worktree>" },
+        journal: { expected: true, exists: true },
+        prDraft: { expected: true, exists: false, ref: "draft-pr" },
+        verificationFacts: [{ status: "running", source: "operator-status" }],
+      },
+    });
+
+    assert.equal(result.state, "blocked");
+    assert.equal(result.category, "blocked");
+    assert.equal(result.publicDiagnostics.reason, "active lane run is missing its PR draft reference");
+    assert.equal(result.nextOperatorAction, "stop the active lane run, inspect evidence, then requeue explicitly if safe");
+    assert.equal(result.mismatches[0]?.kind, "missing-pr-draft");
   });
 });
 


### PR DESCRIPTION
## Summary
- add side-effect-free lane stale-state reconciliation with public-safe mismatch categories
- preserve queue, lock, journal, and evidence state while reporting operator next actions
- cover missing branch, missing worktree, missing journal, missing PR draft, stale lock, conflicting verification facts, and redacted diagnostics

## Verification
- npm ci
- npm run build && node --test dist/test/lane-run-reconciliation.test.js
- npm run typecheck
- npm run build
- npm test

Part of #109
Closes #113