### PR TITLE
LOOP-X4-005 verify recovery smoke

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,10 @@ node dist/src/cli/index.js x-gate2-smoke <run-request-json-file>
 node dist/src/cli/index.js x-gate3-smoke <run-request-json-file> --workspace-root <workspace-root> --state-root <state-root>
 node dist/src/cli/index.js loop-mode one-shot --state-root <state-root> --issue <stable-work-item-id>
 node dist/src/cli/index.js loop-mode continuous --state-root <state-root>
+node dist/src/cli/index.js reconcile --state-root <state-root> --issue <stable-work-item-id> [--lane-run <lane-run-id>] --observed-at <iso-timestamp> --surfaces <surfaces-json-file>
+node dist/src/cli/index.js stop --state-root <state-root> --issue <stable-work-item-id> --lane-run <lane-run-id> --reason <public-reason>
+node dist/src/cli/index.js retry --state-root <state-root> --issue <stable-work-item-id> --lane-run <lane-run-id> --reason <public-reason>
+node dist/src/cli/index.js requeue --state-root <state-root> --issue <stable-work-item-id> --lane-run <lane-run-id> --reason <public-reason>
 ```
 
 `npm test` includes the EIP conformance fixture suite. After `npm run build`, `node --test dist/test/eip-conformance-fixtures.test.js` runs only the focused suite for the vendored Ensen-protocol v0.2.0 RunRequest, RunStatusSnapshot, RunResult, and EvidenceBundleRef fixtures. Those fixtures remain `eip.run-request.v1`, `eip.run-status.v1`, `eip.run-result.v1`, and `eip.evidence-bundle-ref.v1`.
@@ -85,6 +89,10 @@ node dist/src/cli/index.js loop-mode continuous --state-root <state-root>
 `x-gate3-smoke <run-request-json-file> --workspace-root <workspace-root> --state-root <state-root>` runs the bounded Phase 3 local fake lane smoke path. It validates the RunRequest, prepares local lane workspace/state directories, invokes the deterministic local fake executor, persists LaneRunState plus local evidence metadata, and emits one aggregate JSON object with RunStatusSnapshot and RunResult projections. It does not create or mutate GitHub issues, branches, pull requests, reviews, commits, real agent-provider sessions, or production evidence archives. Invalid input, unsupported EIP major versions, unsafe roots, failed fake outcomes, and blocked fake outcomes fail closed with parseable JSON output.
 
 `loop-mode one-shot --state-root <state-root> --issue <stable-work-item-id>` emits a bounded plan for one operator-selected queued lane run. `loop-mode continuous --state-root <state-root>` emits a supervised repeated-selection plan for the next queued lane run. Both modes report public-safe diagnostics and next operator actions without leaking local paths or credentials. Continuous mode keeps `automaticMerge`, `automaticQualityDecision`, `customerRepoExecution`, and `regulatedDataHandling` false.
+
+`reconcile --state-root <state-root> --issue <stable-work-item-id> [--lane-run <lane-run-id>] --observed-at <iso-timestamp> --surfaces <surfaces-json-file>` reads a public-safe stale-state surfaces payload and emits queue, lock, mismatch, and next-operator diagnostics. Blocked reconciliation exits nonzero without deleting evidence, rewriting history, merging, or making quality decisions.
+
+`stop`, `retry`, and `requeue` are explicit operator recovery actions. They record bounded public reasons, preserve lineage metadata, and emit public diagnostics without printing queue metadata, local workstation paths, or credential-looking values.
 
 EvidenceBundleRef validation is exposed as an Ensen-loop-native protocol helper for copied Ensen-protocol v0.2.0 fixtures and dry-run metadata. It accepts relative traversal-free local paths and absolute `file:///` URIs, rejects credential-shaped URIs, query or fragment-bearing file URIs, traversal, absolute local paths, and ambiguous local path shapes, and keeps validation independent from any Ensen-flow runtime.
 

--- a/docs/runbooks/x-gate4-dogfood-readiness.md
+++ b/docs/runbooks/x-gate4-dogfood-readiness.md
@@ -78,6 +78,10 @@ node dist/src/cli/index.js status --state-root <state-root>
 node dist/src/cli/index.js explain --state-root <state-root> --issue <stable-work-item-id>
 node dist/src/cli/index.js loop-mode one-shot --state-root <state-root> --issue <stable-work-item-id>
 node dist/src/cli/index.js loop-mode continuous --state-root <state-root>
+node dist/src/cli/index.js reconcile --state-root <state-root> --issue <stable-work-item-id> --lane-run <lane-run-id> --observed-at <iso-timestamp> --surfaces <surfaces-json-file>
+node dist/src/cli/index.js stop --state-root <state-root> --issue <stable-work-item-id> --lane-run <lane-run-id> --reason <public-reason>
+node dist/src/cli/index.js retry --state-root <state-root> --issue <stable-work-item-id> --lane-run <lane-run-id> --reason <public-reason>
+node dist/src/cli/index.js requeue --state-root <state-root> --issue <stable-work-item-id> --lane-run <lane-run-id> --reason <public-reason>
 ```
 
 ## LOOP-X4-004 Status And Explain Evidence
@@ -103,6 +107,29 @@ surface is:
 Public diagnostics must redact credentials, workstation-local paths, customer
 identifiers, private repository details, and regulated-looking values before
 they reach status or explain output.
+
+## LOOP-X4-005 Recovery Smoke Evidence
+
+The recovery smoke boundary is the focused `lane-run-operator-actions` and
+`lane-run-reconciliation` test suites plus the CLI command examples above. It
+covers operator stop, retry, requeue, stale lock detection, missing branch,
+missing worktree, missing journal, missing PR draft reference, and conflicting
+verification facts.
+
+Expected recovery behavior:
+
+| Recovery path | Operator surface |
+| --- | --- |
+| Stop active lane | Records revoked lineage and a bounded public reason. |
+| Retry terminal lane | Creates a new queued attempt linked to the prior lane run and preserves evidence counts. |
+| Requeue revoked or superseded lane | Returns the selected issue to the queue with explicit lineage. |
+| Safe stale state | Blocks with explicit cleanup or requeue guidance. |
+| Ambiguous or conflicting state | Fails closed with manual-review or blocked diagnostics. |
+
+Recovery diagnostics must not expose raw local paths, credentials, customer
+data, private repository details, queue metadata, or durable evidence contents.
+Recovery commands must not delete evidence, rewrite history, create an
+automatic merge, or make an automatic quality decision.
 
 ## Stop Criteria
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -18,10 +18,12 @@ import {
   getLaneRunStatus,
   planLoopMode,
   prepareLocalLaneWorkspace,
+  reconcileLaneRunState,
   requeueLaneRun,
   retryLaneRun,
   stopLaneRun,
 } from "../lane/index.js";
+import type { ReconcileLaneRunStateInput } from "../lane/index.js";
 import type { LaneRunOperatorActionResult } from "../lane/index.js";
 import {
   createBlockedRunResultFromValidationIssues,
@@ -321,6 +323,28 @@ async function main(): Promise<number> {
     return plan.state === "ready" ? 0 : 1;
   }
 
+  if (command === "reconcile") {
+    const options = parseReconcileArgs(args);
+
+    if (options === undefined) {
+      console.error(
+        "Usage: ensen-loop reconcile --state-root <state-root> --issue <stable-work-item-id> [--lane-run <lane-run-id>] --observed-at <iso-timestamp> --surfaces <surfaces-json-file>",
+      );
+      return 1;
+    }
+
+    const surfaces = await readJsonFile(options.surfacesPath);
+    const result = await reconcileLaneRunState(options.stateRoot, {
+      stableWorkItemId: options.stableWorkItemId,
+      laneRunId: options.laneRunId,
+      observedAt: options.observedAt,
+      surfaces,
+    } as ReconcileLaneRunStateInput);
+
+    printJson(result);
+    return result.state === "ok" ? 0 : 1;
+  }
+
   if (command === "stop" || command === "retry" || command === "requeue") {
     const options = parseOperatorActionArgs(args);
 
@@ -379,6 +403,9 @@ async function main(): Promise<number> {
   );
   console.error("Usage: ensen-loop loop-mode continuous --state-root <state-root>");
   console.error("X-Gate 4 dogfood is owner-controlled only and does not authorize customer repo execution.");
+  console.error(
+    "Usage: ensen-loop reconcile --state-root <state-root> --issue <stable-work-item-id> [--lane-run <lane-run-id>] --observed-at <iso-timestamp> --surfaces <surfaces-json-file>",
+  );
   console.error(
     "Usage: ensen-loop stop|retry|requeue --state-root <state-root> --issue <stable-work-item-id> --lane-run <lane-run-id> --reason <public-reason>",
   );
@@ -595,6 +622,57 @@ interface OperatorActionOptions {
   readonly stableWorkItemId: string;
   readonly laneRunId: string;
   readonly reason: string;
+}
+
+interface ReconcileOptions {
+  readonly stateRoot: string;
+  readonly stableWorkItemId: string;
+  readonly laneRunId?: string;
+  readonly observedAt: string;
+  readonly surfacesPath: string;
+}
+
+function parseReconcileArgs(args: readonly string[]): ReconcileOptions | undefined {
+  if (args.length !== 8 && args.length !== 10) {
+    return undefined;
+  }
+
+  const values = new Map<string, string>();
+
+  for (let index = 0; index < args.length; index += 2) {
+    const flag = args[index];
+    const value = args[index + 1];
+
+    if (flag === undefined || value === undefined || !flag.startsWith("--")) {
+      return undefined;
+    }
+
+    values.set(flag, value);
+  }
+
+  const stateRoot = values.get("--state-root");
+  const stableWorkItemId = values.get("--issue");
+  const laneRunId = values.get("--lane-run");
+  const observedAt = values.get("--observed-at");
+  const surfacesPath = values.get("--surfaces");
+
+  if (
+    stateRoot === undefined ||
+    stableWorkItemId === undefined ||
+    observedAt === undefined ||
+    surfacesPath === undefined ||
+    values.size !== (laneRunId === undefined ? 4 : 5)
+  ) {
+    return undefined;
+  }
+
+  return {
+    stateRoot,
+    stableWorkItemId,
+    laneRunId,
+    observedAt,
+    surfacesPath,
+  };
 }
 
 function parseOperatorActionArgs(args: readonly string[]): OperatorActionOptions | undefined {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -24,7 +24,7 @@ import {
   stopLaneRun,
 } from "../lane/index.js";
 import type { ReconcileLaneRunStateInput } from "../lane/index.js";
-import type { LaneRunOperatorActionResult } from "../lane/index.js";
+import type { LaneRunOperatorActionResult, LaneRunReconciliationResult } from "../lane/index.js";
 import {
   createBlockedRunResultFromValidationIssues,
   createBlockedRunStatusSnapshotFromValidationIssues,
@@ -61,6 +61,26 @@ function projectLaneRunOperatorActionCliResult(result: LaneRunOperatorActionResu
       newQueueRecordId: result.lineage.newQueueRecordId,
       preservedEvidenceRefCount: result.lineage.preservedEvidenceRefs.length,
     },
+  };
+}
+
+function projectLaneRunReconciliationCliResult(result: LaneRunReconciliationResult): unknown {
+  return {
+    schemaVersion: result.schemaVersion,
+    state: result.state,
+    category: result.category,
+    stableWorkItemId: result.stableWorkItemId,
+    laneRunId: result.laneRunId,
+    observedAt: result.observedAt,
+    publicDiagnostics: result.publicDiagnostics,
+    nextOperatorAction: result.nextOperatorAction,
+    mismatches: result.mismatches,
+    evidence: {
+      bundleRefCount: result.evidence.bundleRefs.length,
+    },
+    queue: result.queue,
+    lock: result.lock,
+    startsAgentExecution: result.startsAgentExecution,
   };
 }
 
@@ -341,7 +361,7 @@ async function main(): Promise<number> {
       surfaces,
     } as ReconcileLaneRunStateInput);
 
-    printJson(result);
+    printJson(projectLaneRunReconciliationCliResult(result));
     return result.state === "ok" ? 0 : 1;
   }
 

--- a/test/lane-run-operator-actions.test.ts
+++ b/test/lane-run-operator-actions.test.ts
@@ -1092,3 +1092,74 @@ test("CLI retry does not print queued metadata values", async () => {
     assert.equal(serializedOutput.includes("privateOperatorNote"), false);
   });
 });
+
+test("CLI stop and requeue smoke preserves lineage without printing durable metadata", async () => {
+  await withStateRoot(async (stateRoot) => {
+    await enqueueLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-112",
+      workItemId: "issue-112",
+      source: "github-issue",
+      laneId: "owner-dogfood",
+      repositoryClassification: "owner-controlled-dogfood",
+      queuedAt,
+      metadata: {
+        privateOperatorNote: "token=ghp_sampleSecretValue",
+      },
+    });
+    await claimQueuedLaneRun(stateRoot, {
+      stableWorkItemId: "github-issue-112",
+      laneRunId: "lane-run-112-a",
+      claimedBy: "local-supervisor",
+      claimedAt,
+    });
+
+    const stopResult = await execCli([
+      "stop",
+      "--state-root",
+      stateRoot,
+      "--issue",
+      "github-issue-112",
+      "--lane-run",
+      "lane-run-112-a",
+      "--reason",
+      "operator stops before requeue",
+    ]);
+    assert.equal(stopResult.exitCode, 0);
+
+    const requeueResult = await execCli([
+      "requeue",
+      "--state-root",
+      stateRoot,
+      "--issue",
+      "github-issue-112",
+      "--lane-run",
+      "lane-run-112-a",
+      "--reason",
+      "operator token=ghp_sampleSecretValue requeue",
+    ]);
+    const output = JSON.parse(requeueResult.stdout) as {
+      readonly ok?: unknown;
+      readonly action?: unknown;
+      readonly publicDiagnostics?: { readonly reason?: unknown };
+      readonly lineage?: { readonly relationship?: unknown; readonly previousLaneRunId?: unknown; readonly newQueueRecordId?: unknown };
+    };
+    const serializedOutput = JSON.stringify(output);
+
+    assert.equal(requeueResult.stderr, "");
+    assert.equal(requeueResult.exitCode, 0);
+    assert.equal(output.ok, true);
+    assert.equal(output.action, "requeue");
+    assert.equal(output.publicDiagnostics?.reason, "operator <redacted> requeue");
+    assert.deepEqual(output.lineage, {
+      relationship: "requeued",
+      previousLaneRunId: "lane-run-112-a",
+      newQueueRecordId: "queue-github-issue-112-2",
+      preservedEvidenceRefCount: 0,
+    });
+    assert.equal(serializedOutput.includes(stateRoot), false);
+    assert.equal(serializedOutput.includes("ghp_sampleSecretValue"), false);
+    assert.equal(serializedOutput.includes("queueRecord"), false);
+    assert.equal(serializedOutput.includes("metadata"), false);
+    assert.equal(serializedOutput.includes("privateOperatorNote"), false);
+  });
+});

--- a/test/lane-run-reconciliation.test.ts
+++ b/test/lane-run-reconciliation.test.ts
@@ -1,9 +1,11 @@
 import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
 import { createHash } from "node:crypto";
 import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
+import { promisify } from "node:util";
 
 import {
   claimQueuedLaneRun,
@@ -23,6 +25,7 @@ import {
 const queuedAt = "2026-05-23T05:00:00.000Z";
 const claimedAt = "2026-05-23T05:01:00.000Z";
 const observedAt = "2026-05-23T05:02:00.000Z";
+const execFileAsync = promisify(execFile);
 
 function laneRunIdDigest(laneRunId: string): string {
   return createHash("sha256").update(laneRunId).digest("hex");
@@ -36,6 +39,31 @@ async function withStateRoot(callback: (stateRoot: string) => Promise<void>): Pr
     await callback(stateRoot);
   } finally {
     await rm(stateRoot, { recursive: true, force: true });
+  }
+}
+
+async function execCli(args: readonly string[]): Promise<{ readonly stdout: string; readonly stderr: string; readonly exitCode: number }> {
+  try {
+    const result = await execFileAsync(process.execPath, ["dist/src/cli/index.js", ...args]);
+
+    return { stdout: result.stdout, stderr: result.stderr, exitCode: 0 };
+  } catch (error) {
+    if (
+      error instanceof Error &&
+      typeof (error as { readonly code?: unknown }).code === "number" &&
+      typeof (error as { readonly stdout?: unknown }).stdout === "string" &&
+      typeof (error as { readonly stderr?: unknown }).stderr === "string"
+    ) {
+      const cliError = error as Error & { readonly code: number; readonly stdout: string; readonly stderr: string };
+
+      return {
+        stdout: cliError.stdout,
+        stderr: cliError.stderr,
+        exitCode: cliError.code,
+      };
+    }
+
+    throw error;
   }
 }
 
@@ -1199,5 +1227,64 @@ test("reconciliation public diagnostics redact workstation paths and secret-look
     assert.equal(serialized.includes(workstationPath), false);
     assert.equal(serialized.includes("ghp_sampleSecretValue"), false);
     assert.equal(result.mismatches[0]?.ref, "<redacted>");
+  });
+});
+
+test("CLI stale-state reconciliation smoke emits public-safe blocked diagnostics", async () => {
+  await withStateRoot(async (stateRoot) => {
+    await queueAndClaim(stateRoot);
+    await writeLaneState(stateRoot, {
+      evidenceRefs: ["artifacts/evidence/lane-run-113-a.json"],
+    });
+    const surfacesPath = path.join(stateRoot, "reconciliation-surfaces.json");
+    const workstationPath = ["", "Users", "example", "private", "repo"].join("/");
+    await writeFile(
+      surfacesPath,
+      `${JSON.stringify(
+        {
+          branch: { expected: true, exists: false, ref: `${workstationPath} token=ghp_sampleSecretValue` },
+          worktree: { expected: true, exists: true, ref: "<lane-worktree>" },
+          journal: { expected: true, exists: true },
+          prDraft: { expected: false, exists: false },
+          verificationFacts: [{ status: "running", source: "operator-status" }],
+        },
+        null,
+        2,
+      )}\n`,
+      "utf8",
+    );
+
+    const result = await execCli([
+      "reconcile",
+      "--state-root",
+      stateRoot,
+      "--issue",
+      "github-issue-113",
+      "--lane-run",
+      "lane-run-113-a",
+      "--observed-at",
+      observedAt,
+      "--surfaces",
+      surfacesPath,
+    ]);
+    const output = JSON.parse(result.stdout) as {
+      readonly state?: unknown;
+      readonly category?: unknown;
+      readonly publicDiagnostics?: { readonly reason?: unknown };
+      readonly mismatches?: readonly { readonly kind?: unknown; readonly ref?: unknown }[];
+    };
+    const serializedOutput = JSON.stringify(output);
+
+    assert.equal(result.stderr, "");
+    assert.equal(result.exitCode, 1);
+    assert.equal(output.state, "blocked");
+    assert.equal(output.category, "blocked");
+    assert.equal(output.publicDiagnostics?.reason, "active lane run is missing its branch");
+    assert.equal(output.mismatches?.[0]?.kind, "missing-branch");
+    assert.equal(output.mismatches?.[0]?.ref, "<redacted>");
+    assert.equal(serializedOutput.includes(stateRoot), false);
+    assert.equal(serializedOutput.includes(surfacesPath), false);
+    assert.equal(serializedOutput.includes(workstationPath), false);
+    assert.equal(serializedOutput.includes("ghp_sampleSecretValue"), false);
   });
 });

--- a/test/lane-run-reconciliation.test.ts
+++ b/test/lane-run-reconciliation.test.ts
@@ -1233,8 +1233,9 @@ test("reconciliation public diagnostics redact workstation paths and secret-look
 test("CLI stale-state reconciliation smoke emits public-safe blocked diagnostics", async () => {
   await withStateRoot(async (stateRoot) => {
     await queueAndClaim(stateRoot);
+    const privateEvidencePath = ["", "Users", "example", "private", "evidence.json"].join("/");
     await writeLaneState(stateRoot, {
-      evidenceRefs: ["artifacts/evidence/lane-run-113-a.json"],
+      evidenceRefs: [`${privateEvidencePath}?token=ghp_sampleEvidenceSecret`],
     });
     const surfacesPath = path.join(stateRoot, "reconciliation-surfaces.json");
     const workstationPath = ["", "Users", "example", "private", "repo"].join("/");
@@ -1272,6 +1273,7 @@ test("CLI stale-state reconciliation smoke emits public-safe blocked diagnostics
       readonly category?: unknown;
       readonly publicDiagnostics?: { readonly reason?: unknown };
       readonly mismatches?: readonly { readonly kind?: unknown; readonly ref?: unknown }[];
+      readonly evidence?: { readonly bundleRefCount?: unknown };
     };
     const serializedOutput = JSON.stringify(output);
 
@@ -1282,9 +1284,13 @@ test("CLI stale-state reconciliation smoke emits public-safe blocked diagnostics
     assert.equal(output.publicDiagnostics?.reason, "active lane run is missing its branch");
     assert.equal(output.mismatches?.[0]?.kind, "missing-branch");
     assert.equal(output.mismatches?.[0]?.ref, "<redacted>");
+    assert.equal(output.evidence?.bundleRefCount, 1);
     assert.equal(serializedOutput.includes(stateRoot), false);
     assert.equal(serializedOutput.includes(surfacesPath), false);
     assert.equal(serializedOutput.includes(workstationPath), false);
     assert.equal(serializedOutput.includes("ghp_sampleSecretValue"), false);
+    assert.equal(serializedOutput.includes(privateEvidencePath), false);
+    assert.equal(serializedOutput.includes("ghp_sampleEvidenceSecret"), false);
+    assert.equal(serializedOutput.includes("bundleRefs"), false);
   });
 });


### PR DESCRIPTION
## Summary
- add a public `reconcile` CLI command for stale-state recovery smoke diagnostics
- add CLI smoke coverage for stop-to-requeue and public-safe stale-state reconciliation output
- document LOOP-X4-005 recovery command examples and expected behavior

## Verification
- `npm ci`
- `npm run typecheck`
- `npm run build`
- `npm test`
- `node --test dist/test/lane-run-operator-actions.test.js dist/test/lane-run-reconciliation.test.js`

Closes #126