### PR TITLE
LOOP-054: Add loop mode boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ The Protocol dependency is evidence-only: Ensen-protocol v0.3.0, TommyKammy/Ense
 
 X-Gate 4 dogfood readiness still depends on the broader cross-repo checklist, including Flow Track A closure and the general roadmap update. Track B remains future work: customer repos, ERPNext live connector, regulated data, electronic signatures, batch release, final disposition, and compliance guarantees.
 
+Phase 6 loop mode planning is exposed through `loop-mode`. One-shot mode is a bounded operator-invoked run for one selected issue or lane work item. Continuous mode is supervised repeated selection over the same queue, lock, status, explain, stop, retry, requeue, and stale-state reconciliation boundaries. Continuous mode does not authorize automatic merge, automatic final quality decisions, customer repo execution, live customer pilots, regulated-data handling, or compliance claims. X-Gate 4 dogfood is owner-controlled only and does not authorize customer repo execution.
+
 ## Commands
 
 ```sh
@@ -64,6 +66,8 @@ node dist/src/cli/index.js run-request <run-request-json-file>
 node dist/src/cli/index.js run-request <run-request-json-file> --status-snapshot queued
 node dist/src/cli/index.js x-gate2-smoke <run-request-json-file>
 node dist/src/cli/index.js x-gate3-smoke <run-request-json-file> --workspace-root <workspace-root> --state-root <state-root>
+node dist/src/cli/index.js loop-mode one-shot --state-root <state-root> --issue <stable-work-item-id>
+node dist/src/cli/index.js loop-mode continuous --state-root <state-root>
 ```
 
 `npm test` includes the EIP conformance fixture suite. After `npm run build`, `node --test dist/test/eip-conformance-fixtures.test.js` runs only the focused suite for the vendored Ensen-protocol v0.2.0 RunRequest, RunStatusSnapshot, RunResult, and EvidenceBundleRef fixtures. Those fixtures remain `eip.run-request.v1`, `eip.run-status.v1`, `eip.run-result.v1`, and `eip.evidence-bundle-ref.v1`.
@@ -77,6 +81,8 @@ node dist/src/cli/index.js x-gate3-smoke <run-request-json-file> --workspace-roo
 `x-gate2-smoke <run-request-json-file>` emits the X-Gate 2 narrow loop-flow dry-run smoke payload to stdout. The JSON payload always contains deterministic `statusSnapshot` and `runResult` fields when stable request and correlation identifiers are available. Plannable smoke requests also include an `evidenceBundleRef`; blocked dry-runs omit that field. The EvidenceBundleRef uses a relative local artifact URI under `artifacts/evidence/x-gate2/<request-id>.json`; the command describes that artifact location but does not create or write the artifact. The smoke path does not create a repository, branch, worktree, GitHub issue, pull request, Codex session, durable evidence bundle, or provider call. Invalid RunRequest input and unsupported EIP major versions fail closed with blocked status/result output when stable request and correlation identifiers are available.
 
 `x-gate3-smoke <run-request-json-file> --workspace-root <workspace-root> --state-root <state-root>` runs the bounded Phase 3 local fake lane smoke path. It validates the RunRequest, prepares local lane workspace/state directories, invokes the deterministic local fake executor, persists LaneRunState plus local evidence metadata, and emits one aggregate JSON object with RunStatusSnapshot and RunResult projections. It does not create or mutate GitHub issues, branches, pull requests, reviews, commits, real agent-provider sessions, or production evidence archives. Invalid input, unsupported EIP major versions, unsafe roots, failed fake outcomes, and blocked fake outcomes fail closed with parseable JSON output.
+
+`loop-mode one-shot --state-root <state-root> --issue <stable-work-item-id>` emits a bounded plan for one operator-selected queued lane run. `loop-mode continuous --state-root <state-root>` emits a supervised repeated-selection plan for the next queued lane run. Both modes report public-safe diagnostics and next operator actions without leaking local paths or credentials. Continuous mode keeps `automaticMerge`, `automaticQualityDecision`, `customerRepoExecution`, and `regulatedDataHandling` false.
 
 EvidenceBundleRef validation is exposed as an Ensen-loop-native protocol helper for copied Ensen-protocol v0.2.0 fixtures and dry-run metadata. It accepts relative traversal-free local paths and absolute `file:///` URIs, rejects credential-shaped URIs, query or fragment-bearing file URIs, traversal, absolute local paths, and ambiguous local path shapes, and keeps validation independent from any Ensen-flow runtime.
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -16,6 +16,7 @@ import type { LocalFakeExecutorOutcome } from "../executor/index.js";
 import {
   explainLaneRun,
   getLaneRunStatus,
+  planLoopMode,
   prepareLocalLaneWorkspace,
   requeueLaneRun,
   retryLaneRun,
@@ -298,6 +299,28 @@ async function main(): Promise<number> {
     return explanation.state === "ok" ? 0 : 1;
   }
 
+  if (command === "loop-mode") {
+    const options = parseLoopModeArgs(args);
+
+    if (options === undefined) {
+      console.error(
+        "Usage: ensen-loop loop-mode one-shot --state-root <state-root> --issue <stable-work-item-id>",
+      );
+      console.error("Usage: ensen-loop loop-mode continuous --state-root <state-root>");
+      console.error("X-Gate 4 dogfood is owner-controlled only and does not authorize customer repo execution.");
+      return 1;
+    }
+
+    const plan = await planLoopMode(options.stateRoot, {
+      mode: options.mode,
+      stableWorkItemId: options.stableWorkItemId,
+      invokedBy: "local-operator",
+    });
+
+    printJson(plan);
+    return plan.state === "ready" ? 0 : 1;
+  }
+
   if (command === "stop" || command === "retry" || command === "requeue") {
     const options = parseOperatorActionArgs(args);
 
@@ -351,6 +374,11 @@ async function main(): Promise<number> {
   );
   console.error("Usage: ensen-loop status --state-root <state-root>");
   console.error("Usage: ensen-loop explain --state-root <state-root> [--issue <stable-work-item-id>]");
+  console.error(
+    "Usage: ensen-loop loop-mode one-shot --state-root <state-root> --issue <stable-work-item-id>",
+  );
+  console.error("Usage: ensen-loop loop-mode continuous --state-root <state-root>");
+  console.error("X-Gate 4 dogfood is owner-controlled only and does not authorize customer repo execution.");
   console.error(
     "Usage: ensen-loop stop|retry|requeue --state-root <state-root> --issue <stable-work-item-id> --lane-run <lane-run-id> --reason <public-reason>",
   );
@@ -504,6 +532,61 @@ function parseExplainArgs(args: readonly string[]): ExplainOptions | undefined {
   return {
     stateRoot: args[1],
     stableWorkItemId: args[3],
+  };
+}
+
+interface LoopModeOptions {
+  readonly mode: "one-shot" | "continuous";
+  readonly stateRoot: string;
+  readonly stableWorkItemId?: string;
+}
+
+function parseLoopModeArgs(args: readonly string[]): LoopModeOptions | undefined {
+  const [mode, ...optionArgs] = args;
+
+  if (mode !== "one-shot" && mode !== "continuous") {
+    return undefined;
+  }
+
+  const values = new Map<string, string>();
+
+  for (let index = 0; index < optionArgs.length; index += 2) {
+    const flag = optionArgs[index];
+    const value = optionArgs[index + 1];
+
+    if (flag === undefined || value === undefined || !flag.startsWith("--")) {
+      return undefined;
+    }
+
+    values.set(flag, value);
+  }
+
+  const stateRoot = values.get("--state-root");
+  const stableWorkItemId = values.get("--issue");
+
+  if (stateRoot === undefined) {
+    return undefined;
+  }
+
+  if (mode === "one-shot") {
+    if (stableWorkItemId === undefined || values.size !== 2) {
+      return undefined;
+    }
+
+    return {
+      mode,
+      stateRoot,
+      stableWorkItemId,
+    };
+  }
+
+  if (stableWorkItemId !== undefined || values.size !== 1) {
+    return undefined;
+  }
+
+  return {
+    mode,
+    stateRoot,
   };
 }
 

--- a/src/lane/index.ts
+++ b/src/lane/index.ts
@@ -1205,10 +1205,17 @@ export async function planLoopMode(
 ): Promise<LoopModePlan> {
   validatePlanLoopModeInput(input);
 
-  const explanation =
-    input.mode === "one-shot"
-      ? await explainLaneRun(stateRoot, { stableWorkItemId: input.stableWorkItemId })
-      : await explainLaneRun(stateRoot);
+  let explanation: LaneRunOperatorExplanation;
+
+  if (input.mode === "one-shot") {
+    explanation = await explainLaneRun(stateRoot, { stableWorkItemId: input.stableWorkItemId });
+  } else {
+    if (input.stableWorkItemId !== undefined) {
+      throw new Error("Continuous loop mode does not accept a selected work item.");
+    }
+
+    explanation = await explainLaneRun(stateRoot);
+  }
   const blockerReason = resolveLoopModeBlockerReason(explanation);
   const basePlan = createLoopModePlanBase(input.mode, explanation);
 

--- a/src/lane/index.ts
+++ b/src/lane/index.ts
@@ -1228,21 +1228,21 @@ export async function planLoopMode(
     };
   }
 
-  const ownershipBlocker = await resolveLoopModeOwnershipBlocker(stateRoot, input.mode, explanation);
+  const ownershipDecision = await resolveLoopModeOwnershipDecision(stateRoot, input.mode, explanation);
 
-  if (ownershipBlocker !== undefined) {
+  if (ownershipDecision.state === "blocked") {
     return {
       ...basePlan,
       state: "blocked",
-      blockerReason: ownershipBlocker.blockerReason,
-      nextOperatorAction: ownershipBlocker.nextOperatorAction,
+      blockerReason: ownershipDecision.blockerReason,
+      nextOperatorAction: ownershipDecision.nextOperatorAction,
     };
   }
 
   return {
     ...basePlan,
     state: "ready",
-    nextOperatorAction: explanation.nextOperatorAction,
+    nextOperatorAction: ownershipDecision.nextOperatorAction,
   };
 }
 
@@ -3141,19 +3141,24 @@ function resolveLoopModeBlockerReason(
   return undefined;
 }
 
-async function resolveLoopModeOwnershipBlocker(
+async function resolveLoopModeOwnershipDecision(
   stateRoot: string,
   mode: LoopMode,
   explanation: LaneRunOperatorExplanation,
 ): Promise<
   | {
+      readonly state: "ready";
+      readonly nextOperatorAction: string;
+    }
+  | {
+      readonly state: "blocked";
       readonly blockerReason: string;
       readonly nextOperatorAction: string;
     }
-  | undefined
 > {
   if (explanation.stableWorkItemId === undefined) {
     return {
+      state: "blocked",
       blockerReason: "no selected issue",
       nextOperatorAction: "select or enqueue an owner-controlled dogfood lane run before starting loop mode",
     };
@@ -3166,6 +3171,7 @@ async function resolveLoopModeOwnershipBlocker(
 
     if (customerQueueRecord !== undefined) {
       return {
+        state: "blocked",
         blockerReason: "customer repository execution is not authorized for loop mode",
         nextOperatorAction: "remove or requeue customer repository lane runs before starting continuous loop mode",
       };
@@ -3175,10 +3181,14 @@ async function resolveLoopModeOwnershipBlocker(
   const queueRecord = await readLaneRunQueueRecord(stateRoot, explanation.stableWorkItemId);
 
   if (queueRecord.repositoryClassification === "owner-controlled-dogfood") {
-    return undefined;
+    return {
+      state: "ready",
+      nextOperatorAction: explanation.nextOperatorAction,
+    };
   }
 
   return {
+    state: "blocked",
     blockerReason: "customer repository execution is not authorized for loop mode",
     nextOperatorAction: "select an owner-controlled dogfood lane run before starting loop mode",
   };

--- a/src/lane/index.ts
+++ b/src/lane/index.ts
@@ -1221,6 +1221,17 @@ export async function planLoopMode(
     };
   }
 
+  const ownershipBlocker = await resolveLoopModeOwnershipBlocker(stateRoot, explanation);
+
+  if (ownershipBlocker !== undefined) {
+    return {
+      ...basePlan,
+      state: "blocked",
+      blockerReason: ownershipBlocker.blockerReason,
+      nextOperatorAction: ownershipBlocker.nextOperatorAction,
+    };
+  }
+
   return {
     ...basePlan,
     state: "ready",
@@ -3117,6 +3128,35 @@ function resolveLoopModeBlockerReason(
   }
 
   return undefined;
+}
+
+async function resolveLoopModeOwnershipBlocker(
+  stateRoot: string,
+  explanation: LaneRunOperatorExplanation,
+): Promise<
+  | {
+      readonly blockerReason: string;
+      readonly nextOperatorAction: string;
+    }
+  | undefined
+> {
+  if (explanation.stableWorkItemId === undefined) {
+    return {
+      blockerReason: "no selected issue",
+      nextOperatorAction: "select or enqueue an owner-controlled dogfood lane run before starting loop mode",
+    };
+  }
+
+  const queueRecord = await readLaneRunQueueRecord(stateRoot, explanation.stableWorkItemId);
+
+  if (queueRecord.repositoryClassification === "owner-controlled-dogfood") {
+    return undefined;
+  }
+
+  return {
+    blockerReason: "customer repository execution is not authorized for loop mode",
+    nextOperatorAction: "select an owner-controlled dogfood lane run before starting loop mode",
+  };
 }
 
 function publicSafeDiagnosticText(value: string | undefined): string | undefined {

--- a/src/lane/index.ts
+++ b/src/lane/index.ts
@@ -1221,7 +1221,7 @@ export async function planLoopMode(
     };
   }
 
-  const ownershipBlocker = await resolveLoopModeOwnershipBlocker(stateRoot, explanation);
+  const ownershipBlocker = await resolveLoopModeOwnershipBlocker(stateRoot, input.mode, explanation);
 
   if (ownershipBlocker !== undefined) {
     return {
@@ -3136,6 +3136,7 @@ function resolveLoopModeBlockerReason(
 
 async function resolveLoopModeOwnershipBlocker(
   stateRoot: string,
+  mode: LoopMode,
   explanation: LaneRunOperatorExplanation,
 ): Promise<
   | {
@@ -3149,6 +3150,19 @@ async function resolveLoopModeOwnershipBlocker(
       blockerReason: "no selected issue",
       nextOperatorAction: "select or enqueue an owner-controlled dogfood lane run before starting loop mode",
     };
+  }
+
+  if (mode === "continuous") {
+    const customerQueueRecord = (await readLaneRunQueueRecords(stateRoot)).find(
+      (record) => record.status === "queued" && record.repositoryClassification === "customer-repository",
+    );
+
+    if (customerQueueRecord !== undefined) {
+      return {
+        blockerReason: "customer repository execution is not authorized for loop mode",
+        nextOperatorAction: "remove or requeue customer repository lane runs before starting continuous loop mode",
+      };
+    }
   }
 
   const queueRecord = await readLaneRunQueueRecord(stateRoot, explanation.stableWorkItemId);

--- a/src/lane/index.ts
+++ b/src/lane/index.ts
@@ -204,6 +204,47 @@ export interface LaneRunOperatorExplanation {
   };
 }
 
+export type LoopMode = "one-shot" | "continuous";
+
+export interface PlanLoopModeInput {
+  readonly mode: LoopMode;
+  readonly stableWorkItemId?: string;
+  readonly invokedBy: string;
+}
+
+export interface LoopModePlan {
+  readonly schemaVersion: "ensen.loop-mode-plan.v1";
+  readonly mode: LoopMode;
+  readonly state: "ready" | "blocked";
+  readonly selectedIssue?: string;
+  readonly stableWorkItemId?: string;
+  readonly selection: {
+    readonly strategy: "operator-selected" | "supervised-repeated-selection";
+    readonly maxSelections: 1;
+    readonly repeats: boolean;
+  };
+  readonly safetyGates: {
+    readonly ownerControlledOnly: true;
+    readonly customerRepoExecution: false;
+    readonly regulatedDataHandling: false;
+    readonly automaticMerge: false;
+    readonly automaticQualityDecision: false;
+  };
+  readonly sharedBoundaries: readonly [
+    "queue",
+    "lock",
+    "status",
+    "explain",
+    "stop",
+    "retry",
+    "requeue",
+    "stale-state-reconciliation",
+  ];
+  readonly xGate4DogfoodBoundary?: "owner-controlled repos only; does not authorize customer repo execution";
+  readonly blockerReason?: string;
+  readonly nextOperatorAction: string;
+}
+
 export interface EnqueueLaneRunInput {
   readonly stableWorkItemId: string;
   readonly workItemId: WorkItem["id"];
@@ -1155,6 +1196,35 @@ export async function explainLaneRun(
     blockerReason: selected.blockerReason,
     nextOperatorAction: selected.nextOperatorAction,
     activeLock: selected.activeLock,
+  };
+}
+
+export async function planLoopMode(
+  stateRoot: string,
+  input: PlanLoopModeInput,
+): Promise<LoopModePlan> {
+  validatePlanLoopModeInput(input);
+
+  const explanation =
+    input.mode === "one-shot"
+      ? await explainLaneRun(stateRoot, { stableWorkItemId: input.stableWorkItemId })
+      : await explainLaneRun(stateRoot);
+  const blockerReason = resolveLoopModeBlockerReason(explanation);
+  const basePlan = createLoopModePlanBase(input.mode, explanation);
+
+  if (blockerReason !== undefined) {
+    return {
+      ...basePlan,
+      state: "blocked",
+      blockerReason,
+      nextOperatorAction: explanation.nextOperatorAction,
+    };
+  }
+
+  return {
+    ...basePlan,
+    state: "ready",
+    nextOperatorAction: explanation.nextOperatorAction,
   };
 }
 
@@ -2950,6 +3020,103 @@ function resolveBlockedOperatorStatusReason(item: LaneRunOperatorStatusItem): st
   }
 
   return "one or more lane runs are blocked";
+}
+
+function validatePlanLoopModeInput(input: PlanLoopModeInput): void {
+  if (input.mode !== "one-shot" && input.mode !== "continuous") {
+    throw new Error("Loop mode must be one-shot or continuous.");
+  }
+
+  if (!isNonEmptyString(input.invokedBy)) {
+    throw new Error("Loop mode requires an operator invocation context.");
+  }
+
+  if (input.mode === "one-shot" && input.stableWorkItemId === undefined) {
+    throw new Error("One-shot loop mode requires a selected work item.");
+  }
+
+  if (input.stableWorkItemId !== undefined) {
+    assertSafeStableWorkItemId(input.stableWorkItemId);
+  }
+}
+
+function createLoopModePlanBase(
+  mode: LoopMode,
+  explanation: LaneRunOperatorExplanation,
+): Omit<LoopModePlan, "state" | "blockerReason" | "nextOperatorAction"> {
+  const plan = {
+    schemaVersion: "ensen.loop-mode-plan.v1" as const,
+    mode,
+    selectedIssue: explanation.selectedIssue,
+    stableWorkItemId: explanation.stableWorkItemId,
+    selection:
+      mode === "one-shot"
+        ? {
+            strategy: "operator-selected" as const,
+            maxSelections: 1 as const,
+            repeats: false as const,
+          }
+        : {
+            strategy: "supervised-repeated-selection" as const,
+            maxSelections: 1 as const,
+            repeats: true as const,
+          },
+    safetyGates: createLoopModeSafetyGates(),
+    sharedBoundaries: createLoopModeSharedBoundaries(),
+    xGate4DogfoodBoundary:
+      mode === "continuous"
+        ? ("owner-controlled repos only; does not authorize customer repo execution" as const)
+        : undefined,
+  };
+
+  if (plan.xGate4DogfoodBoundary === undefined) {
+    const { xGate4DogfoodBoundary: _omitted, ...withoutXGate4 } = plan;
+
+    return withoutXGate4;
+  }
+
+  return plan;
+}
+
+function createLoopModeSafetyGates(): LoopModePlan["safetyGates"] {
+  return {
+    ownerControlledOnly: true,
+    customerRepoExecution: false,
+    regulatedDataHandling: false,
+    automaticMerge: false,
+    automaticQualityDecision: false,
+  };
+}
+
+function createLoopModeSharedBoundaries(): LoopModePlan["sharedBoundaries"] {
+  return [
+    "queue",
+    "lock",
+    "status",
+    "explain",
+    "stop",
+    "retry",
+    "requeue",
+    "stale-state-reconciliation",
+  ];
+}
+
+function resolveLoopModeBlockerReason(
+  explanation: LaneRunOperatorExplanation,
+): string | undefined {
+  if (explanation.state === "blocked") {
+    return explanation.blockerReason ?? "lane run is blocked";
+  }
+
+  if (explanation.laneState === "active") {
+    return "lane run is already active";
+  }
+
+  if (explanation.laneState !== "queued") {
+    return `lane run is not queued: ${explanation.laneState}`;
+  }
+
+  return undefined;
 }
 
 function publicSafeDiagnosticText(value: string | undefined): string | undefined {

--- a/src/lane/index.ts
+++ b/src/lane/index.ts
@@ -3046,6 +3046,10 @@ function validatePlanLoopModeInput(input: PlanLoopModeInput): void {
     throw new Error("One-shot loop mode requires a selected work item.");
   }
 
+  if (input.mode === "continuous" && input.stableWorkItemId !== undefined) {
+    throw new Error("Continuous loop mode does not accept a selected work item.");
+  }
+
   if (input.stableWorkItemId !== undefined) {
     assertSafeStableWorkItemId(input.stableWorkItemId);
   }

--- a/test/lane-loop-mode.test.ts
+++ b/test/lane-loop-mode.test.ts
@@ -186,6 +186,41 @@ test("blocks continuous mode for customer repository queue records", async () =>
   });
 });
 
+test("blocks one-shot mode for customer repository queue records", async () => {
+  await withStateRoot(async (stateRoot) => {
+    await enqueueLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-114",
+      workItemId: "issue-114",
+      source: "github-issue",
+      laneId: "customer-lane",
+      repositoryClassification: "customer-repository",
+      queuedAt,
+      metadata: {
+        issueNumber: "114",
+      },
+    });
+
+    const plan = await planLoopMode(stateRoot, {
+      mode: "one-shot",
+      stableWorkItemId: "github-issue-114",
+      invokedBy: "operator",
+    });
+
+    assert.equal(plan.state, "blocked");
+    assert.equal(
+      plan.blockerReason,
+      "customer repository execution is not authorized for loop mode",
+    );
+    assert.equal(
+      plan.nextOperatorAction,
+      "select an owner-controlled dogfood lane run before starting loop mode",
+    );
+    assert.equal(plan.safetyGates.ownerControlledOnly, true);
+    assert.equal(plan.safetyGates.customerRepoExecution, false);
+    assert.equal(JSON.stringify(plan).includes(stateRoot), false);
+  });
+});
+
 test("blocks continuous mode when the selected queue item is already locked", async () => {
   await withStateRoot(async (stateRoot) => {
     await enqueueLaneRun(stateRoot, {

--- a/test/lane-loop-mode.test.ts
+++ b/test/lane-loop-mode.test.ts
@@ -152,6 +152,31 @@ test("plans continuous mode as repeated supervised selection without auto merge 
   });
 });
 
+test("rejects continuous mode with an operator-selected issue", async () => {
+  await withStateRoot(async (stateRoot) => {
+    await enqueueLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-114",
+      workItemId: "issue-114",
+      source: "github-issue",
+      laneId: "owner-dogfood",
+      repositoryClassification: "owner-controlled-dogfood",
+      queuedAt,
+      metadata: {
+        issueNumber: "114",
+      },
+    });
+
+    await assert.rejects(
+      planLoopMode(stateRoot, {
+        mode: "continuous",
+        stableWorkItemId: "github-issue-114",
+        invokedBy: "operator",
+      }),
+      /Continuous loop mode does not accept a selected work item\./,
+    );
+  });
+});
+
 test("blocks continuous mode for customer repository queue records", async () => {
   await withStateRoot(async (stateRoot) => {
     await enqueueLaneRun(stateRoot, {

--- a/test/lane-loop-mode.test.ts
+++ b/test/lane-loop-mode.test.ts
@@ -1,0 +1,216 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { promisify } from "node:util";
+
+import {
+  claimQueuedLaneRun,
+  enqueueLaneRun,
+  planLoopMode,
+} from "../src/lane/index.js";
+
+const execFileAsync = promisify(execFile);
+const queuedAt = "2026-05-29T10:00:00.000Z";
+const claimedAt = "2026-05-29T10:01:00.000Z";
+
+interface CliResult {
+  readonly stdout: string;
+  readonly stderr: string;
+  readonly exitCode: number;
+}
+
+async function withStateRoot(callback: (stateRoot: string) => Promise<void>): Promise<void> {
+  const stateRoot = await mkdtemp(path.join(os.tmpdir(), "ensen-loop-state-"));
+
+  try {
+    await callback(stateRoot);
+  } finally {
+    await rm(stateRoot, { recursive: true, force: true });
+  }
+}
+
+async function execCli(args: readonly string[]): Promise<CliResult> {
+  try {
+    const result = await execFileAsync(process.execPath, ["dist/src/cli/index.js", ...args]);
+
+    return {
+      stdout: result.stdout,
+      stderr: result.stderr,
+      exitCode: 0,
+    };
+  } catch (error) {
+    if (isCliExitError(error)) {
+      return {
+        stdout: error.stdout,
+        stderr: error.stderr,
+        exitCode: error.code,
+      };
+    }
+
+    throw error;
+  }
+}
+
+function isCliExitError(error: unknown): error is Error & { readonly code: number; readonly stdout: string; readonly stderr: string } {
+  return (
+    error instanceof Error &&
+    typeof (error as { readonly code?: unknown }).code === "number" &&
+    typeof (error as { readonly stdout?: unknown }).stdout === "string" &&
+    typeof (error as { readonly stderr?: unknown }).stderr === "string"
+  );
+}
+
+test("plans one-shot mode for exactly one selected queued issue", async () => {
+  await withStateRoot(async (stateRoot) => {
+    await enqueueLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-114",
+      workItemId: "issue-114",
+      source: "github-issue",
+      laneId: "owner-dogfood",
+      repositoryClassification: "owner-controlled-dogfood",
+      queuedAt,
+      metadata: {
+        issueNumber: "114",
+      },
+    });
+
+    const plan = await planLoopMode(stateRoot, {
+      mode: "one-shot",
+      stableWorkItemId: "github-issue-114",
+      invokedBy: "operator",
+    });
+
+    assert.deepEqual(plan, {
+      schemaVersion: "ensen.loop-mode-plan.v1",
+      mode: "one-shot",
+      state: "ready",
+      selectedIssue: "#114",
+      stableWorkItemId: "github-issue-114",
+      selection: {
+        strategy: "operator-selected",
+        maxSelections: 1,
+        repeats: false,
+      },
+      safetyGates: {
+        ownerControlledOnly: true,
+        customerRepoExecution: false,
+        regulatedDataHandling: false,
+        automaticMerge: false,
+        automaticQualityDecision: false,
+      },
+      sharedBoundaries: [
+        "queue",
+        "lock",
+        "status",
+        "explain",
+        "stop",
+        "retry",
+        "requeue",
+        "stale-state-reconciliation",
+      ],
+      nextOperatorAction: "claim queued lane run when ready",
+    });
+    assert.equal(JSON.stringify(plan).includes(stateRoot), false);
+  });
+});
+
+test("plans continuous mode as repeated supervised selection without auto merge or quality decisions", async () => {
+  await withStateRoot(async (stateRoot) => {
+    await enqueueLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-114",
+      workItemId: "issue-114",
+      source: "github-issue",
+      laneId: "owner-dogfood",
+      repositoryClassification: "owner-controlled-dogfood",
+      queuedAt,
+      metadata: {
+        issueNumber: "114",
+      },
+    });
+
+    const plan = await planLoopMode(stateRoot, {
+      mode: "continuous",
+      invokedBy: "operator",
+    });
+
+    assert.equal(plan.state, "ready");
+    assert.equal(plan.mode, "continuous");
+    assert.equal(plan.selectedIssue, "#114");
+    assert.deepEqual(plan.selection, {
+      strategy: "supervised-repeated-selection",
+      maxSelections: 1,
+      repeats: true,
+    });
+    assert.equal(plan.safetyGates.automaticMerge, false);
+    assert.equal(plan.safetyGates.automaticQualityDecision, false);
+    assert.equal(plan.safetyGates.customerRepoExecution, false);
+    assert.equal(plan.safetyGates.regulatedDataHandling, false);
+    assert.equal(plan.nextOperatorAction, "claim queued lane run when ready");
+  });
+});
+
+test("blocks continuous mode when the selected queue item is already locked", async () => {
+  await withStateRoot(async (stateRoot) => {
+    await enqueueLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-114",
+      workItemId: "issue-114",
+      source: "github-issue",
+      laneId: "owner-dogfood",
+      repositoryClassification: "owner-controlled-dogfood",
+      queuedAt,
+      metadata: {
+        issueNumber: "114",
+      },
+    });
+    await claimQueuedLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-114",
+      laneRunId: "lane-run-114-a",
+      claimedBy: "operator-token=ghp_sampleSecretValue",
+      claimedAt,
+    });
+
+    const plan = await planLoopMode(stateRoot, {
+      mode: "continuous",
+      invokedBy: "operator-token=ghp_sampleSecretValue",
+    });
+
+    assert.equal(plan.state, "blocked");
+    assert.equal(plan.blockerReason, "lane run is already active");
+    assert.equal(plan.nextOperatorAction, "wait for active lane run lane-run-114-a to finish");
+    assert.equal(JSON.stringify(plan).includes("ghp_sampleSecretValue"), false);
+  });
+});
+
+test("CLI loop-mode emits public-safe diagnostics and X-Gate 4 owner-only wording", async () => {
+  await withStateRoot(async (stateRoot) => {
+    await enqueueLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-114",
+      workItemId: "issue-114",
+      source: "github-issue",
+      laneId: "owner-dogfood",
+      repositoryClassification: "owner-controlled-dogfood",
+      queuedAt,
+      metadata: {
+        issueNumber: "114",
+      },
+    });
+
+    const result = await execCli(["loop-mode", "continuous", "--state-root", stateRoot]);
+    const plan = JSON.parse(result.stdout) as {
+      readonly state?: unknown;
+      readonly xGate4DogfoodBoundary?: unknown;
+    };
+
+    assert.equal(result.stderr, "");
+    assert.equal(result.exitCode, 0);
+    assert.equal(plan.state, "ready");
+    assert.equal(
+      plan.xGate4DogfoodBoundary,
+      "owner-controlled repos only; does not authorize customer repo execution",
+    );
+    assert.equal(JSON.stringify(plan).includes(stateRoot), false);
+  });
+});

--- a/test/lane-loop-mode.test.ts
+++ b/test/lane-loop-mode.test.ts
@@ -203,8 +203,54 @@ test("blocks continuous mode for customer repository queue records", async () =>
     );
     assert.equal(
       plan.nextOperatorAction,
-      "select an owner-controlled dogfood lane run before starting loop mode",
+      "remove or requeue customer repository lane runs before starting continuous loop mode",
     );
+    assert.equal(plan.safetyGates.ownerControlledOnly, true);
+    assert.equal(plan.safetyGates.customerRepoExecution, false);
+    assert.equal(JSON.stringify(plan).includes(stateRoot), false);
+  });
+});
+
+test("blocks continuous mode when any queued record is a customer repository", async () => {
+  await withStateRoot(async (stateRoot) => {
+    await enqueueLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-114",
+      workItemId: "issue-114",
+      source: "github-issue",
+      laneId: "owner-dogfood",
+      repositoryClassification: "owner-controlled-dogfood",
+      queuedAt,
+      metadata: {
+        issueNumber: "114",
+      },
+    });
+    await enqueueLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-115",
+      workItemId: "issue-115",
+      source: "github-issue",
+      laneId: "customer-lane",
+      repositoryClassification: "customer-repository",
+      queuedAt: "2026-05-29T10:02:00.000Z",
+      metadata: {
+        issueNumber: "115",
+      },
+    });
+
+    const plan = await planLoopMode(stateRoot, {
+      mode: "continuous",
+      invokedBy: "operator",
+    });
+
+    assert.equal(plan.state, "blocked");
+    assert.equal(
+      plan.blockerReason,
+      "customer repository execution is not authorized for loop mode",
+    );
+    assert.equal(
+      plan.nextOperatorAction,
+      "remove or requeue customer repository lane runs before starting continuous loop mode",
+    );
+    assert.equal(plan.selectedIssue, "#114");
     assert.equal(plan.safetyGates.ownerControlledOnly, true);
     assert.equal(plan.safetyGates.customerRepoExecution, false);
     assert.equal(JSON.stringify(plan).includes(stateRoot), false);

--- a/test/lane-loop-mode.test.ts
+++ b/test/lane-loop-mode.test.ts
@@ -152,7 +152,7 @@ test("plans continuous mode as repeated supervised selection without auto merge 
   });
 });
 
-test("rejects continuous mode with an operator-selected issue", async () => {
+test("rejects continuous mode with an operator-selected issue in a multi-item queue", async () => {
   await withStateRoot(async (stateRoot) => {
     await enqueueLaneRun(stateRoot, {
       stableWorkItemId: "github-issue-114",
@@ -165,11 +165,22 @@ test("rejects continuous mode with an operator-selected issue", async () => {
         issueNumber: "114",
       },
     });
+    await enqueueLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-115",
+      workItemId: "issue-115",
+      source: "github-issue",
+      laneId: "owner-dogfood",
+      repositoryClassification: "owner-controlled-dogfood",
+      queuedAt: "2026-05-29T10:02:00.000Z",
+      metadata: {
+        issueNumber: "115",
+      },
+    });
 
     await assert.rejects(
       planLoopMode(stateRoot, {
         mode: "continuous",
-        stableWorkItemId: "github-issue-114",
+        stableWorkItemId: "github-issue-115",
         invokedBy: "operator",
       }),
       /Continuous loop mode does not accept a selected work item\./,

--- a/test/lane-loop-mode.test.ts
+++ b/test/lane-loop-mode.test.ts
@@ -152,6 +152,40 @@ test("plans continuous mode as repeated supervised selection without auto merge 
   });
 });
 
+test("blocks continuous mode for customer repository queue records", async () => {
+  await withStateRoot(async (stateRoot) => {
+    await enqueueLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-114",
+      workItemId: "issue-114",
+      source: "github-issue",
+      laneId: "customer-lane",
+      repositoryClassification: "customer-repository",
+      queuedAt,
+      metadata: {
+        issueNumber: "114",
+      },
+    });
+
+    const plan = await planLoopMode(stateRoot, {
+      mode: "continuous",
+      invokedBy: "operator",
+    });
+
+    assert.equal(plan.state, "blocked");
+    assert.equal(
+      plan.blockerReason,
+      "customer repository execution is not authorized for loop mode",
+    );
+    assert.equal(
+      plan.nextOperatorAction,
+      "select an owner-controlled dogfood lane run before starting loop mode",
+    );
+    assert.equal(plan.safetyGates.ownerControlledOnly, true);
+    assert.equal(plan.safetyGates.customerRepoExecution, false);
+    assert.equal(JSON.stringify(plan).includes(stateRoot), false);
+  });
+});
+
 test("blocks continuous mode when the selected queue item is already locked", async () => {
   await withStateRoot(async (stateRoot) => {
     await enqueueLaneRun(stateRoot, {


### PR DESCRIPTION
## Summary
- add one-shot and continuous loop mode planning over existing queue/status/explain boundaries
- expose loop-mode CLI diagnostics with owner-controlled X-Gate 4 wording
- document the Phase 6 mode boundary and add focused regression coverage

## Verification
- npm ci
- npm run typecheck
- npm run build && node --test dist/test/lane-loop-mode.test.js
- npm test

Part of #109
Closes #114