### PR TITLE
LOOP-X4-004 verify status and explain UX

### DIFF
--- a/docs/runbooks/x-gate4-dogfood-readiness.md
+++ b/docs/runbooks/x-gate4-dogfood-readiness.md
@@ -74,9 +74,35 @@ Before a dogfood smoke run, verify all items below:
 Focused command examples:
 
 ```sh
+node dist/src/cli/index.js status --state-root <state-root>
+node dist/src/cli/index.js explain --state-root <state-root> --issue <stable-work-item-id>
 node dist/src/cli/index.js loop-mode one-shot --state-root <state-root> --issue <stable-work-item-id>
 node dist/src/cli/index.js loop-mode continuous --state-root <state-root>
 ```
+
+## LOOP-X4-004 Status And Explain Evidence
+
+The status and explain readiness evidence is the focused
+`lane-run-status-explain` test suite plus the CLI command examples above. It
+covers no selected issue, queued, active, blocked, completed, revoked,
+superseded, stale queue projection, and malformed state. The expected operator
+surface is:
+
+| Readiness state | Operator surface |
+| --- | --- |
+| No selected issue | Blocked with an explicit select-or-enqueue next action. |
+| Queued | OK with `claim queued lane run when ready`. |
+| Active | OK with the active lock id and wait guidance. |
+| Blocked | Blocked with a public-safe blocker reason and repair guidance. |
+| Completed | OK with succeeded verification and no action required. |
+| Revoked | Blocked with revocation inspection guidance. |
+| Superseded | Blocked with fresh enqueue guidance if the issue is still selected. |
+| Stale queue projection | Terminal lock state wins over stale queued display text. |
+| Malformed state | Blocked with a repair-or-remove next action. |
+
+Public diagnostics must redact credentials, workstation-local paths, customer
+identifiers, private repository details, and regulated-looking values before
+they reach status or explain output.
 
 ## Stop Criteria
 

--- a/src/safety/public-artifact.ts
+++ b/src/safety/public-artifact.ts
@@ -30,7 +30,7 @@ const customerDomainPatterns: readonly RegExp[] = [
 ];
 
 const privateRepositoryDetailPatterns: readonly RegExp[] = [
-  /\b(?:https?:\/\/)?github\.com\/(?:(?:[A-Za-z0-9_.-]*(?:private|customer|tenant|confidential|internal)[A-Za-z0-9_.-]*\/[A-Za-z0-9_.-]+)|(?:[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]*(?:private|customer|tenant|confidential|internal)[A-Za-z0-9_.-]*))(?=$|[\s"'`<>)\]}?,.;:/#])/gi,
+  /\b(?:https?:\/\/)?github\.com\/(?:(?:[A-Za-z0-9_.-]*(?:private|customer|tenant|confidential|internal)[A-Za-z0-9_.-]*\/[A-Za-z0-9_.-]+)|(?:[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]*(?:private|customer|tenant|confidential|internal)[A-Za-z0-9_.-]*))(?:\/[A-Za-z0-9._~:@!$&()*+,;=%-]+)*(?:[?#][A-Za-z0-9._~:@!$&()*+,;=%/?-]+)?(?=$|[\s"'`<>)\]}?,.;:/#])/gi,
   /\bgit@github\.com:(?:(?:[A-Za-z0-9_.-]*(?:private|customer|tenant|confidential|internal)[A-Za-z0-9_.-]*\/[A-Za-z0-9_.-]+)|(?:[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]*(?:private|customer|tenant|confidential|internal)[A-Za-z0-9_.-]*))(?:\.git)?(?=$|[\s"'`<>)\]}?,.;:/#])/gi,
 ];
 
@@ -58,9 +58,9 @@ export function containsUnsafePublicArtifactText(value: string): boolean {
 export function sanitizePublicDiagnosticMessage(message: string): string {
   let sanitized = replacePatterns(message, secretLikePatterns, secretLikePlaceholder);
   sanitized = replacePatterns(sanitized, customerIdentifierPatterns, customerIdentifierPlaceholder);
+  sanitized = replacePatterns(sanitized, privateRepositoryDetailPatterns, privateRepositoryPlaceholder);
   sanitized = replacePatterns(sanitized, customerPathPatterns, customerPathPlaceholder);
   sanitized = replacePatterns(sanitized, customerDomainPatterns, customerDomainPlaceholder);
-  sanitized = replacePatterns(sanitized, privateRepositoryDetailPatterns, privateRepositoryPlaceholder);
   sanitized = replacePatterns(
     sanitized,
     regulatedRecordLikePatterns,

--- a/src/safety/public-artifact.ts
+++ b/src/safety/public-artifact.ts
@@ -29,9 +29,36 @@ const customerDomainPatterns: readonly RegExp[] = [
   /\b[A-Za-z0-9-]+(?:\.[A-Za-z0-9-]+)*\.(?:customer|tenant|private|internal)\.example\b/gi,
 ];
 
+const privateRepositoryNameSegment =
+  "[A-Za-z0-9_.-]*(?:private|customer|tenant|confidential|internal)[A-Za-z0-9_.-]*";
+const repositoryNameSegment = "[A-Za-z0-9_.-]+";
+const privateRepositorySlug =
+  `(?:(?:${privateRepositoryNameSegment}/${repositoryNameSegment})` +
+  `|(?:${repositoryNameSegment}/${privateRepositoryNameSegment}))`;
+const privateRepositoryBareSlug = `(?!customers?\\/|tenants?\\/|accounts?\\/)${privateRepositorySlug}`;
+const privateRepositoryPathTail =
+  "(?:/[A-Za-z0-9._~:@!$&()*+,;=%-]+)*(?:[?#][A-Za-z0-9._~:@!$&()*+,;=%/?#-]+)?";
+const privateRepositoryReferenceTail =
+  "(?:\\.git)?(?:[/?#][A-Za-z0-9._~:@!$&()*+,;=%/?#-]+)?";
+const publicDiagnosticBoundary = "(?=$|[\\s\"'`<>)\\]}?,.;:/#])";
+
 const privateRepositoryDetailPatterns: readonly RegExp[] = [
-  /\b(?:https?:\/\/)?github\.com\/(?:(?:[A-Za-z0-9_.-]*(?:private|customer|tenant|confidential|internal)[A-Za-z0-9_.-]*\/[A-Za-z0-9_.-]+)|(?:[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]*(?:private|customer|tenant|confidential|internal)[A-Za-z0-9_.-]*))(?:\/[A-Za-z0-9._~:@!$&()*+,;=%-]+)*(?:[?#][A-Za-z0-9._~:@!$&()*+,;=%/?#-]+)?(?=$|[\s"'`<>)\]}?,.;:/#])/gi,
-  /\bgit@github\.com:(?:(?:[A-Za-z0-9_.-]*(?:private|customer|tenant|confidential|internal)[A-Za-z0-9_.-]*\/[A-Za-z0-9_.-]+)|(?:[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]*(?:private|customer|tenant|confidential|internal)[A-Za-z0-9_.-]*))(?:\.git)?(?=$|[\s"'`<>)\]}?,.;:/#])/gi,
+  new RegExp(
+    `\\b(?:https?:\\/\\/)?github\\.com\\/${privateRepositorySlug}${privateRepositoryPathTail}${publicDiagnosticBoundary}`,
+    "gi",
+  ),
+  new RegExp(
+    `\\b(?:https?:\\/\\/)?api\\.github\\.com\\/repos\\/${privateRepositorySlug}${privateRepositoryPathTail}${publicDiagnosticBoundary}`,
+    "gi",
+  ),
+  new RegExp(
+    `\\bgit@github\\.com:${privateRepositorySlug}${privateRepositoryReferenceTail}${publicDiagnosticBoundary}`,
+    "gi",
+  ),
+  new RegExp(
+    `\\b${privateRepositoryBareSlug}${privateRepositoryPathTail}${publicDiagnosticBoundary}`,
+    "gi",
+  ),
 ];
 
 const regulatedRecordLikePatterns: readonly RegExp[] = [

--- a/src/safety/public-artifact.ts
+++ b/src/safety/public-artifact.ts
@@ -2,6 +2,7 @@ const secretLikePlaceholder = "<secret-like-value>";
 const customerIdentifierPlaceholder = "<customer-identifier>";
 const customerPathPlaceholder = "<customer-path>";
 const customerDomainPlaceholder = "<customer-domain>";
+const privateRepositoryPlaceholder = "<private-repository>";
 const regulatedRecordLikePlaceholder = "<regulated-record-like-value>";
 
 const secretLikePatterns: readonly RegExp[] = [
@@ -28,6 +29,11 @@ const customerDomainPatterns: readonly RegExp[] = [
   /\b[A-Za-z0-9-]+(?:\.[A-Za-z0-9-]+)*\.(?:customer|tenant|private|internal)\.example\b/gi,
 ];
 
+const privateRepositoryDetailPatterns: readonly RegExp[] = [
+  /\b(?:https?:\/\/)?github\.com\/[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]*(?:private|customer|tenant|confidential|internal)[A-Za-z0-9_.-]*(?=$|[\s"'`<>)\]}?,.;:/#])/gi,
+  /\bgit@github\.com:[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]*(?:private|customer|tenant|confidential|internal)[A-Za-z0-9_.-]*(?:\.git)?(?=$|[\s"'`<>)\]}?,.;:/#])/gi,
+];
+
 const regulatedRecordLikePatterns: readonly RegExp[] = [
   /\bMRN[-_:# ]*\d{6,}\b(?:\s+DOB\s+\d{4}-\d{2}-\d{2})?/gi,
   /\bDOB\s+\d{4}-\d{2}-\d{2}\b/gi,
@@ -43,6 +49,7 @@ export function containsUnsafePublicArtifactText(value: string): boolean {
     containsPattern(value, customerIdentifierPatterns) ||
     containsPattern(value, customerPathPatterns) ||
     containsPattern(value, customerDomainPatterns) ||
+    containsPattern(value, privateRepositoryDetailPatterns) ||
     containsPattern(value, regulatedRecordLikePatterns) ||
     workstationLocalPathPattern.test(value)
   );
@@ -53,6 +60,7 @@ export function sanitizePublicDiagnosticMessage(message: string): string {
   sanitized = replacePatterns(sanitized, customerIdentifierPatterns, customerIdentifierPlaceholder);
   sanitized = replacePatterns(sanitized, customerPathPatterns, customerPathPlaceholder);
   sanitized = replacePatterns(sanitized, customerDomainPatterns, customerDomainPlaceholder);
+  sanitized = replacePatterns(sanitized, privateRepositoryDetailPatterns, privateRepositoryPlaceholder);
   sanitized = replacePatterns(
     sanitized,
     regulatedRecordLikePatterns,

--- a/src/safety/public-artifact.ts
+++ b/src/safety/public-artifact.ts
@@ -30,8 +30,8 @@ const customerDomainPatterns: readonly RegExp[] = [
 ];
 
 const privateRepositoryDetailPatterns: readonly RegExp[] = [
-  /\b(?:https?:\/\/)?github\.com\/[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]*(?:private|customer|tenant|confidential|internal)[A-Za-z0-9_.-]*(?=$|[\s"'`<>)\]}?,.;:/#])/gi,
-  /\bgit@github\.com:[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]*(?:private|customer|tenant|confidential|internal)[A-Za-z0-9_.-]*(?:\.git)?(?=$|[\s"'`<>)\]}?,.;:/#])/gi,
+  /\b(?:https?:\/\/)?github\.com\/(?:(?:[A-Za-z0-9_.-]*(?:private|customer|tenant|confidential|internal)[A-Za-z0-9_.-]*\/[A-Za-z0-9_.-]+)|(?:[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]*(?:private|customer|tenant|confidential|internal)[A-Za-z0-9_.-]*))(?=$|[\s"'`<>)\]}?,.;:/#])/gi,
+  /\bgit@github\.com:(?:(?:[A-Za-z0-9_.-]*(?:private|customer|tenant|confidential|internal)[A-Za-z0-9_.-]*\/[A-Za-z0-9_.-]+)|(?:[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]*(?:private|customer|tenant|confidential|internal)[A-Za-z0-9_.-]*))(?:\.git)?(?=$|[\s"'`<>)\]}?,.;:/#])/gi,
 ];
 
 const regulatedRecordLikePatterns: readonly RegExp[] = [

--- a/src/safety/public-artifact.ts
+++ b/src/safety/public-artifact.ts
@@ -30,7 +30,7 @@ const customerDomainPatterns: readonly RegExp[] = [
 ];
 
 const privateRepositoryDetailPatterns: readonly RegExp[] = [
-  /\b(?:https?:\/\/)?github\.com\/(?:(?:[A-Za-z0-9_.-]*(?:private|customer|tenant|confidential|internal)[A-Za-z0-9_.-]*\/[A-Za-z0-9_.-]+)|(?:[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]*(?:private|customer|tenant|confidential|internal)[A-Za-z0-9_.-]*))(?:\/[A-Za-z0-9._~:@!$&()*+,;=%-]+)*(?:[?#][A-Za-z0-9._~:@!$&()*+,;=%/?-]+)?(?=$|[\s"'`<>)\]}?,.;:/#])/gi,
+  /\b(?:https?:\/\/)?github\.com\/(?:(?:[A-Za-z0-9_.-]*(?:private|customer|tenant|confidential|internal)[A-Za-z0-9_.-]*\/[A-Za-z0-9_.-]+)|(?:[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]*(?:private|customer|tenant|confidential|internal)[A-Za-z0-9_.-]*))(?:\/[A-Za-z0-9._~:@!$&()*+,;=%-]+)*(?:[?#][A-Za-z0-9._~:@!$&()*+,;=%/?#-]+)?(?=$|[\s"'`<>)\]}?,.;:/#])/gi,
   /\bgit@github\.com:(?:(?:[A-Za-z0-9_.-]*(?:private|customer|tenant|confidential|internal)[A-Za-z0-9_.-]*\/[A-Za-z0-9_.-]+)|(?:[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]*(?:private|customer|tenant|confidential|internal)[A-Za-z0-9_.-]*))(?:\.git)?(?=$|[\s"'`<>)\]}?,.;:/#])/gi,
 ];
 

--- a/src/safety/public-artifact.ts
+++ b/src/safety/public-artifact.ts
@@ -40,6 +40,8 @@ const privateRepositoryPathTail =
   "(?:/[A-Za-z0-9._~:@!$&()*+,;=%-]+)*(?:[?#][A-Za-z0-9._~:@!$&()*+,;=%/?#-]+)?";
 const privateRepositoryReferenceTail =
   "(?:\\.git)?(?:[/?#][A-Za-z0-9._~:@!$&()*+,;=%/?#-]+)?";
+const privateRepositoryBareSlugReferenceTail =
+  "(?:(?:\\.git)|(?:/(?:actions|blob|branches|commit|compare|issues|packages|projects|pulls?|releases|security|settings|tags|tree|wiki)\\b[A-Za-z0-9._~:@!$&()*+,;=%/?#-]*)|(?:[?#][A-Za-z0-9._~:@!$&()*+,;=%/?#-]+))";
 const publicDiagnosticBoundary = "(?=$|[\\s\"'`<>)\\]}?,.;:/#])";
 
 const privateRepositoryDetailPatterns: readonly RegExp[] = [
@@ -56,7 +58,7 @@ const privateRepositoryDetailPatterns: readonly RegExp[] = [
     "gi",
   ),
   new RegExp(
-    `\\b${privateRepositoryBareSlug}${privateRepositoryPathTail}${publicDiagnosticBoundary}`,
+    `\\b${privateRepositoryBareSlug}${privateRepositoryBareSlugReferenceTail}${publicDiagnosticBoundary}`,
     "gi",
   ),
 ];

--- a/test/lane-artifact-output.test.ts
+++ b/test/lane-artifact-output.test.ts
@@ -489,18 +489,26 @@ test("rejects customer and regulated-looking public artifact values without echo
   }
 });
 
-test("allows public record artifact paths without customer-specific prefixes", () => {
-  const artifact = createLaneArtifactOutput(
-    createSafePatchInput({
-      artifactRef: {
-        uri: "artifacts/records/report.json",
-        mediaType: "application/json",
-      },
-    }),
-  );
+test("allows public artifact paths with repo-local private-looking segments", () => {
+  const artifactUris = [
+    "artifacts/records/report.json",
+    "artifacts/internal/report.json",
+    "artifacts/evidence/unverified-private.json",
+  ];
 
-  assert.equal(artifact.artifact.uri, "artifacts/records/report.json");
-  assert.equal(validateLaneArtifactOutput(artifact).ok, true);
+  for (const artifactUri of artifactUris) {
+    const artifact = createLaneArtifactOutput(
+      createSafePatchInput({
+        artifactRef: {
+          uri: artifactUri,
+          mediaType: "application/json",
+        },
+      }),
+    );
+
+    assert.equal(artifact.artifact.uri, artifactUri);
+    assert.equal(validateLaneArtifactOutput(artifact).ok, true);
+  }
 });
 
 test("emits guarded PR draft intent without implying automatic merge authority", () => {

--- a/test/lane-run-status-explain.test.ts
+++ b/test/lane-run-status-explain.test.ts
@@ -224,6 +224,43 @@ test("status and explain redact private repository details from blocker diagnost
   });
 });
 
+test("status and explain redact private repository URL tails from blocker diagnostics", async () => {
+  await withStateRoot(async (stateRoot) => {
+    await enqueueLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-111",
+      workItemId: "issue-111",
+      source: "github-issue",
+      laneId: "owner-dogfood",
+      repositoryClassification: "owner-controlled-dogfood",
+      queuedAt,
+      metadata: {
+        issueNumber: "111",
+        blockerReason:
+          "review evidence from github.com/acme/private-repo/blob/customer-alpha/secrets.md is unavailable",
+      },
+    });
+
+    const status = await getLaneRunStatus(stateRoot);
+    const explanation = await explainLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-111",
+    });
+    const serialized = JSON.stringify({ status, explanation });
+
+    assert.equal(status.state, "blocked");
+    assert.equal(
+      status.blockerReason,
+      "review evidence from <private-repository> is unavailable",
+    );
+    assert.equal(
+      explanation.blockerReason,
+      "review evidence from <private-repository> is unavailable",
+    );
+    assert.equal(serialized.includes("github.com/acme/private-repo"), false);
+    assert.equal(serialized.includes("customer-alpha"), false);
+    assert.equal(serialized.includes("secrets.md"), false);
+  });
+});
+
 test("CLI status exits blocked for queued blocker diagnostics", async () => {
   await withStateRoot(async (stateRoot) => {
     await enqueueLaneRun(stateRoot, {

--- a/test/lane-run-status-explain.test.ts
+++ b/test/lane-run-status-explain.test.ts
@@ -261,6 +261,43 @@ test("status and explain redact private repository URL tails from blocker diagno
   });
 });
 
+test("status and explain redact private repository query and fragment tails", async () => {
+  await withStateRoot(async (stateRoot) => {
+    await enqueueLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-111",
+      workItemId: "issue-111",
+      source: "github-issue",
+      laneId: "owner-dogfood",
+      repositoryClassification: "owner-controlled-dogfood",
+      queuedAt,
+      metadata: {
+        issueNumber: "111",
+        blockerReason:
+          "review evidence from https://github.com/acme/private-repo/blob/main/file.md?plain=1#customer-alpha is unavailable",
+      },
+    });
+
+    const status = await getLaneRunStatus(stateRoot);
+    const explanation = await explainLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-111",
+    });
+    const serialized = JSON.stringify({ status, explanation });
+
+    assert.equal(status.state, "blocked");
+    assert.equal(
+      status.blockerReason,
+      "review evidence from <private-repository> is unavailable",
+    );
+    assert.equal(
+      explanation.blockerReason,
+      "review evidence from <private-repository> is unavailable",
+    );
+    assert.equal(serialized.includes("github.com/acme/private-repo"), false);
+    assert.equal(serialized.includes("plain=1"), false);
+    assert.equal(serialized.includes("customer-alpha"), false);
+  });
+});
+
 test("CLI status exits blocked for queued blocker diagnostics", async () => {
   await withStateRoot(async (stateRoot) => {
     await enqueueLaneRun(stateRoot, {

--- a/test/lane-run-status-explain.test.ts
+++ b/test/lane-run-status-explain.test.ts
@@ -298,6 +298,66 @@ test("status and explain redact private repository query and fragment tails", as
   });
 });
 
+test("status and explain redact private repository references across GitHub forms", async () => {
+  const examples = [
+    {
+      blockerReason:
+        "review evidence from git@github.com:acme/private-repo.git#customer-alpha is unavailable",
+      unsafeFragments: ["git@github.com:acme/private-repo.git", "customer-alpha"],
+    },
+    {
+      blockerReason:
+        "review evidence from https://api.github.com/repos/acme/private-repo/contents/customer-alpha/secrets.md is unavailable",
+      unsafeFragments: [
+        "api.github.com/repos/acme/private-repo",
+        "customer-alpha",
+        "secrets.md",
+      ],
+    },
+    {
+      blockerReason:
+        "review evidence from acme/private-repo/blob/customer-alpha/secrets.md is unavailable",
+      unsafeFragments: ["acme/private-repo", "customer-alpha", "secrets.md"],
+    },
+  ];
+
+  for (const example of examples) {
+    await withStateRoot(async (stateRoot) => {
+      await enqueueLaneRun(stateRoot, {
+        stableWorkItemId: "github-issue-111",
+        workItemId: "issue-111",
+        source: "github-issue",
+        laneId: "owner-dogfood",
+        repositoryClassification: "owner-controlled-dogfood",
+        queuedAt,
+        metadata: {
+          issueNumber: "111",
+          blockerReason: example.blockerReason,
+        },
+      });
+
+      const status = await getLaneRunStatus(stateRoot);
+      const explanation = await explainLaneRun(stateRoot, {
+        stableWorkItemId: "github-issue-111",
+      });
+      const serialized = JSON.stringify({ status, explanation });
+
+      assert.equal(status.state, "blocked");
+      assert.equal(
+        status.blockerReason,
+        "review evidence from <private-repository> is unavailable",
+      );
+      assert.equal(
+        explanation.blockerReason,
+        "review evidence from <private-repository> is unavailable",
+      );
+      for (const unsafeFragment of example.unsafeFragments) {
+        assert.equal(serialized.includes(unsafeFragment), false);
+      }
+    });
+  }
+});
+
 test("CLI status exits blocked for queued blocker diagnostics", async () => {
   await withStateRoot(async (stateRoot) => {
     await enqueueLaneRun(stateRoot, {

--- a/test/lane-run-status-explain.test.ts
+++ b/test/lane-run-status-explain.test.ts
@@ -200,7 +200,7 @@ test("status and explain redact private repository details from blocker diagnost
       queuedAt,
       metadata: {
         issueNumber: "111",
-        blockerReason: "review evidence from github.com/acme/private-customer-repo is unavailable",
+        blockerReason: "review evidence from github.com/customer-alpha/public-evidence is unavailable",
       },
     });
 
@@ -219,7 +219,8 @@ test("status and explain redact private repository details from blocker diagnost
       explanation.blockerReason,
       "review evidence from <private-repository> is unavailable",
     );
-    assert.equal(serialized.includes("github.com/acme/private-customer-repo"), false);
+    assert.equal(serialized.includes("github.com/customer-alpha/public-evidence"), false);
+    assert.equal(serialized.includes("customer-alpha"), false);
   });
 });
 

--- a/test/lane-run-status-explain.test.ts
+++ b/test/lane-run-status-explain.test.ts
@@ -189,6 +189,40 @@ test("explain identifies blocked active lane run and safe next action", async ()
   });
 });
 
+test("status and explain redact private repository details from blocker diagnostics", async () => {
+  await withStateRoot(async (stateRoot) => {
+    await enqueueLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-111",
+      workItemId: "issue-111",
+      source: "github-issue",
+      laneId: "owner-dogfood",
+      repositoryClassification: "owner-controlled-dogfood",
+      queuedAt,
+      metadata: {
+        issueNumber: "111",
+        blockerReason: "review evidence from github.com/acme/private-customer-repo is unavailable",
+      },
+    });
+
+    const status = await getLaneRunStatus(stateRoot);
+    const explanation = await explainLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-111",
+    });
+    const serialized = JSON.stringify({ status, explanation });
+
+    assert.equal(status.state, "blocked");
+    assert.equal(
+      status.blockerReason,
+      "review evidence from <private-repository> is unavailable",
+    );
+    assert.equal(
+      explanation.blockerReason,
+      "review evidence from <private-repository> is unavailable",
+    );
+    assert.equal(serialized.includes("github.com/acme/private-customer-repo"), false);
+  });
+});
+
 test("CLI status exits blocked for queued blocker diagnostics", async () => {
   await withStateRoot(async (stateRoot) => {
     await enqueueLaneRun(stateRoot, {

--- a/test/quality-kit-docs.test.ts
+++ b/test/quality-kit-docs.test.ts
@@ -299,6 +299,11 @@ test("documents the X-Gate 4 owner-controlled dogfood readiness checklist", asyn
     "one-shot",
     "continuous loop mode",
     "does not rely on Ensen-flow runtime state",
+    "LOOP-X4-004 Status And Explain Evidence",
+    "node dist/src/cli/index.js status --state-root <state-root>",
+    "node dist/src/cli/index.js explain --state-root <state-root> --issue <stable-work-item-id>",
+    "stale queue projection",
+    "private repository details",
   ]) {
     assert.match(checklist, new RegExp(phrase.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"), "i"));
   }


### PR DESCRIPTION
## Summary
- add a focused status/explain regression for private repository detail redaction in blocker diagnostics
- extend public diagnostic sanitization for private repository-looking GitHub references
- record LOOP-X4-004 status/explain readiness evidence in the X-Gate 4 runbook

## Verification
- npm ci
- npm run typecheck
- npm run build
- npm run build && node --test dist/test/lane-run-status-explain.test.js dist/test/quality-kit-docs.test.js dist/test/cli-diagnostics.test.js dist/test/operational-evidence-profile.test.js
- npm test

Refs #125