### PR TITLE
Add X-Gate 4 readiness report

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ The X-Gate 3 local fake lane smoke command is documented in [docs/runbooks/x-gat
 
 The X-Gate 4 owner-controlled dogfood readiness checklist is documented in [docs/runbooks/x-gate4-dogfood-readiness.md](docs/runbooks/x-gate4-dogfood-readiness.md). It defines the public-safe owner-only scope, Phase 6 baseline, and stop criteria for later dogfood child issues without relying on Ensen-flow runtime state.
 
+The X-Gate 4 readiness report and Phase 7 handoff decision are documented in [docs/runbooks/x-gate4-readiness-report.md](docs/runbooks/x-gate4-readiness-report.md). The decision is go for owner-controlled codex-supervisor parity automation only; customer repositories, regulated data, automatic merge, automatic quality decisions, production readiness, and compliance claims remain out of scope.
+
 The Ensen-loop mission and development charter alignment are summarized in [docs/mission.md](docs/mission.md).
 
 The Phase 1 local Work Item validation skeleton is documented in [docs/reference/work-item-contract.md](docs/reference/work-item-contract.md).

--- a/docs/runbooks/x-gate4-readiness-report.md
+++ b/docs/runbooks/x-gate4-readiness-report.md
@@ -1,0 +1,77 @@
+# X-Gate 4 Readiness Report
+
+Date: 2026-06-01.
+
+Decision: go for Phase 7 codex-supervisor parity automation.
+
+This decision is owner-controlled only. It authorizes Ensen-loop to begin Phase 7 parity automation against the Ensen-loop owner-controlled dogfood boundary, using repo-local state, public-safe diagnostics, and explicit operator control. It does not authorize customer repositories, regulated data, automatic merge, automatic quality decision, production readiness, compliance claims, live customer pilots, ERPNext live connector work, electronic signatures, batch release, final disposition, or branch-protection bypass.
+
+Ensen-loop remains a standalone Node/TypeScript project. Phase 7 does not import Ensen-flow implementation code and must not require an Ensen-flow checkout, call an Ensen-flow service, depend on Ensen-flow fixture paths, or treat Ensen-flow runtime state as execution authority.
+
+## Evidence Summary
+
+The X-Gate 4 child issue set is complete enough for Epic #121 closure from this report:
+
+| Issue | Outcome | Evidence used for this decision |
+| --- | --- | --- |
+| #122, owner-controlled dogfood readiness scope | Closed | Added the repo-owned X-Gate 4 checklist with Phase 6 baseline, owner-controlled-only scope, explicit stop criteria, public-safe diagnostics, and Ensen-flow independence. |
+| #123, one-shot loop-mode smoke | Closed | `lane-loop-mode` proves a deterministic one-shot plan for one selected owner-controlled queued issue, fail-closed blocked cases, and no automatic merge or quality authority. |
+| #124, continuous loop-mode smoke | Closed | `lane-loop-mode` proves supervised repeated selection, rejection of operator-selected issue arguments in continuous mode, customer repository blocking, and public-safe diagnostics. |
+| #125, status and explain UX | Closed | `lane-run-status-explain` covers no selected issue, queued, active, blocked, completed, revoked, superseded, stale projection, malformed state, and redaction of unsafe diagnostics. |
+| #126, recovery smoke | Closed | `lane-run-operator-actions` and `lane-run-reconciliation` cover stop, retry, requeue, stale lock, missing branch, missing worktree, missing journal, missing PR draft reference, conflicting verification facts, preserved lineage, and fail-closed ambiguous state. |
+| #127, readiness report | In progress until this artifact lands | This report records the final go decision, local verification evidence, continuing non-goals, and Phase 7 entry boundary. |
+
+## Local Verification
+
+Local verification for issue #127 used repo-owned commands and focused X-Gate 4 smoke suites. Outcomes recorded in this report:
+
+| Command | Outcome |
+| --- | --- |
+| `npm ci` | Passed; installed repo dependencies from `package-lock.json` with zero reported vulnerabilities. |
+| `npm run build && node --test dist/test/quality-kit-docs.test.js` | Initially failed because this report did not exist; passed after adding the report. |
+| `node --test dist/test/lane-loop-mode.test.js` | Passed: 12 tests. |
+| `node --test dist/test/lane-run-status-explain.test.js` | Passed: 31 tests. |
+| `node --test dist/test/lane-run-operator-actions.test.js` | Passed: 21 tests. |
+| `node --test dist/test/lane-run-reconciliation.test.js` | Passed: 33 tests. |
+| `npm run typecheck` | Passed during final issue verification. |
+| `npm run build` | Passed during final issue verification. |
+| `npm test` | Passed during final issue verification. |
+
+The focused failure reproduced for #127 was the missing decision artifact:
+
+```text
+ENOENT: no such file or directory, open 'docs/runbooks/x-gate4-readiness-report.md'
+```
+
+That failure is now covered by `quality-kit-docs.test.ts`, which requires the report, child issue references, verification commands, Phase 7 recommendation, owner-controlled-only scope, continuing non-goals, and Ensen-flow independence.
+
+## Phase 7 Entry Boundary
+
+Phase 7 may start only inside the owner-controlled Ensen-loop dogfood boundary:
+
+- The allowed repository is `TommyKammy/Ensen-loop`.
+- The lane target must be an explicitly selected owner-approved issue or an owner-controlled queue record.
+- The execution surface must continue through repo-relative commands and placeholders such as `node dist/src/cli/index.js ...`, `<state-root>`, `<stable-work-item-id>`, `<lane-run-id>`, and `<public-reason>`.
+- Queue, lock, status, explain, stop, retry, requeue, stale-state reconciliation, one-shot mode, and continuous loop mode remain the authoritative local boundaries.
+- Missing, malformed, mixed-snapshot, stale, customer-repository, regulated-data, or unsafe diagnostic signals must fail closed.
+- Operator-facing status text and summaries remain derived surfaces. Authoritative queue, lock, lane state, and lineage records decide lifecycle state.
+
+Phase 7 parity automation may work on codex-supervisor-equivalent operator workflows such as issue pickup, per-issue worktree orchestration, issue journal updates, PR draft handoff, CI polling, review handling, status/explain parity, and issue-lint style readiness. Each parity slice must preserve bounded execution and prove behavior at the real enforcement boundary before widening automation.
+
+## Continuing Non-Goals
+
+The following remain non-goals after X-Gate 4:
+
+- Customer repository execution or customer repo pilots.
+- Regulated data handling, customer data handling, ERPNext live connector state, electronic signatures, batch release, final disposition, or compliance guarantees.
+- Automatic merge, auto-merge enablement, branch-protection bypass, or merge-readiness claims without local verification and human decision.
+- Automatic quality decision, auto-approval, reviewer substitution, or human review replacement.
+- Production readiness claims, durable compliance evidence packaging, or public compliance language.
+- EIP RunRequest or RunResult expansion beyond the already documented current baseline.
+- Shared implementation imports from Ensen-flow or runtime dependence on Ensen-flow, Ensen-protocol, or codex-supervisor checkouts.
+
+## Handoff Recommendation
+
+Proceed to Phase 7 with a narrow first slice: codex-supervisor parity automation for owner-controlled issue pickup and local lane handoff only. The first Phase 7 task should require a reproducible smoke path that starts from an explicit owner-approved issue, writes only repo-local state, emits public-safe status/explain output, and stops before pull request publication, automatic merge, or automatic quality decisions unless a later gate explicitly authorizes those surfaces.
+
+No no-go blockers remain for X-Gate 4 after the report and verification pass. Any Phase 7 task that needs customer repositories, regulated data, automatic merge, automatic quality authority, or production/compliance claims must open a later gate instead of treating this X-Gate 4 go decision as authority.

--- a/test/quality-kit-docs.test.ts
+++ b/test/quality-kit-docs.test.ts
@@ -316,3 +316,45 @@ test("documents the X-Gate 4 owner-controlled dogfood readiness checklist", asyn
     /\/Users\/[^/\s]+|\/home\/[^/\s]+|\/root(?:\/|\b)|[A-Z]:[\\/]+Users[\\/]|~[\\/]/i,
   );
 });
+
+test("documents the X-Gate 4 readiness report and Phase 7 handoff decision", async () => {
+  const report = await readMarkdown("docs/runbooks/x-gate4-readiness-report.md");
+  const readme = await readMarkdown("README.md");
+
+  for (const phrase of [
+    "X-Gate 4 Readiness Report",
+    "Decision: go",
+    "Phase 7 codex-supervisor parity automation",
+    "#122",
+    "#123",
+    "#124",
+    "#125",
+    "#126",
+    "#127",
+    "owner-controlled only",
+    "customer repositories",
+    "regulated data",
+    "automatic merge",
+    "automatic quality decision",
+    "production readiness",
+    "compliance claims",
+    "npm ci",
+    "npm run typecheck",
+    "npm run build",
+    "npm test",
+    "node --test dist/test/lane-loop-mode.test.js",
+    "node --test dist/test/lane-run-status-explain.test.js",
+    "node --test dist/test/lane-run-operator-actions.test.js",
+    "node --test dist/test/lane-run-reconciliation.test.js",
+    "standalone Node/TypeScript project",
+    "does not import Ensen-flow implementation code",
+  ]) {
+    assert.match(report, new RegExp(phrase.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"), "i"));
+  }
+
+  assert.match(readme, /docs\/runbooks\/x-gate4-readiness-report\.md/);
+  assert.doesNotMatch(
+    report,
+    /\/Users\/[^/\s]+|\/home\/[^/\s]+|\/root(?:\/|\b)|[A-Z]:[\\/]+Users[\\/]|~[\\/]/i,
+  );
+});


### PR DESCRIPTION
## Summary

- add the X-Gate 4 readiness report with a go decision for owner-controlled Phase 7 codex-supervisor parity automation
- link the report from README and preserve continuing non-goals
- add a focused docs regression so the decision artifact stays present and bounded

## Verification

- npm ci
- npm run typecheck
- npm run build
- npm test
- npm run build && node --test dist/test/quality-kit-docs.test.js
- node --test dist/test/lane-loop-mode.test.js
- node --test dist/test/lane-run-status-explain.test.js
- node --test dist/test/lane-run-operator-actions.test.js
- node --test dist/test/lane-run-reconciliation.test.js

Part of #121
Closes #127
